### PR TITLE
Implement Locale's identifier from components in Swift

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -971,27 +971,26 @@ public struct Locale : Hashable, Equatable, Sendable {
             
             // Identifier keywords must be ASCII a-z, A-Z, 0-9
             // They are normalized to all-lowercase
-            var ok = true
-            var correctedKey = key.utf8.map { c in
-                if 0x41 <= c && c <= 0x5a {
+            var correctedKey : [CChar] = []
+            for char in key.utf8 {
+                if (0x41...0x5a).contains(char) {
                     // A-Z
                     // Convert to lowercase by adding 0x20
-                    return CChar(c + 0x20)
-                } else if 0x61 <= c && c <= 0x7a {
+                    correctedKey.append(CChar(char + 0x20))
+                } else if (0x61...0x7a).contains(char) {
                     // a-z
-                    return CChar(c)
-                } else if 0x30 <= c && c <= 0x39 {
+                    correctedKey.append(CChar(char))
+                } else if (0x30...0x39).contains(char) {
                     // 0-9
-                    return CChar(c)
+                    correctedKey.append(CChar(char))
                 } else {
-                    ok = false
-                    return CChar(0)
+                    // Skip this key
+                    return nil
                 }
             }
             // null-terminate
             correctedKey.append(CChar(0))
             
-            guard ok else { return nil }
             let correctedKeyString = String(cString: correctedKey)
             
             // Values must be non-empty

--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -932,21 +932,62 @@ public struct Locale : Hashable, Equatable, Sendable {
 
     /// Constructs an identifier from a dictionary of components.
     public static func identifier(fromComponents components: [String : String]) -> String {
-#if FOUNDATION_FRAMEWORK
-        // TODO: Port to Swift
-        // n.b. the CFLocaleCreateLocaleIdentifierFromComponents API is normally [String: String], but for 'convenience' allows a `Calendar` value for "kCFLocaleCalendarKey"/"calendar".
-        return CFLocaleCreateLocaleIdentifierFromComponents(kCFAllocatorSystemDefault, components as CFDictionary).rawValue as String
-#else
-        return ""
-#endif // FOUNDATION_FRAMEWORK
+        var result = ""
+        if let language = components["kCFLocaleLanguageCodeKey"] {
+            result += language
+        }
+        if let script = components["kCFLocaleScriptCodeKey"] {
+            result += "_" + script
+        }
+        let country = components["kCFLocaleCountryCodeKey"]
+        let variant = components["kCFLocaleVariantCodeKey"]
+        
+        if country != nil || variant != nil {
+            result += "_"
+        }
+        
+        if let country {
+            result += country
+        }
+        
+        if let variant {
+            result += "_" + variant
+        }
+        
+        return result
     }
 
 #if FOUNDATION_FRAMEWORK
     /// Constructs an identifier from a dictionary of components, allowing a `Calendar` value. Compatibility only.
     internal static func identifier(fromComponents components: [String : Any]) -> String {
-        // TODO: Port to Swift: https://github.com/apple/swift-foundation/issues/45
-        // n.b. the CFLocaleCreateLocaleIdentifierFromComponents API is normally [String: String], but for 'convenience' allows a `Calendar` value for "kCFLocaleCalendarKey"/"calendar".
-        return CFLocaleCreateLocaleIdentifierFromComponents(kCFAllocatorSystemDefault, components as CFDictionary).rawValue as String
+        // n.b. the CFLocaleCreateLocaleIdentifierFromComponents API is normally [String: String], but for 'convenience' allows a `Calendar` value for "kCFLocaleCalendarKey"/"calendar". This version for framework use allows Calendar.
+        var result = ""
+        if let language = components["kCFLocaleLanguageCodeKey"] as? String {
+            result += language
+        }
+        if let script = components["kCFLocaleScriptCodeKey"] as? String {
+            result += "_" + script
+        }
+        let country = components["kCFLocaleCountryCodeKey"] as? String
+        let variant = components["kCFLocaleVariantCodeKey"] as? String
+        
+        if country != nil || variant != nil {
+            result += "_"
+        }
+        
+        if let country {
+            result += country
+        }
+        
+        if let variant {
+            result += "_" + variant
+        }
+        
+        if let calendar = components["kCFLocaleCalendarKey"] as? Calendar {
+            result += "@calendar=" + calendar.identifier.cfCalendarIdentifier
+        }
+        
+        return result
     }
 #endif // FOUNDATION_FRAMEWORK
 

--- a/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
@@ -108,7 +108,7 @@ extension NSLocale {
     @objc(_localeIdentifierFromComponents:)
     class func _localeIdentifier(fromComponents dict: [String : Any]) -> String {
         // n.b. the CFLocaleCreateLocaleIdentifierFromComponents API is normally [String: String], but for 'convenience' allows a `Calendar` value for "kCFLocaleCalendarKey"/"calendar". We call through to a compatibility version of `Locale.identifier(fromComponents:)` to support this.
-        Locale.identifier(fromComponents: dict)
+        Locale.identifier(fromAnyComponents: dict)
     }
 
     @available(macOS, deprecated: 13) @available(iOS, deprecated: 16) @available(tvOS, deprecated: 16) @available(watchOS, deprecated: 9)


### PR DESCRIPTION
Implement `Locale`'s `identifier(from:)` in Swift.

Perf test:

```swift
        let c1 = ["kCFLocaleLanguageCodeKey" : "en"]
        let c2 = ["kCFLocaleLanguageCodeKey" : "zh",
                  "kCFLocaleScriptCodeKey" : "Hans",
                  "kCFLocaleCountryCodeKey" : "TW"]
        let c3 = ["kCFLocaleLanguageCodeKey" : "es",
                  "kCFLocaleScriptCodeKey" : "",
                  "kCFLocaleCountryCodeKey" : "409"]
        
        for _ in 0..<100_000 {
            let id1 = Locale.identifier(fromComponents: c1)
            let id2 = Locale.identifier(fromComponents: c2)
            let id3 = Locale.identifier(fromComponents: c3)
            assert(id1.isEmpty == false)
            assert(id2.isEmpty == false)
            assert(id3.isEmpty == false)
        }
```

And the results:

```
// Swift implementation
test_identifierFromComponents()	0.040965125 seconds
test_identifierFromComponents()	0.039983875 seconds
// Previous CF implementation, from Swift
test_identifierFromComponents()	0.35747675 seconds
test_identifierFromComponents()	0.357553 seconds
```

Part of issue #45
Resolves rdar://108618701
