### PR TITLE
Fix typos

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -36,7 +36,7 @@ extension AttributedString {
 
         internal init(_ g: Guts) {
             _guts = g
-            // The bounds of a whole attributed string are alread character-aligned.
+            // The bounds of a whole attributed string are already character-aligned.
             _range = Range(uncheckedBounds: (g.startIndex, g.endIndex))
         }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -220,7 +220,7 @@ extension AttributedString.Guts {
         if type == .attributes, range.isEmpty {
             // For attribute-only mutations, we expand the constrained styles out from the mutated
             // range to the paragraph boundaries. If only attributes were modified and the range is
-            // empty, then no true mutation ocurred.
+            // empty, then no true mutation occurred.
             return
         }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
@@ -320,7 +320,7 @@ extension AttributedString.Guts {
     }
     
     /// Replaces the runs for a specified range of block indices with the given `newElements`
-    /// Note: The provided `newElements` must already be coalsced together if needed.
+    /// Note: The provided `newElements` must already be coalesced together if needed.
     func replaceRunsSubrange(_ subrange: Range<Int>, with newElements: some Collection<_InternalRun>) {
         runOffsetCache.withLockUnchecked { runOffsetCache in
             if runOffsetCache.block > subrange.lowerBound {

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -91,7 +91,7 @@ public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepre
 internal struct _AttributeConversionOptions : OptionSet {
     let rawValue: Int
     
-    // If an attribute's value(for: ObjectieCValue) or objectiveCValue(for: Value) function throws, ignore the error and drop the attribute
+    // If an attribute's value(for: ObjectiveCValue) or objectiveCValue(for: Value) function throws, ignore the error and drop the attribute
     static let dropThrowingAttributes = Self(rawValue: 1 << 0)
 }
 

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -168,7 +168,7 @@ internal final class __DataStorage : @unchecked Sendable {
     @inlinable // This is inlinable as trivially computable.
     var isExternallyOwned: Bool {
         // all __DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
-        // anything with 0 capacity means that we have not allocated this pointer and concequently mutation is not ours to make.
+        // anything with 0 capacity means that we have not allocated this pointer and consequently mutation is not ours to make.
         return _capacity == 0
     }
 
@@ -399,7 +399,7 @@ internal final class __DataStorage : @unchecked Sendable {
         setLength(length)
     }
 
-    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    @usableFromInline // This is not @inlinable as a non-convenience initializer.
     init(capacity capacity_: Int = 0) {
         var capacity = capacity_
         precondition(capacity < __DataStorage.maxSize)
@@ -413,7 +413,7 @@ internal final class __DataStorage : @unchecked Sendable {
         _offset = 0
     }
 
-    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    @usableFromInline // This is not @inlinable as a non-convenience initializer.
     init(bytes: UnsafeRawPointer?, length: Int) {
         precondition(length < __DataStorage.maxSize)
         _offset = 0
@@ -441,7 +441,7 @@ internal final class __DataStorage : @unchecked Sendable {
         }
     }
 
-    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    @usableFromInline // This is not @inlinable as a non-convenience initializer.
     init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
         precondition(length < __DataStorage.maxSize)
         _offset = offset
@@ -628,7 +628,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             }
         }
 
-        @inlinable // This is @inlinable as tribially computable.
+        @inlinable // This is @inlinable as trivially computable.
         mutating func append(byte: UInt8) {
             let count = self.count
             assert(count + 1 <= MemoryLayout<Buffer>.size)
@@ -995,7 +995,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-    // A buffer of bytes whose range is too large to fit in a signle word. Used alongside a RangeReference to make it fit into _Representation's two-word size.
+    // A buffer of bytes whose range is too large to fit in a single word. Used alongside a RangeReference to make it fit into _Representation's two-word size.
     // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
     @usableFromInline
     @frozen
@@ -2041,7 +2041,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
     /// Enumerate the contents of the data.
     ///
-    /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontiguously. In those cases, this function invokes the closure for each contiguous region of bytes.
+    /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontinuously. In those cases, this function invokes the closure for each contiguous region of bytes.
     /// - parameter block: The closure to invoke for each region of data. You may stop the enumeration by setting the `stop` parameter to `true`.
     @available(swift, deprecated: 5, message: "use `regions` or `for-in` instead")
     public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {

--- a/Sources/FoundationEssentials/DateInterval.swift
+++ b/Sources/FoundationEssentials/DateInterval.swift
@@ -141,8 +141,8 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
     public func contains(_ date: Date) -> Bool {
         let timeIntervalForGivenDate = date.timeIntervalSinceReferenceDate
         let timeIntervalForSelfStart = start.timeIntervalSinceReferenceDate
-        let timeIntervalforSelfEnd = end.timeIntervalSinceReferenceDate
-        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalforSelfEnd) {
+        let timeIntervalForSelfEnd = end.timeIntervalSinceReferenceDate
+        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalForSelfEnd) {
             return true
         }
         return false

--- a/Sources/FoundationEssentials/Decimal+Stub.swift
+++ b/Sources/FoundationEssentials/Decimal+Stub.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !FOUDATION_FRAMEWORK
+#if !FOUNDATION_FRAMEWORK
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -164,7 +164,7 @@ internal struct JSON5Scanner {
         self.depth &+= 1
         defer { depth &-= 1 }
 
-        // parse first value or end immediatly
+        // parse first value or end immediately
         switch try reader.consumeWhitespace() {
         case ._space, ._return, ._newline, ._tab:
             preconditionFailure("Expected that all white space is consumed")
@@ -273,7 +273,7 @@ internal struct JSON5Scanner {
         self.depth &+= 1
         defer { depth &-= 1 }
 
-        // parse first value or end immediatly
+        // parse first value or end immediately
         switch try reader.consumeWhitespace(allowingEOF: withoutBraces) {
         case ._closebrace?:
             if withoutBraces {

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -560,7 +560,7 @@ extension JSONDecoderImpl: Decoder {
         }
     }
 
-    // Instead of creating a new JSONDecoderImpl for passing to methods that take Decoder arguments, wrap the access in this method, which temporarily mutates this JSONDecoderImpl instance with the nesteed value and its coding path.
+    // Instead of creating a new JSONDecoderImpl for passing to methods that take Decoder arguments, wrap the access in this method, which temporarily mutates this JSONDecoderImpl instance with the nested value and its coding path.
     @inline(__always)
     func with<T>(value: JSONMap.Value, path: _JSONCodingPathNode?, perform closure: () throws -> T) rethrows -> T {
         let oldPath = self.codingPathNode
@@ -847,7 +847,7 @@ extension JSONDecoderImpl: Decoder {
                     } // else, fall through to the T(prevalidatedBuffer:) invocation, which is otherwise compatible with JSON5 after our pre-validation.
 
                     if let floatingPoint = T(prevalidatedBuffer: numberBuffer) {
-                        // Check for overflow/underflow, which can result in "rounding" to infinty or zero.
+                        // Check for overflow/underflow, which can result in "rounding" to infinity or zero.
                         // While strtod does set ERANGE in the either case, we don't rely on it because setting errno to 0 first and then check the result is surprisingly expensive. For values "rounded" to infinity, we reject those out of hand, unless it's an explicit JSON5 infinity/nan value. For values "rounded" down to zero, we perform check for any non-zero digits in the input, which turns out to be much faster.
                         if floatingPoint.isFinite {
                             guard floatingPoint != 0 || isTrueZero(numberBuffer) else {

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif canImport(Gibc)
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -15,7 +15,7 @@
 
  To minimize the number of allocations required during scanning, the map's contents are implemented using a array of integers, whose values are a serialization of the JSON payload's full structure. Each type has its own unique marker value, which is followed by zero or more other integers that describe that contents of that type, if any.
 
- Due to the complexity and additional allocations required to parse JSON string values into Swift Strings or JSON number values into the requested integer or floating-point types, their map contents are captured as lengths of bytes and byte offsets into the input. This allows the full parsing to occur at decode time, or to be skipped if the value is not desired. A partial, imperfect parsing is performed by the scanner, simply "skipping" characters which are valid in their given contexts without interpeting or further validating them relative to the other inputs. This incomplete scanning process does however guarnatee that the structure of the JSON input is correctly interpreted.
+ Due to the complexity and additional allocations required to parse JSON string values into Swift Strings or JSON number values into the requested integer or floating-point types, their map contents are captured as lengths of bytes and byte offsets into the input. This allows the full parsing to occur at decode time, or to be skipped if the value is not desired. A partial, imperfect parsing is performed by the scanner, simply "skipping" characters which are valid in their given contexts without interpreting or further validating them relative to the other inputs. This incomplete scanning process does however guarantee that the structure of the JSON input is correctly interpreted.
 
  The JSONMap representation of JSON arrays and objects is a sequence of integers that is delimited by their starting marker and a shared "collection end" marker. Their contents are nested in between those two markers. To facilitate skipping over unwanted elements of a collection, which is especially useful for JSON objects, the map encodes the offset in the map array to the next object after the end of the collection.
 
@@ -31,7 +31,7 @@
  Key:
  <OM> == Object Marker
  <AM> == Array Marker
- <SS> == Simple String (a variant of String that can has no escpaes and can be passed directly to a UTF-8 parser)
+ <SS> == Simple String (a variant of String that can has no escapes and can be passed directly to a UTF-8 parser)
  <NM> == Number Marker
  <CE> == Collection End
  (See JSONMap.TypeDescriptor comments below for more details)
@@ -50,7 +50,7 @@
  3. Skip the key's value by finding its type (array), and then its nextSiblingOffset index (19)
  4. Parse the next key at index 4. It decodes the string and finds "number", which is a match.
  5. Decode the value by findings its type (number), its length (2) and the byte offset from the beginning of the input (26).
- 6. Pass that byte offset + length into the number parser to produce the correspomding Swift Int value.
+ 6. Pass that byte offset + length into the number parser to produce the corresponding Swift Int value.
 */
 
 #if canImport(Darwin)
@@ -418,7 +418,7 @@ internal struct JSONScanner {
         self.depth &+= 1
         defer { depth &-= 1 }
 
-        // parse first value or end immediatly
+        // parse first value or end immediately
         switch try reader.consumeWhitespace() {
         case ._space, ._return, ._newline, ._tab:
             preconditionFailure("Expected that all white space is consumed")
@@ -527,7 +527,7 @@ internal struct JSONScanner {
         self.depth &+= 1
         defer { depth &-= 1 }
 
-        // parse first value or end immediatly
+        // parse first value or end immediately
         switch try reader.consumeWhitespace(allowingEOF: withoutBraces) {
         case ._closebrace?:
             if withoutBraces {

--- a/Sources/FoundationEssentials/JSON/JSONWriter.swift
+++ b/Sources/FoundationEssentials/JSON/JSONWriter.swift
@@ -12,7 +12,7 @@
 
 extension String {
     
-    // Ideally we'd entirely de-deuplicate this code with serializeString()'s, but at the moment there's a noticeable performance regression when doing so.
+    // Ideally we'd entirely de-duplicate this code with serializeString()'s, but at the moment there's a noticeable performance regression when doing so.
     func serializedForJSON(withoutEscapingSlashes: Bool) -> String {
         var bytes = [UInt8]()
         bytes.reserveCapacity(self.utf8.count + 2)

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -381,7 +381,7 @@ extension PredicateCodableConfiguration {
         configuration.allowKeyPath(\String.count, identifier: "Swift.String.count")
         configuration.allowKeyPath(\Substring.count, identifier: "Swift.Substring.count")
         configuration.allowKeyPath(\String.isEmpty, identifier: "Swift.String.isEmpty")
-        configuration.allowKeyPath(\Substring.isEmpty, identifier: "Swift.Subtring.isEmpty")
+        configuration.allowKeyPath(\Substring.isEmpty, identifier: "Swift.Substring.isEmpty")
         configuration.allowKeyPath(\String.first, identifier: "Swift.String.first")
         configuration.allowKeyPath(\Substring.first, identifier: "Swift.Substring.first")
         configuration.allowKeyPath(\String.last, identifier: "Swift.String.last")

--- a/Sources/FoundationEssentials/String/String+Essentials.swift
+++ b/Sources/FoundationEssentials/String/String+Essentials.swift
@@ -46,7 +46,7 @@ extension String {
     ///
     /// - Parameters:
     ///   - bytes: A sequence of bytes to interpret using `encoding`.
-    ///   - encoding: The ecoding to use to interpret `bytes`.
+    ///   - encoding: The encoding to use to interpret `bytes`.
     public init?<S: Sequence>(bytes: __shared S, encoding: Encoding)
         where S.Iterator.Element == UInt8
     {

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -122,7 +122,7 @@ extension StringProtocol {
                 let options: String.CompareOptions
                 if separator == "\n" {
                     // 106365366: Some clients intend to separate strings whose line separator is "\r\n" with "\n".
-                    // Maintain compability with `.literal` so that "\n" can match that in "\r\n" on the unicode scalar level.
+                    // Maintain compatibility with `.literal` so that "\n" can match that in "\r\n" on the unicode scalar level.
                     options = [.literal]
                 } else {
                     options = []

--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -1044,7 +1044,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
     /// Same as `dateComponents:from:` but uses the more efficient bitset form of ComponentSet.
-    /// Prefixed with `_` to avoid ambiguity at call stie with the `Set<Component>` method.
+    /// Prefixed with `_` to avoid ambiguity at call site with the `Set<Component>` method.
     internal func _dateComponents(_ components: ComponentSet, from date: Date) -> DateComponents {
         var dc: DateComponents
         switch _kind {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_Enumerate.swift
@@ -810,7 +810,7 @@ extension Calendar {
         return result
     }
 
-    // This function adjusts a mismatched data in the case where it is the chinese calendar and we have detected a leap month mismatch.
+    // This function adjusts a mismatched data in the case where it is the Chinese calendar and we have detected a leap month mismatch.
     // It will return nil in the case where we could not find an appropriate adjustment. In that case, the algorithm should keep iterating.
     func _adjustedDateForMismatchedChineseLeapMonth(start: Date,
                                                     searchingDate: Date,
@@ -1613,7 +1613,7 @@ extension Calendar {
 
     private func dateAfterMatchingWeekday(startingAt: Date, components: DateComponents, direction: SearchDirection) -> Date? {
         // NOTE: This differs from the weekday check in weekdayOrdinal because weekday is meant to be ambiguous and can be set without setting the ordinality.
-        // e.g. inquiries like "find the next tuesday after 2017-06-01" or "find every wednesday before 2012-12-25"
+        // e.g. inquiries like "find the next Tuesday after 2017-06-01" or "find every Wednesday before 2012-12-25"
 
         guard let weekday = components.weekday else { return nil }
         var dateWeekday = component(.weekday, from: startingAt)

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
@@ -940,7 +940,7 @@ public extension Date.FormatStyle.Symbol.TimeZone {
     }
 
     /// Generic non-location format. Falls back to `genericLocation` if unavailable. For example,
-    /// short: "PT". Fallback again to `localizedGMT(.short)` if `genericLocation(.short)` is unavaiable.
+    /// short: "PT". Fallback again to `localizedGMT(.short)` if `genericLocation(.short)` is unavailable.
     /// long: "Pacific Time"
     static func genericName(_ width: Width) -> Self {
         switch width {

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -18,7 +18,7 @@ import Glibc
 
 extension Locale {
 
-    // Identifier canoncalization
+    // Identifier canonicalization
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum IdentifierType : Sendable {
         /* This canonicalizes the identifier */
@@ -2414,7 +2414,7 @@ extension Locale.Region {
     @_alwaysEmitIntoClient
     public static var zimbabwe: Locale.Region { Locale.Region("ZW") }
 
-    // MARK: - Region codes for specifiying language variants
+    // MARK: - Region codes for specifying language variants
 
     @_alwaysEmitIntoClient
     public static var world: Locale.Region { Locale.Region("001") }

--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -1004,7 +1004,7 @@ public struct Locale : Hashable, Equatable, Sendable {
 
     // MARK: -
 
-    /// Returns `true` if the locale is one of the "special" languages that rqeuires special handling during case mapping.
+    /// Returns `true` if the locale is one of the "special" languages that requires special handling during case mapping.
     /// - "az": Azerbaijani
     /// - "lt": Lithuanian
     /// - "tr": Turkish

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1435,7 +1435,7 @@ internal final class _Locale: Sendable, Hashable {
                 // The numbering system is already the default numbering system (index 0)
                 localeIDComponents.numberingSystem = nil
             } else if whichNumberingSystem > 0 {
-                // If the numbering system for `localeIDWithDesiredComponents` is compatible with the constructed locale’s language and is not already the default numbering system (index 0), then set it on the new locale, e.g. `hi_IN@numbers=latn` + `ar` shoudl get `ar_IN@numbers=latn`, since `latn` is valid for `ar`.
+                // If the numbering system for `localeIDWithDesiredComponents` is compatible with the constructed locale’s language and is not already the default numbering system (index 0), then set it on the new locale, e.g. `hi_IN@numbers=latn` + `ar` should get `ar_IN@numbers=latn`, since `latn` is valid for `ar`.
                 localeIDComponents.numberingSystem = validNumberingSystems[whichNumberingSystem]
             }
 
@@ -1494,7 +1494,7 @@ internal final class _Locale: Sendable, Hashable {
 
 // MARK: -
 
-/// Holds user preferences about `Locale`, retrieved from user defaults. It is only used when creating the `current` Locale. Fixed-identiifer locales never have preferences.
+/// Holds user preferences about `Locale`, retrieved from user defaults. It is only used when creating the `current` Locale. Fixed-identifier locales never have preferences.
 internal struct LocalePreferences: Hashable {
     enum MeasurementUnit {
         case centimeters

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -1194,7 +1194,7 @@ E {
         XCTAssertEqual(type, decoded)
     }
     
-    func testCodingErrorsPropogateUpToCallSite() {
+    func testCodingErrorsPropagateUpToCallSite() {
         enum CustomAttribute : CodableAttributedStringKey {
             typealias Value = String
             static var name = "CustomAttribute"

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1537,7 +1537,7 @@ final class JSONEncoderTests : XCTestCase {
                 try unkeyedSVC1.encode("First")
                 try unkeyedSVC2.encode("Second")
 
-                // NOTE!!! At pressent, the order in which the values in the unkeyed container's superEncoders above get inserted into the resulting array depends on the order in which the superEncoders are deinit'd!! This can result in some very unexpected results, and this pattern is not recommended. This test exists just to verify compatibility.
+                // NOTE!!! At present, the order in which the values in the unkeyed container's superEncoders above get inserted into the resulting array depends on the order in which the superEncoders are deinit'd!! This can result in some very unexpected results, and this pattern is not recommended. This test exists just to verify compatibility.
             }
         }
         let data = try! JSONEncoder().encode(SuperEncoding())

--- a/Tests/FoundationInternationalizationTests/BinaryIntegerExtensionTests.swift
+++ b/Tests/FoundationInternationalizationTests/BinaryIntegerExtensionTests.swift
@@ -106,7 +106,7 @@ final class BinaryIntegerExtensionTests : XCTestCase {
         func verify(_ test: Int64, mode: FloatingPointRoundingRule, expected: [Int64: Int64], file: StaticString = #file, line: UInt = #line) {
             for (digit, expectation) in expected {
                 let actual = test.roundedToSignificantDigits(digit, rule: mode)
-                XCTAssertEqual(actual, expectation, "\(digit) signficant digits does not match", file: file, line: line)
+                XCTAssertEqual(actual, expectation, "\(digit) significant digits does not match", file: file, line: line)
             }
         }
 

--- a/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
@@ -181,7 +181,7 @@ final class ByteCountFormatStyleTests : XCTestCase {
 
 #if !os(watchOS)
     func testEveryAllowedUnit() {
-        // 84270854: The largest unit supported currenly is pb
+        // 84270854: The largest unit supported currently is pb
         let expectations: [ByteCountFormatStyle.Units: String] = [
             .bytes: "10,000,000,000,000,000 bytes",
             .kb: "10,000,000,000,000 kB",

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -111,7 +111,7 @@ final class DateIntervalFormatStyleTests: XCTestCase {
         XCTAssertEqual(noAMPMStyle.format(date..<date + day * 32), "1/1/2001, 12:00 – 2/2/2001, 12:00")
     }
 
-#if FOUNDATION_FRAMWORK
+#if FOUNDATION_FRAMEWORK
     func testLeadingDotSyntax() {
         let _ = (date..<date + hour).formatted(.interval)
         let _ = (date..<date + hour).formatted()

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -1517,7 +1517,7 @@ final class FormatStylePatternMatchingTests : XCTestCase {
         for testCase in signTests {
             _verifyMatching(testCase.string, formatStyle: style, expectedUpperBound: testCase.string.endIndex, expectedValue: testCase.value)
         }
-        // Scientific notitation
+        // Scientific notation
         let scientificTests = [
             (string: "4.2E4", value: 42000),
             (string: "-128.82E6", value: -128820000)

--- a/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
+++ b/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
@@ -21,7 +21,7 @@ import TestSupport
 #endif
 
 extension String {
-    var _scalarViewDiscription: String {
+    var _scalarViewDescription: String {
         return unicodeScalars.map { "\\u{\(String($0.value, radix: 16, uppercase: true))}" }.joined()
     }
 }
@@ -74,7 +74,7 @@ final class StringLocaleTests: XCTestCase {
             }
             let actual = string._uppercased(with: locale)
 
-            XCTAssertEqual(actual, expected, "actual: \(actual._scalarViewDiscription), expected: \(expected._scalarViewDiscription)", file: file, line: line)
+            XCTAssertEqual(actual, expected, "actual: \(actual._scalarViewDescription), expected: \(expected._scalarViewDescription)", file: file, line: line)
         }
 
         test(nil, "ﬄ", "FFL") // 0xFB04
@@ -117,7 +117,7 @@ final class StringLocaleTests: XCTestCase {
             }
             let actual = string._lowercased(with: locale)
 
-            XCTAssertEqual(actual, expected, "actual: \(actual._scalarViewDiscription), expected: \(expected._scalarViewDiscription)", file: file, line: line)
+            XCTAssertEqual(actual, expected, "actual: \(actual._scalarViewDescription), expected: \(expected._scalarViewDescription)", file: file, line: line)
         }
 
         test(nil, "ᾈ", "ᾀ")     // 0x1F88


### PR DESCRIPTION
Fixes ~40 typos of which two where incorrect spellings of `#if FOUNDATION_FRAMWORK`. 

I don't have Swift 5.9 toolchain setup, so I have not been able to run tests.