### PR TITLE
Fix "Gibc" -> "Glibc" in JSONDecoder #canImport

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif canImport(Gibc)
+#elseif canImport(Glibc)
 import Glibc
 #endif
 


### PR DESCRIPTION
The #canImport was typoed, which would have resulted in Glibc never being imported.

I grepped the source tree to make sure this was the only occurrence of this issue.