### PR TITLE
Refine the documentation of Calendar's methods.

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -1393,12 +1393,13 @@ public struct Calendar : Hashable, Equatable, Sendable {
         }
     }
 
-    /// Find the range of the weekend around the given date, returned via two by-reference parameters.
+    /// Finds the range of the weekend around the given date, and returns the starting date and duration of the weekend via two inout parameters.
     ///
     /// Note that a given entire day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
     /// - seealso: `dateIntervalOfWeekend(containing:)`
     /// - parameter date: The date at which to start the search.
-    /// - parameter start: When the result is `true`, set
+    /// - parameter start: Upon return, the starting date of the weekend if found.
+    /// - parameter interval: Upon return, the duration of the weekend if found.
     /// - returns: `true` if a date range could be found, and `false` if the date is not in a weekend.
     @available(iOS 8.0, *)
     public func dateIntervalOfWeekend(containing date: Date, start: inout Date, interval: inout TimeInterval) -> Bool {
@@ -1445,8 +1446,10 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// Note that a given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
     /// - parameter date: The date at which to begin the search.
+    /// - parameter start: Upon return, the starting date of the next weekend if found.
+    /// - parameter interval: Upon return, the duration of the next weekend if found.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`.
-    /// - returns: A `DateInterval`, or nil if the weekend could not be found.
+    /// - returns: `true` if the next weekend could be found, and `false` if there are no such things as weekend in the calendar and its locale.
     @available(iOS 8.0, *)
     public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool {
         guard let weekend = nextWeekend(startingAfter: date, direction: direction) else {

--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -1449,7 +1449,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - parameter start: Upon return, the starting date of the next weekend if found.
     /// - parameter interval: Upon return, the duration of the next weekend if found.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`.
-    /// - returns: `true` if the next weekend could be found, and `false` if there are no such things as weekend in the calendar and its locale.
+    /// - returns: `true` if the next weekend is found.
     @available(iOS 8.0, *)
     public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool {
         guard let weekend = nextWeekend(startingAfter: date, direction: direction) else {


### PR DESCRIPTION
Updates the documentation of the parameters and return types of the following two methods:

`public func dateIntervalOfWeekend(containing date: Date, start: inout Date, interval: inout TimeInterval) -> Bool`
and
`public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool`

The updated documentation is written with reference to the language used in `public func dateInterval(of component: Component, start: inout Date, interval: inout TimeInterval, for date: Date) -> Bool`.