### PR TITLE
AttributeScope Cacheing and Performance Improvements

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -104,19 +104,11 @@ extension AttributedString {
 
     public init<S : AttributeScope, T : AttributedStringProtocol>(_ other: T, including scope: S.Type) {
         self.init(other.__guts.copy(in: other.startIndex ..< other.endIndex))
-        var attributeCache = [String : Bool]()
+        let attributeTypes = scope.attributeKeyTypes()
         _guts.enumerateRuns { run, _, _, modification in
             modification = .guaranteedNotModified
             for key in run.attributes.keys {
-                var inScope: Bool
-                if let cachedInScope = attributeCache[key] {
-                    inScope = cachedInScope
-                } else {
-                    inScope = scope.attributeKeyType(matching: key) != nil
-                    attributeCache[key] = inScope
-                }
-
-                if !inScope {
+                if !attributeTypes.keys.contains(key) {
                     run.attributes[key] = nil
                     modification = .guaranteedModified
                 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -126,23 +126,6 @@ extension AttributedStringKey {
 
 // MARK: Attribute Scopes
 
-// Developers can also add the attributes to pre-defined scopes of attributes, which are used to provide type information to the encoding and decoding of AttributedString values, as well as allow for dynamic member lookup in Runss of AttributedStrings.
-// Example, where ForegroundColor is an existing AttributedStringKey:
-// struct MyAttributes : AttributeScope {
-//     var foregroundColor : ForegroundColor
-// }
-// An AttributeScope can contain other scopes as well.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigurationProviding {
-    static var decodingConfiguration: AttributeScopeCodableConfiguration { get }
-    static var encodingConfiguration: AttributeScopeCodableConfiguration { get }
-}
-
-@_nonSendable
-@frozen
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-public enum AttributeScopes { }
-
 @_nonSendable
 @dynamicMemberLookup @frozen
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -179,14 +162,9 @@ public struct ScopedAttributeContainer<S: AttributeScope> : Sendable {
 #if FOUNDATION_FRAMEWORK
     // TODO: Support scope-specific equality/attributes in FoundationPreview
     internal func equals(_ other: Self) -> Bool {
-        for field in Type(S.self).fields {
-            switch field.type.swiftType {
-            case let attribute as any AttributedStringKey.Type:
-                if self.storage[attribute.name] != other.storage[attribute.name] {
-                    return false
-                }
-                break
-            default: break // TODO: Nested scopes
+        for (name, _) in S.attributeKeyTypes() {
+            if self.storage[name] != other.storage[name] {
+                return false
             }
         }
         return true
@@ -194,10 +172,8 @@ public struct ScopedAttributeContainer<S: AttributeScope> : Sendable {
 
     internal var attributes : AttributeContainer {
         var contents = AttributedString._AttributeStorage()
-        for field in Type(S.self).fields {
-            if let attribute = field.type.swiftType as? any AttributedStringKey.Type {
-                contents[attribute.name] = self.storage[attribute.name]
-            }
+        for (name, _) in S.attributeKeyTypes() {
+            contents[name] = self.storage[name]
         }
         return AttributeContainer(contents)
     }
@@ -238,35 +214,4 @@ internal extension AttributedStringKey {
         }
     }
 }
-
-// TODO: Support AttributeScope key finding in FoundationPreview
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-internal extension AttributeScope {
-    static func attributeKeyType(matching key: String) -> (any AttributedStringKey.Type)? {
-        for field in Type(Self.self).fields {
-            if let attributeType = field.type.swiftType as? any AttributedStringKey.Type, attributeType.name == key {
-                return attributeType
-            }
-            
-            if let scopeType = field.type.swiftType as? any AttributeScope.Type, let found = scopeType.attributeKeyType(matching: key) {
-                return found
-            }
-        }
-        return nil
-    }
-    
-    static func markdownAttributeKeyType(matching key: String) -> (any MarkdownDecodableAttributedStringKey.Type)? {
-        for field in Type(Self.self).fields {
-            if let attributeType = field.type.swiftType as? any MarkdownDecodableAttributedStringKey.Type, attributeType.markdownName == key {
-                return attributeType
-            }
-            
-            if let scopeType = field.type.swiftType as? any AttributeScope.Type, let found = scopeType.markdownAttributeKeyType(matching: key) {
-                return found
-            }
-        }
-        return nil
-    }
-}
-
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -97,22 +97,29 @@ public extension DecodableAttributedStringKey where Value : NSSecureCoding & NSO
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributeScopeCodableConfiguration : Sendable {
-    internal let scopeType : any AttributeScope.Type
-    internal let extraAttributesTable : [String : any AttributedStringKey.Type]
+    internal let attributesTable : [String : any AttributedStringKey.Type]
     
     internal init(
-        scopeType: any AttributeScope.Type,
-        extraAttributesTable: [String : any AttributedStringKey.Type] = [:]
+        _ attributesTable: [String : any AttributedStringKey.Type]
     ) {
-        self.scopeType = scopeType
-        self.extraAttributesTable = extraAttributesTable
+        self.attributesTable = attributesTable
+    }
+    
+    internal init<S: AttributeScope>(
+        _ scope: S.Type
+    ) {
+#if FOUNDATION_FRAMEWORK
+        self.attributesTable = S.attributeKeyTypes()
+#else
+        self.attributesTable = [:]
+#endif // FOUNDATION_FRAMEWORK
     }
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public extension AttributeScope {
-    static var encodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(scopeType: self) }
-    static var decodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(scopeType: self) }
+    static var encodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(Self.self) }
+    static var decodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(Self.self) }
 }
 
 #if FOUNDATION_FRAMEWORK
@@ -120,16 +127,12 @@ public extension AttributeScope {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString : Codable {
     public func encode(to encoder: Encoder) throws {
-        let conf = AttributeScopeCodableConfiguration(
-            scopeType: AttributeScopes.FoundationAttributes.self,
-            extraAttributesTable: _loadDefaultAttributes())
+        let conf = AttributeScopeCodableConfiguration(_loadDefaultAttributes())
         try encode(to: encoder, configuration: conf)
     }
     
     public init(from decoder: Decoder) throws {
-        let conf = AttributeScopeCodableConfiguration(
-            scopeType: AttributeScopes.FoundationAttributes.self,
-            extraAttributesTable: _loadDefaultAttributes())
+        let conf = AttributeScopeCodableConfiguration(_loadDefaultAttributes())
         try self.init(from: decoder, configuration: conf)
     }
 }
@@ -176,7 +179,6 @@ extension AttributedString : CodableWithConfiguration {
         }
 
         var currentIndex = self.startIndex
-        var attributeKeyTypes = configuration.extraAttributesTable
         for run in self._guts.runs {
             let currentEndIndex = self._guts.utf8Index(currentIndex, offsetBy: run.length)
             let range = (currentIndex ..< currentEndIndex)._bstringRange
@@ -189,8 +191,7 @@ extension AttributedString : CodableWithConfiguration {
                     try Self.encodeAttributeContainer(
                         run.attributes,
                         to: attributeTableContainer.superEncoder(),
-                        configuration: configuration,
-                        using: &attributeKeyTypes)
+                        configuration: configuration)
                     attributeTable[run.attributes] = index
                     attributeTableNextIndex += 1
                 }
@@ -199,8 +200,7 @@ extension AttributedString : CodableWithConfiguration {
                 try Self.encodeAttributeContainer(
                     run.attributes,
                     to: runsContainer.superEncoder(),
-                    configuration: configuration,
-                    using: &attributeKeyTypes)
+                    configuration: configuration)
             }
 
             currentIndex = currentEndIndex
@@ -210,16 +210,14 @@ extension AttributedString : CodableWithConfiguration {
     fileprivate static func encodeAttributeContainer(
         _ attributes: _AttributeStorage,
         to encoder: Encoder,
-        configuration: AttributeScopeCodableConfiguration,
-        using attributeKeyTypeTable: inout [String : any AttributedStringKey.Type]
+        configuration: AttributeScopeCodableConfiguration
     ) throws {
         var attributesContainer = encoder.container(keyedBy: AttributeKey.self)
         for name in attributes.keys {
             if
-                let attributeKeyType = attributeKeyTypeTable[name] ?? configuration.scopeType.attributeKeyType(matching: name),
+                let attributeKeyType = configuration.attributesTable[name],
                 let encodableAttributeType = attributeKeyType as? any EncodableAttributedStringKey.Type
             {
-                attributeKeyTypeTable[name] = attributeKeyType
                 let attributeEncoder = attributesContainer.superEncoder(forKey: AttributeKey(stringValue: name)!)
                 func project<K: EncodableAttributedStringKey>(_: K.Type) throws {
                     try K.encode(attributes[K.self]!, to: attributeEncoder)
@@ -237,7 +235,6 @@ extension AttributedString : CodableWithConfiguration {
 
         var runsContainer: UnkeyedDecodingContainer
         var attributeTable: [_AttributeStorage]?
-        var attributeKeyTypeTable = configuration.extraAttributesTable
 
         if let runs = try? decoder.unkeyedContainer() {
             runsContainer = runs
@@ -247,8 +244,7 @@ extension AttributedString : CodableWithConfiguration {
             runsContainer = try topLevelContainer.nestedUnkeyedContainer(forKey: .runs)
             attributeTable = try Self.decodeAttributeTable(
                 from: topLevelContainer.superDecoder(forKey: .attributeTable),
-                configuration: configuration,
-                using: &attributeKeyTypeTable)
+                configuration: configuration)
         }
 
         var string: BigString = ""
@@ -277,8 +273,7 @@ extension AttributedString : CodableWithConfiguration {
             } else {
                 attributes = try Self.decodeAttributeContainer(
                     from: try runsContainer.superDecoder(),
-                    configuration: configuration,
-                    using: &attributeKeyTypeTable)
+                    configuration: configuration)
             }
 
             if substring.isEmpty && (runs.count > 0 || !runsContainer.isAtEnd) {
@@ -309,8 +304,7 @@ extension AttributedString : CodableWithConfiguration {
 
     private static func decodeAttributeTable(
         from decoder: Decoder,
-        configuration: AttributeScopeCodableConfiguration,
-        using attributeKeyTypeTable: inout [String : any AttributedStringKey.Type]
+        configuration: AttributeScopeCodableConfiguration
     ) throws -> [_AttributeStorage] {
         var container = try decoder.unkeyedContainer()
         var table = [_AttributeStorage]()
@@ -318,25 +312,23 @@ extension AttributedString : CodableWithConfiguration {
             table.reserveCapacity(size)
         }
         while !container.isAtEnd {
-            table.append(try decodeAttributeContainer(from: try container.superDecoder(), configuration: configuration, using: &attributeKeyTypeTable))
+            table.append(try decodeAttributeContainer(from: try container.superDecoder(), configuration: configuration))
         }
         return table
     }
 
     fileprivate static func decodeAttributeContainer(
         from decoder: Decoder,
-        configuration: AttributeScopeCodableConfiguration,
-        using attributeKeyTypeTable: inout [String : any AttributedStringKey.Type]
+        configuration: AttributeScopeCodableConfiguration
     ) throws -> _AttributeStorage {
         let attributesContainer = try decoder.container(keyedBy: AttributeKey.self)
         var attributes = _AttributeStorage()
         for key in attributesContainer.allKeys {
             let name = key.stringValue
             if
-                let attributeKeyType = attributeKeyTypeTable[name] ?? configuration.scopeType.attributeKeyType(matching: name),
+                let attributeKeyType = configuration.attributesTable[name],
                 let decodableAttributeType = attributeKeyType as? any DecodableAttributedStringKey.Type
             {
-                attributeKeyTypeTable[name] = attributeKeyType
                 func project<K: DecodableAttributedStringKey>(_: K.Type) throws {
                     attributes[K.self] = try K.decode(from: try attributesContainer.superDecoder(forKey: key))
                 }
@@ -351,13 +343,11 @@ extension AttributedString : CodableWithConfiguration {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeContainer : CodableWithConfiguration {
     public func encode(to encoder: Encoder, configuration: AttributeScopeCodableConfiguration) throws {
-        var attributeKeyTypeTable = configuration.extraAttributesTable
-        try AttributedString.encodeAttributeContainer(self.storage, to: encoder, configuration: configuration, using: &attributeKeyTypeTable)
+        try AttributedString.encodeAttributeContainer(self.storage, to: encoder, configuration: configuration)
     }
 
     public init(from decoder: Decoder, configuration: AttributeScopeCodableConfiguration) throws {
-        var attributeKeyTypeTable = configuration.extraAttributesTable
-        self.storage = try AttributedString.decodeAttributeContainer(from: decoder, configuration: configuration, using: &attributeKeyTypeTable)
+        self.storage = try AttributedString.decodeAttributeContainer(from: decoder, configuration: configuration)
     }
 }
 

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -1695,7 +1695,7 @@ E {
         container.testInt = 2
         container[Attribute.self] = 3
         let str = AttributedString("Hello", attributes: container)
-        let result = try? NSAttributedString(str, scope: Scope.self, options: .dropThrowingAttributes) // The same call that the no-scope initializer will make
+        let result = try? NSAttributedString(str, attributeTable: Scope.attributeKeyTypes(), options: .dropThrowingAttributes) // The same call that the no-scope initializer will make
         XCTAssertEqual(result, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key("TestInt") : 2]))
     }
     


### PR DESCRIPTION
Currently, when converting/serializing an `AttributedString` we walk the provided `AttributeScope` one time for every new attribute we encounter and we do not cache the information between conversions. However, walking an attribute scope is fairly slow (since it requires a conforms-to-protocol check on the type of each field in the scope) so this behavior has been demonstrated to be a performance bottleneck. This patch improves the behavior by:

- Eagerly walking a scope at the start of conversion rather than walking it after encountering each new attribute
- Cache the result of scope walking so that each scope is walked a maximum of one time
- Switch from `dlopen`/`dlsym` to `_typeByName` to avoid a dependency on framework paths and simplify scope loading code