### PR TITLE
rdar://105027055: Improve AttributedString view slicing

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -156,7 +156,36 @@ extension AttributedString.CharacterView: BidirectionalCollection {
         return j
     }
 
-    // FIXME: Implement index(_:offsetBy:limitedBy:)
+    @_alwaysEmitIntoClient
+    public func index(
+        _ i: AttributedString.Index,
+        offsetBy distance: Int,
+        limitedBy limit: AttributedString.Index
+    ) -> AttributedString.Index? {
+        if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+            return _index(i, offsetBy: distance, limitedBy: limit)
+        }
+        return _defaultIndex(i, offsetBy: distance, limitedBy: limit)
+    }
+
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @usableFromInline
+    internal func _index(
+        _ i: AttributedString.Index,
+        offsetBy distance: Int,
+        limitedBy limit: AttributedString.Index
+    ) -> AttributedString.Index? {
+        precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
+        precondition(limit >= startIndex && limit <= endIndex, "AttributedString index out of bounds")
+        guard let j = _guts.string.index(
+            i._value, offsetBy: distance, limitedBy: limit._value
+        ) else {
+            return nil
+        }
+        precondition(j >= startIndex._value && j <= endIndex._value,
+                     "AttributedString index out of bounds")
+        return Index(j)
+    }
 
     @_alwaysEmitIntoClient
     public func distance(from start: AttributedString.Index, to end: AttributedString.Index) -> Int {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -271,6 +271,18 @@ extension AttributedString.Guts {
         Index(string.index(roundingUp: i._value))
     }
 
+    func unicodeScalarRange(roundingDown range: Range<Index>) -> Range<Index> {
+        let lower = unicodeScalarIndex(roundingDown: range.lowerBound)
+        let upper = unicodeScalarIndex(roundingDown: range.upperBound)
+        return Range(uncheckedBounds: (lower, upper))
+    }
+
+    func characterRange(roundingDown range: Range<Index>) -> Range<Index> {
+        let lower = characterIndex(roundingDown: range.lowerBound)
+        let upper = characterIndex(roundingDown: range.upperBound)
+        return Range(uncheckedBounds: (lower, upper))
+    }
+
     func boundsCheck(_ idx: AttributedString.Index) {
         precondition(
             idx._value >= string.startIndex && idx._value < string.endIndex,
@@ -463,32 +475,59 @@ extension AttributedString.Guts {
         }
     }
 
+    func _prepareStringMutation(
+        in range: Range<Index>
+    ) -> (oldUTF8Count: Int, invalidationRange: Range<Int>) {
+        let utf8TargetRange = range._utf8OffsetRange
+        let invalidationRange = self.enforceAttributeConstraintsBeforeMutation(to: utf8TargetRange)
+        assert(invalidationRange.lowerBound <= utf8TargetRange.lowerBound)
+        assert(invalidationRange.upperBound >= utf8TargetRange.upperBound)
+        return (self.string.utf8.count, invalidationRange)
+    }
+
+    func _finalizeStringMutation(
+        _ state: (oldUTF8Count: Int, invalidationRange: Range<Int>)
+    ) {
+        let utf8Delta = self.string.utf8.count - state.oldUTF8Count
+        let lower = state.invalidationRange.lowerBound
+        let upper = state.invalidationRange.upperBound + utf8Delta
+        self.enforceAttributeConstraintsAfterMutation(
+            in: lower ..< upper,
+            type: .attributesAndCharacters)
+    }
+
+    func _finalizeAttributeMutation(in range: Range<Index>) {
+        self.enforceAttributeConstraintsAfterMutation(in: range._utf8OffsetRange, type: .attributes)
+    }
+
     func replaceSubrange(_ range: Range<Index>, with replacement: some AttributedStringProtocol) {
-        let utf8TargetRange = utf8OffsetRange(from: range)
+        let brange = range._bstringRange
+        let replacementScalars = replacement.unicodeScalars._unicodeScalars
 
-        let utf8SourceRange = replacement.__guts.utf8OffsetRange(from: replacement._bounds)
+        // Determine if this replacement is going to actively change character data, or if this is
+        // purely an attributes update, by seeing if the replacement string slice is identical to
+        // our own storage. (If it is identical, then we need to update attributes surrounding the
+        // affected bounds in a different way.)
+        //
+        // Note: this is intentionally not comparing actual string data.
+        let hasStringChanges = !replacementScalars.isIdentical(to: string.unicodeScalars[brange])
 
-        var mutationRange = utf8TargetRange
-        var mutationType: _MutationType = .attributes
-
-        let oldScalars = self.string.unicodeScalars[range._bstringRange]
-        let newScalars = replacement.unicodeScalars._unicodeScalars
-        if oldScalars == newScalars {
-            assert(utf8TargetRange.count == utf8SourceRange.count)
-        } else {
-            let invalidationRange = self.enforceAttributeConstraintsBeforeMutation(
-                to: utf8TargetRange)
-            assert(invalidationRange.lowerBound <= utf8TargetRange.lowerBound)
-            assert(invalidationRange.upperBound >= utf8TargetRange.upperBound)
-            let utf8Delta = utf8SourceRange.count - utf8TargetRange.count
-            mutationRange = invalidationRange.lowerBound ..< invalidationRange.upperBound + utf8Delta
-            mutationType = .attributesAndCharacters
-            self.string.unicodeScalars.replaceSubrange(range._bstringRange, with: newScalars)
-        }
+        let utf8TargetRange = brange._utf8OffsetRange
+        let utf8SourceRange = Range(uncheckedBounds: (
+            replacementScalars.startIndex.utf8Offset,
+            replacementScalars.endIndex.utf8Offset
+        ))
         let replacementRuns = replacement.__guts.runs(containing: utf8SourceRange)
-        self.replaceRunsSubrange(locations: utf8TargetRange, with: replacementRuns)
-        // FIXME: Collect boundary constraints.
-        self.enforceAttributeConstraintsAfterMutation(in: mutationRange, type: mutationType)
+
+        if hasStringChanges {
+            let state = _prepareStringMutation(in: range)
+            self.string.unicodeScalars.replaceSubrange(brange, with: replacementScalars)
+            self.replaceRunsSubrange(locations: utf8TargetRange, with: replacementRuns)
+            _finalizeStringMutation(state)
+        } else {
+            self.replaceRunsSubrange(locations: utf8TargetRange, with: replacementRuns)
+            _finalizeAttributeMutation(in: range)
+        }
     }
 
     func attributesToUseForTextReplacement(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -55,7 +55,7 @@ extension AttributedString.Runs.Run: Equatable {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs.Run: CustomStringConvertible {
     public var description: String {
-        AttributedSubstring(_guts, range).description
+        AttributedSubstring(_guts, in: _range).description
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -18,7 +18,7 @@ import _RopeModule
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    public struct Runs : Sendable {
+    public struct Runs: Sendable {
         internal typealias _InternalRun = AttributedString._InternalRun
         internal typealias _AttributeStorage = AttributedString._AttributeStorage
         internal typealias AttributeRunBoundaries = AttributedString.AttributeRunBoundaries
@@ -27,9 +27,9 @@ extension AttributedString {
         internal var _range: Range<AttributedString.Index>
         internal var _runRange: Range<AttributedString.Runs.Index>
 
-        internal init(_ g: Guts, _ r: Range<AttributedString.Index>) {
-            _guts = g
-            _range = r
+        internal init(_ guts: Guts, _ range: Range<AttributedString.Index>) {
+            _guts = guts
+            _range = range
             let startRun = _guts.indexOfRun(at: _range.lowerBound)
             let endRun: AttributedString.Runs.Index
             if _range.upperBound == _guts.endIndex {
@@ -106,7 +106,7 @@ extension AttributedString.Runs: Equatable {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs: CustomStringConvertible {
     public var description: String {
-        AttributedSubstring(_guts, _range).description
+        AttributedSubstring(_guts, in: _range).description
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -18,54 +18,69 @@ import _RopeModule
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    public struct UnicodeScalarView : Sendable {
-        internal var _guts : Guts
-        internal var _range : Range<Index>
-        internal var _identity : Int = 0
-        internal init(_ g: Guts, _ r: Range<Index>) {
-            _guts = g
-            _range = r
+    public struct UnicodeScalarView: Sendable {
+        internal var _guts: Guts
+
+        /// The boundary range of this character view.
+        ///
+        /// The bounds are always rounded down to the nearest Unicode scalar boundary in the
+        /// original string.
+        internal var _range: Range<Index>
+
+        internal var _identity: Int = 0
+
+        internal init(_ guts: AttributedString.Guts) {
+            // The bounds of a whole attributed string are already scalar-aligned.
+            self.init(guts, in: Range(uncheckedBounds: (guts.startIndex, guts.endIndex)))
         }
-        
+
+        internal init(_ guts: Guts, in range: Range<Index>) {
+            _guts = guts
+            // Forcibly resolve bounds and round them down to nearest scalar boundary.
+            let slice = _guts.string.unicodeScalars[range._bstringRange]
+            _range = Range(uncheckedBounds: (Index(slice.startIndex), Index(slice.endIndex)))
+        }
+
         public init() {
-            _guts = Guts(string: "", runs: [])
-            _range = _guts.startIndex ..< _guts.endIndex
+            self.init(Guts())
         }
     }
 
     public var unicodeScalars: UnicodeScalarView {
         get {
-            UnicodeScalarView(_guts, startIndex ..< endIndex)
+            UnicodeScalarView(_guts)
         }
         _modify {
             ensureUniqueReference()
-            var usv = UnicodeScalarView(_guts, startIndex ..< endIndex)
+            var view = UnicodeScalarView(_guts)
             let ident = Self._nextModifyIdentity
-            usv._identity = ident
-            _guts = Guts(string: "", runs: []) // Dummy guts so the UnicodeScalarView has (hopefully) the sole reference
+            view._identity = ident
+            _guts = Guts() // Preserve uniqueness of view
             defer {
-                if usv._identity != ident {
+                if view._identity != ident {
                     fatalError("Mutating a UnicodeScalarView by replacing it with another from a different source is unsupported")
                 }
-                _guts = usv._guts
+                _guts = view._guts
             }
-            yield &usv
-        } set {
-            self.unicodeScalars.replaceSubrange(startIndex ..< endIndex, with: newValue)
+            yield &view
+        }
+        set {
+            // FIXME: Why is this allowed if _modify traps on replacement?
+            self.unicodeScalars.replaceSubrange(_bounds, with: newValue)
         }
     }
 }
 
 extension AttributedString.UnicodeScalarView {
     var _unicodeScalars: BigSubstring.UnicodeScalarView {
-        _guts.string.unicodeScalars[_range._bstringRange]
+        BigSubstring.UnicodeScalarView(_unchecked: _guts.string, in: _range._bstringRange)
     }
 }
 
 extension Slice<AttributedString.UnicodeScalarView> {
     internal var _rebased: AttributedString.UnicodeScalarView {
         let bounds = Range(uncheckedBounds: (self.startIndex, self.endIndex))
-        return AttributedString.UnicodeScalarView(base._guts, bounds)
+        return AttributedString.UnicodeScalarView(base._guts, in: bounds)
     }
 
     internal var _unicodeScalars: BigSubstring.UnicodeScalarView {
@@ -85,16 +100,16 @@ extension AttributedString.UnicodeScalarView {
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-extension AttributedString.UnicodeScalarView: BidirectionalCollection, RangeReplaceableCollection {
+extension AttributedString.UnicodeScalarView: BidirectionalCollection {
     public typealias Element = UnicodeScalar
     public typealias Index = AttributedString.Index
 
     public var startIndex: AttributedString.Index {
-        return _range.lowerBound
+        _range.lowerBound
     }
 
     public var endIndex: AttributedString.Index {
-        return _range.upperBound
+        _range.upperBound
     }
 
     @_alwaysEmitIntoClient
@@ -108,7 +123,7 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection, RangeRepl
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     @usableFromInline
     internal var _count: Int {
-        _guts.unicodeScalarDistance(from: _range.lowerBound, to: _range.upperBound)
+        _unicodeScalars.count
     }
 
     public func index(before i: AttributedString.Index) -> AttributedString.Index {
@@ -142,6 +157,8 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection, RangeRepl
         if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
             return _distance(from: start, to: end)
         }
+        precondition(start >= startIndex && start <= endIndex, "AttributedString index out of bounds")
+        precondition(end >= startIndex && end <= endIndex, "AttributedString index out of bounds")
         return _defaultDistance(from: start, to: end)
     }
 
@@ -155,46 +172,126 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection, RangeRepl
         precondition(end >= startIndex && end <= endIndex, "AttributedString index out of bounds")
         return _guts.string.unicodeScalars.distance(from: start._value, to: end._value)
     }
-
+    
+    // FIXME: Why isn't this mutable if CharacterView's equivalent subscript has a setter?
     public subscript(index: AttributedString.Index) -> UnicodeScalar {
-        _guts.string.unicodeScalars[index._value]
+        precondition(index >= startIndex && index < endIndex, "AttributedString index out of bounds")
+        return _guts.string.unicodeScalars[index._value]
     }
-
+    
+    // FIXME: Why isn't this mutable if CharacterView's equivalent subscript has a setter?
     public subscript(bounds: Range<AttributedString.Index>) -> Slice<AttributedString.UnicodeScalarView> {
-        Slice(base: self, bounds: bounds)
+        precondition(
+            bounds.lowerBound >= startIndex && bounds.upperBound <= endIndex,
+            "AttributedString index range out of bounds")
+        let view = Self(_guts, in: bounds)
+        return Slice(base: view, bounds: view._range)
     }
+}
 
-    internal mutating func ensureUniqueReference() {
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString.UnicodeScalarView: RangeReplaceableCollection {
+    internal mutating func _ensureUniqueReference() {
         if !isKnownUniquelyReferenced(&_guts) {
             _guts = _guts.copy()
         }
     }
-
-    public mutating func replaceSubrange<C : Collection>(
-        _ subrange: Range<Index>,
-        with newElements: C
-    ) where C.Element == UnicodeScalar {
+    
+    internal mutating func _mutateStringContents(
+        in range: Range<Index>,
+        attributes: AttributedString._AttributeStorage,
+        with body: (inout BigSubstring.UnicodeScalarView, Range<BigString.Index>) -> Void
+    ) {
+        // Invalidate attributes surrounding the affected range. (Phase 1)
+        let state = _guts._prepareStringMutation(in: range)
+        
+        // Update string contents.
+        //
+        // This is "fun". CharacterView (inconsistently) implements self-slicing, and so
+        // mutations of it need to update its bounds to reflect the newly updated content.
+        // We do this by extracting the new bounds from BigSubstring, which already does the
+        // right thing.
+        var scalars = _unicodeScalars
+        _guts.string = BigString() // Preserve uniqueness
+        
+        body(&scalars, range._bstringRange)
+        
+        self._guts.string = BigString(scalars.base)
+        let lower = AttributedString.Index(scalars.startIndex)
+        let upper = AttributedString.Index(scalars.endIndex)
+        self._range = Range(uncheckedBounds: (lower, upper))
+        
+        // Set attributes for the mutated range.
+        let utf8Range = range._utf8OffsetRange
+        let utf8Delta = _guts.string.utf8.count - state.oldUTF8Count
+        let runLength = utf8Range.count + utf8Delta
+        let run = AttributedString._InternalRun(length: runLength, attributes: attributes)
+        _guts.replaceRunsSubrange(locations: utf8Range, with: CollectionOfOne(run))
+        
+        // Invalidate attributes surrounding the affected range. (Phase 2)
+        _guts._finalizeStringMutation(state)
+    }
+    
+    internal mutating func _setAttributes(
+        in range: Range<Index>,
+        to attributes: AttributedString._AttributeStorage
+    ) {
+        let utf8Range = range._utf8OffsetRange
+        let run = AttributedString._InternalRun(length: utf8Range.count, attributes: attributes)
+        _guts.replaceRunsSubrange(locations: utf8Range, with: CollectionOfOne(run))
+    }
+    
+    public mutating func replaceSubrange(
+        _ subrange: Range<Index>, with newElements: some Collection<UnicodeScalar>
+    ) {
         precondition(
             subrange.lowerBound >= self.startIndex && subrange.upperBound <= self.endIndex,
             "AttributedString index range out of bounds")
-
-        ensureUniqueReference()
-        let unicodeScalarView = String.UnicodeScalarView(newElements)
-        let newElementsString = String(unicodeScalarView)
-        let newAttributedString = AttributedString(newElementsString)
-        if newAttributedString._guts.runs.count > 0 {
-            var run = newAttributedString._guts.runs[0]
-            run.attributes = _guts.attributesToUseForTextReplacement(in: subrange, includingCharacterDependentAttributes: newElements.elementsEqual(self[subrange]))
-            newAttributedString._guts.updateAndCoalesce(run: run, at: 0)
+        
+        let subrange = _guts.unicodeScalarRange(roundingDown: subrange)
+        
+        // Prevent the BigString mutation below from falling back to Character-by-Character loops.
+        if let newElements = _specializingCast(newElements, to: Self.self) {
+            _replaceSubrange(subrange, with: newElements._unicodeScalars)
+        } else if let newElements = _specializingCast(newElements, to: Slice<Self>.self) {
+            _replaceSubrange(subrange, with: newElements._rebased._unicodeScalars)
+        } else {
+            _replaceSubrange(subrange, with: newElements)
         }
-
-        let startOffset = _guts.utf8Offset(of: self.startIndex)
-        let endOffset = _guts.utf8Offset(of: self.endIndex)
-
-        let oldCount = _guts.string.utf8.count
-        _guts.replaceSubrange(subrange, with: newAttributedString)
-        let newCount = _guts.string.utf8.count
-
-        _range = _guts.utf8IndexRange(from: startOffset ..< endOffset + (newCount - oldCount))
     }
+    
+    internal mutating func _replaceSubrange(
+        _ subrange: Range<Index>, with newElements: some Collection<UnicodeScalar>
+    ) {
+        _ensureUniqueReference()
+        
+        var hasStringChanges = true
+        if let newElements = _specializingCast(newElements, to: BigSubstring.UnicodeScalarView.self) {
+            // Determine if this replacement is going to actively change character data, or if this
+            // is purely an attributes update, by seeing if the replacement string slice is
+            // identical to our own storage. (If it is identical, then we need to update attributes
+            // surrounding the affected bounds in a different way.)
+            //
+            // Note: this is intentionally not comparing actual string data.
+            if newElements.isIdentical(to: _unicodeScalars[subrange._bstringRange]) {
+                hasStringChanges = false
+            }
+        }
+        
+        let attributes = _guts.attributesToUseForTextReplacement(
+            in: subrange,
+            includingCharacterDependentAttributes: !hasStringChanges)
+        
+        if hasStringChanges {
+            self._mutateStringContents(in: subrange, attributes: attributes) { string, range in
+                string.replaceSubrange(range, with: newElements)
+            }
+        } else {
+            self._setAttributes(in: subrange, to: attributes)
+        }
+    }
+
+    // FIXME: Add individual overrides for other RangeReplaceableCollection mutations.
+    // (Letting everything go through `replaceSubrange` can be extremely costly -- e.g.,
+    // `append(contentsOf:)` calls `replaceSubrange` once for each character!)
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -147,7 +147,36 @@ extension AttributedString.UnicodeScalarView: BidirectionalCollection {
         return j
     }
 
-    // FIXME: Implement index(_:offsetBy:limitedBy:)
+    @_alwaysEmitIntoClient
+    public func index(
+        _ i: AttributedString.Index,
+        offsetBy distance: Int,
+        limitedBy limit: AttributedString.Index
+    ) -> AttributedString.Index? {
+        if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+            return _index(i, offsetBy: distance, limitedBy: limit)
+        }
+        return _defaultIndex(i, offsetBy: distance, limitedBy: limit)
+    }
+
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @usableFromInline
+    internal func _index(
+        _ i: AttributedString.Index,
+        offsetBy distance: Int,
+        limitedBy limit: AttributedString.Index
+    ) -> AttributedString.Index? {
+        precondition(i >= startIndex && i <= endIndex, "AttributedString index out of bounds")
+        precondition(limit >= startIndex && limit <= endIndex, "AttributedString index out of bounds")
+        guard let j = _guts.string.unicodeScalars.index(
+            i._value, offsetBy: distance, limitedBy: limit._value
+        ) else {
+            return nil
+        }
+        precondition(j >= startIndex._value && j <= endIndex._value,
+                     "AttributedString index out of bounds")
+        return Index(j)
+    }
 
     @_alwaysEmitIntoClient
     public func distance(

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -45,14 +45,14 @@ extension AttributedString {
     }
 
     internal init(_ s: some AttributedStringProtocol) {
-        if let s = s as? AttributedString {
+        if let s = _specializingCast(s, to: AttributedString.self) {
             self = s
-        } else if let s = s as? AttributedSubstring {
+        } else if let s = _specializingCast(s, to: AttributedSubstring.self) {
             self = AttributedString(s)
         } else {
             // !!!: We don't expect or want this to happen.
-            // FIXME: Handle slicing.
-            self = AttributedString(s.characters._guts)
+            let substring = AttributedSubstring(s.__guts, s._bounds)
+            self = AttributedString(substring)
         }
     }
 
@@ -121,19 +121,19 @@ extension AttributedString {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
     internal static func _bstring<S: Sequence<Character>>(from elements: S) -> BigString {
-        if S.self == String.self {
-            return BigString(_identityCast(elements, to: String.self))
+        if let elements = _specializingCast(elements, to: String.self) {
+            return BigString(elements)
         }
-        if S.self == Substring.self {
-            return BigString(_identityCast(elements, to: Substring.self))
+        if let elements = _specializingCast(elements, to: Substring.self) {
+            return BigString(elements)
         }
-        if S.self == AttributedString.CharacterView.self {
-            let view = _identityCast(elements, to: AttributedString.CharacterView.self)
-            return BigString(view._characters)
+        if let elements = _specializingCast(elements, to: AttributedString.CharacterView.self) {
+            return BigString(elements._characters)
         }
-        if S.self == Slice<AttributedString.CharacterView>.self {
-            let view = _identityCast(elements, to: Slice<AttributedString.CharacterView>.self)
-            return BigString(view._characters)
+        if let elements = _specializingCast(
+            elements, to: Slice<AttributedString.CharacterView>.self
+        ) {
+            return BigString(elements._characters)
         }
         return BigString(elements)
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -51,7 +51,7 @@ extension AttributedString {
             self = AttributedString(s)
         } else {
             // !!!: We don't expect or want this to happen.
-            let substring = AttributedSubstring(s.__guts, s._bounds)
+            let substring = AttributedSubstring(s.__guts, in: s._bounds)
             self = AttributedString(substring)
         }
     }
@@ -281,7 +281,8 @@ extension AttributedString {
 
     public mutating func replaceSubrange<R: RangeExpression, S: AttributedStringProtocol>(_ range: R, with s: S) where R.Bound == Index {
         ensureUniqueReference()
-        _guts.replaceSubrange(range.relative(to: characters), with: s)
+        // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
+        _guts.replaceSubrange(range.relative(to: unicodeScalars), with: s)
     }
 }
 
@@ -312,13 +313,15 @@ extension AttributedString {
 // MARK: Substring access
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    public subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == Index {
+    public subscript(bounds: some RangeExpression<Index>) -> AttributedSubstring {
         get {
-            return AttributedSubstring(_guts, bounds.relative(to: unicodeScalars))
+            // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
+            return AttributedSubstring(_guts, in: bounds.relative(to: unicodeScalars))
         }
         _modify {
             ensureUniqueReference()
-            var substr = AttributedSubstring(_guts, bounds.relative(to: unicodeScalars))
+            // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
+            var substr = AttributedSubstring(_guts, in: bounds.relative(to: unicodeScalars))
             let ident = Self._nextModifyIdentity
             substr._identity = ident
             _guts = Guts(string: "", runs: []) // Dummy guts so the substr has (hopefully) the sole reference
@@ -331,6 +334,7 @@ extension AttributedString {
             yield &substr
         }
         set {
+            // FIXME: Why is this allowed if _modify traps on replacement?
             self.replaceSubrange(bounds, with: newValue)
         }
     }

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -80,10 +80,10 @@ public extension AttributedStringProtocol {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
-    internal var __guts : AttributedString.Guts {
-        if let s = self as? AttributedString {
+    internal var __guts: AttributedString.Guts {
+        if let s = _specializingCast(self, to: AttributedString.self) {
             return s._guts
-        } else if let s = self as? AttributedSubstring {
+        } else if let s = _specializingCast(self, to: AttributedSubstring.self) {
             return s._guts
         } else {
             return self.characters._guts

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -95,11 +95,11 @@ extension AttributedStringProtocol {
     }
 
     internal var _bounds: Range<AttributedString.Index> {
-        startIndex ..< endIndex
+        Range(uncheckedBounds: (startIndex, endIndex))
     }
 
     internal var _stringBounds: Range<BigString.Index> {
-        startIndex._value ..< endIndex._value
+        Range(uncheckedBounds: (startIndex._value, endIndex._value))
     }
 
     internal var _characters: BigSubstring {
@@ -111,8 +111,12 @@ extension AttributedString {
     internal var _baseString: BigString {
         _guts.string
     }
+    
+    internal var _bounds: Range<AttributedString.Index> {
+        Range(uncheckedBounds: (startIndex, endIndex))
+    }
 
-    internal var _bounds: Range<BigString.Index> {
+    internal var _stringBounds: Range<BigString.Index> {
         Range(uncheckedBounds: (_guts.string.startIndex, _guts.string.endIndex))
     }
 }
@@ -121,9 +125,13 @@ extension AttributedSubstring {
     internal var _baseString: BigString {
         _guts.string
     }
+    
+    internal var _bounds: Range<AttributedString.Index> {
+        _range
+    }
 
-    internal var _bounds: Range<BigString.Index> {
-        _range._bstringRange
+    internal var _stringBounds: Range<BigString.Index> {
+        Range(uncheckedBounds: (_range.lowerBound._value, _range.upperBound._value))
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
+++ b/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
@@ -119,4 +119,3 @@ internal func _specializingCast<Input, Output>(_ value: Input, to type: Output.T
     guard Input.self == Output.self else { return nil }
     return _identityCast(value, to: type)
 }
-

--- a/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
+++ b/Sources/FoundationEssentials/AttributedString/Collection Stdlib Defaults.swift
@@ -113,3 +113,10 @@ extension BidirectionalCollection {
     return i
   }
 }
+
+@inline(__always)
+internal func _specializingCast<Input, Output>(_ value: Input, to type: Output.Type) -> Output? {
+    guard Input.self == Output.self else { return nil }
+    return _identityCast(value, to: type)
+}
+

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -25,12 +25,7 @@ extension String {
         self.init(characters._characters)
     }
 
-    #if true // FIXME: Make this public.
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-    internal init(_characters: AttributedString.CharacterView) {
-        self.init(_characters._characters)
-    }
-    #else
+    #if false // FIXME: Make this public.
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     @_alwaysEmitIntoClient
     public init(_ characters: AttributedString.CharacterView) {
@@ -42,13 +37,13 @@ extension String {
         // the original AttributedString release.
         self.init(characters[...])
     }
+    #endif
 
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     @usableFromInline
     internal init(_characters: AttributedString.CharacterView) {
         self.init(_characters._characters)
     }
-    #endif
 }
 
 #if FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -298,6 +298,18 @@ final class TestAttributedString: XCTestCase {
         b += AttributedString("def", attributes: AttributeContainer().testInt(2))
         b += "ghijkl"
         XCTAssertNotEqual(a, b)
+
+
+        let a1 = AttributedString("Café", attributes: AttributeContainer().testInt(1))
+        let a2 = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(a1, a2)
+
+        let a3 = (AttributedString("Cafe", attributes: AttributeContainer().testInt(1))
+                  + AttributedString("\u{301}", attributes: AttributeContainer().testInt(2)))
+        XCTAssertNotEqual(a1, a3)
+        XCTAssertNotEqual(a2, a3)
+        XCTAssertTrue(a1.characters.elementsEqual(a3.characters))
+        XCTAssertTrue(a2.characters.elementsEqual(a3.characters))
     }
 
     func testAttributedSubstringEquality() {
@@ -1830,7 +1842,17 @@ E {
         XCTAssertEqual(unicode[unicode.index(before: unicode.endIndex)], "\u{301}")
         XCTAssertEqual(unicode[unicode.index(unicode.endIndex, offsetBy: -2)], "e")
     }
-    
+
+    func testCharacterSlicing() {
+        let a: AttributedString = "\u{1f1fa}\u{1f1f8}" // Regional indicators U & S
+        let i = a.unicodeScalars.index(after: a.startIndex)
+        let b = a.characters[..<i]
+        XCTAssertEqual(a.characters.count, 1)
+        XCTAssertEqual(b.startIndex, a.startIndex)
+        XCTAssertEqual(b.endIndex, a.startIndex)
+        XCTAssertEqual(b.count, 0)
+    }
+
     func testUnicodeScalarsSlicing() {
         let attrStr = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
         let range = attrStr.startIndex ..< attrStr.endIndex


### PR DESCRIPTION
This is effectively the same problem as https://github.com/apple/swift/pull/41417, but for `AttributedString` instead of `String`.

Consider the following code:

```swift
import Foundation
let a: AttributedString = "🇺🇸" // U+1F1FA U+1F1F8
let i = a.unicodeScalars.index(after: a.startIndex)
let b = a.characters[..<i]
```

The index `i` falls between character boundaries in the string, and this makes `b` an invalid collection:

```swift
print(b.count) 
// Fatal error: String index is out of bounds
```

The issue is that `AttributedString.CharacterView` shipped with the default `Slice` as its `SubSequence` type, and `Slice` does not expect to deal with unreachable indices.

This is an unintended consequence of SE-0180, which unified the index type for String views, without due consideration to these matters. AttributedString has followed the same design pattern, so it is unfortunately susceptible to the same problems.

One crucial difference here is that unlike String’s views, `AttributedString.CharacterView` (and `AttributedString.UnicodeScalarView`) did not define custom `SubSequence` types — so they are effectively stuck with whatever `Slice` is doing. This prevents us from applying the same fixes as we did for String. https://github.com/apple/swift/pull/65517 is exploring a stdlib fix for this case, but in the meantime, we should clean up index handling in `AttributedString` cases that do not involve `Slice`.

In particular, this patch forcibly rounds indices down to the nearest character/scalar boundary before calling the `Slice` initializer and before applying mutations.
