### PR TITLE
Fix Memory Binding Issues

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -321,11 +321,13 @@ internal final class __DataStorage : @unchecked Sendable {
 
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
+        // index must have already been validated by the caller
         return _bytes!.load(fromByteOffset: index - _offset, as: UInt8.self)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
     func set(_ index: Int, to value: UInt8) {
+        // index must have already been validated by the caller
         ensureUniqueBufferReference()
         _bytes!.storeBytes(of: value, toByteOffset: index - _offset, as: UInt8.self)
     }

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -319,13 +319,13 @@ internal final class __DataStorage : @unchecked Sendable {
 
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
-        return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+        return _bytes!.load(fromByteOffset: index - _offset, as: UInt8.self)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
     func set(_ index: Int, to value: UInt8) {
         ensureUniqueBufferReference()
-        _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee = value
+        _bytes!.storeBytes(of: value, toByteOffset: index - _offset, as: UInt8.self)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2398,8 +2398,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             }
 
             return Swift.withUnsafeMutableBytes(of: &_buffer) {
-                let ptr = $0.bindMemory(to: UInt8.self)
-                return ptr[bufferIdx]
+                $0.load(fromByteOffset: bufferIdx, as: UInt8.self)
             }
         }
     }

--- a/Sources/FoundationEssentials/String/String+Essentials.swift
+++ b/Sources/FoundationEssentials/String/String+Essentials.swift
@@ -104,7 +104,7 @@ extension String {
     public init?(data: __shared Data, encoding: Encoding) {
         if encoding == .utf8 || encoding == .ascii,
         let str = data.withUnsafeBytes({
-            String._tryFromUTF8($0.bindMemory(to: UInt8.self))
+            $0.withMemoryRebound(to: UInt8.self, String._tryFromUTF8(_:))
         }) {
             if encoding == .utf8 || (encoding == .ascii && str._guts._isContiguousASCII) {
                 self = str


### PR DESCRIPTION
This PR updates memory binding call sites for correctness in the wake of SE-0333, which made withMemoryRebound available for raw memory buffers.

Addresses https://github.com/apple/swift-foundation/issues/98 (rdar://108960577)