### PR TITLE
Fixes issue #78: Calling Date.description might result in undefined behaviour

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -249,7 +249,7 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         // This allocates stack space for range of 10^102 years
         // That's more than Date currently supports.
         let bufferSize = 128
-        return withUnsafeTemporaryAllocation(of: CChar.self, capacity: bufferSize) { buffer -> String in
+        return withUnsafeTemporaryAllocation(of: CChar.self, capacity: bufferSize) { buffer in
             guard let ptr = buffer.baseAddress else {
                 return unavailable
             }

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -239,8 +239,21 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
     /// function `description(locale:)`.
     public var description: String {
         // NSDate uses the constant format `uuuu-MM-dd HH:mm:ss '+0000'`
+
+        // Glibc needs a non-standard format option to pad %Y to 4 digits
+#if canImport(Glibc)
+        let format = "%4Y-%m-%d %H:%M:%S +0000"
+#else
         let format = "%Y-%m-%d %H:%M:%S +0000"
+#endif
         let unavailable = "<description unavailable>"
+
+        guard self >= Date.distantPast else {
+            return unavailable
+        }
+        guard self <= Date.distantFuture else {
+            return unavailable
+        }
 
         var info = tm()
         var time = time_t(self.timeIntervalSince1970)

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -250,19 +250,19 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         // That's more than Date currently supports.
         let bufferSize = 128
         return withUnsafeTemporaryAllocation(of: CChar.self, capacity: bufferSize) { buffer -> String in
-           guard let ptr = buffer.baseAddress else {
-              return unavailable
-           }
+            guard let ptr = buffer.baseAddress else {
+                return unavailable
+            }
 
-           guard strftime(ptr, bufferSize, format, &info) != 0 else {
-              return unavailable
-           }
+            guard strftime(ptr, bufferSize, format, &info) != 0 else {
+                return unavailable
+            }
 
-           guard let result = String(validatingUTF8: ptr) else {
-              return unavailable
-           }
+            guard let result = String(validatingUTF8: ptr) else {
+                return unavailable
+            }
 
-           return result
+            return result
         }
     }
 #endif // !FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -71,6 +71,38 @@ final class DateTests : XCTestCase {
         let date2 : Date = .now
         XCTAssertLessThanOrEqual(date1, date2)
     }
+
+    func testDescriptionReferenceDate() {
+        let date = Date(timeIntervalSinceReferenceDate: TimeInterval(0))
+
+        XCTAssertEqual("2001-01-01 00:00:00 +0000", date.description)
+    }
+
+    func testDescription1970() {
+        let date = Date(timeIntervalSince1970: TimeInterval(0))
+
+        XCTAssertEqual("1970-01-01 00:00:00 +0000", date.description)
+    }
+
+    func testDescriptionDistantPast() {
+        XCTAssertEqual("0000-12-30 00:00:00 +0000", Date.distantPast.description)
+    }
+
+    func testDescriptionDistantFuture() {
+        XCTAssertEqual("4001-01-01 00:00:00 +0000", Date.distantFuture.description)
+    }
+
+    func testDescriptionBeyondDistantPast() {
+        let date = Date.distantPast.addingTimeInterval(TimeInterval(-1))
+
+        XCTAssertEqual("<description unavailable>", date.description)
+    }
+
+    func testDescriptionBeyondDistantFuture() {
+        let date = Date.distantFuture.addingTimeInterval(TimeInterval(1))
+
+        XCTAssertEqual("<description unavailable>", date.description)
+    }
 }
 
 // MARK: - Bridging


### PR DESCRIPTION
Calling Date.description might result in undefined behaviour

The buffer used was too small in some cases.
Fixed by allocating (more than) enough space on the stack.