### PR TITLE
Top Level Coder Support for `CodableWithConfiguration`

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -354,7 +354,7 @@ open class JSONDecoder {
     }
     
     @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-    open func decode<T: DecodableWithConfiguration, C : DecodingConfigurationProviding>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T.DecodingConfiguration == C.DecodingConfiguration {
+    open func decode<T, C>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T : DecodableWithConfiguration, C : DecodingConfigurationProviding, T.DecodingConfiguration == C.DecodingConfiguration {
         try decode(type, from: data, configuration: C.decodingConfiguration)
     }
     

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -346,12 +346,14 @@ open class JSONDecoder {
         }, from: data)
     }
     
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     open func decode<T: DecodableWithConfiguration>(_ type: T.Type, from data: Data, configuration: T.DecodingConfiguration) throws -> T {
         try _decode({
             try $0.unwrap($1, as: type, configuration: configuration, for: .root, _JSONKey?.none)
         }, from: data)
     }
     
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     open func decode<T: DecodableWithConfiguration, C : DecodingConfigurationProviding>(_ type: T.Type, from data: Data, configuration: C.Type) throws -> T where T.DecodingConfiguration == C.DecodingConfiguration {
         try decode(type, from: data, configuration: C.decodingConfiguration)
     }

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -356,12 +356,14 @@ open class JSONEncoder {
         }, value: value)
     }
     
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     open func encode<T : EncodableWithConfiguration>(_ value: T, configuration: T.EncodingConfiguration) throws -> Data {
         try _encode({
             try $0.wrapGeneric(value, configuration: configuration, for: .root)
         }, value: value)
     }
     
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     open func encode<T : EncodableWithConfiguration, C : EncodingConfigurationProviding>(_ value: T, configuration: C.Type) throws -> Data where T.EncodingConfiguration == C.EncodingConfiguration {
         try encode(value, configuration: C.encodingConfiguration)
     }

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -364,7 +364,7 @@ open class JSONEncoder {
     }
     
     @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-    open func encode<T : EncodableWithConfiguration, C : EncodingConfigurationProviding>(_ value: T, configuration: C.Type) throws -> Data where T.EncodingConfiguration == C.EncodingConfiguration {
+    open func encode<T, C>(_ value: T, configuration: C.Type) throws -> Data where T : EncodableWithConfiguration, C : EncodingConfigurationProviding, T.EncodingConfiguration == C.EncodingConfiguration {
         try encode(value, configuration: C.encodingConfiguration)
     }
     

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -76,6 +76,17 @@ public typealias EncodableAttributedStringKey = Foundation.EncodableAttributedSt
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias DecodableAttributedStringKey = Foundation.DecodableAttributedStringKey
 
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias CodableWithConfiguration = Foundation.CodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias EncodableWithConfiguration = Foundation.EncodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias DecodableWithConfiguration = Foundation.DecodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias EncodingConfigurationProviding = Foundation.EncodingConfigurationProviding
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias DecodingConfigurationProviding = Foundation.DecodingConfigurationProviding
+
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public typealias Predicate = Foundation.Predicate
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
@@ -156,6 +167,17 @@ public typealias CodableAttributedStringKey = FoundationEssentials.CodableAttrib
 public typealias EncodableAttributedStringKey = FoundationEssentials.EncodableAttributedStringKey
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public typealias DecodableAttributedStringKey = FoundationEssentials.DecodableAttributedStringKey
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias CodableWithConfiguration = FoundationEssentials.CodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias EncodableWithConfiguration = FoundationEssentials.EncodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias DecodableWithConfiguration = FoundationEssentials.DecodableWithConfiguration
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias EncodingConfigurationProviding = FoundationEssentials.EncodingConfigurationProviding
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias DecodingConfigurationProviding = FoundationEssentials.DecodingConfigurationProviding
 
 public typealias Calendar = FoundationInternationalization.Calendar
 public typealias TimeZone = FoundationInternationalization.TimeZone

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -108,6 +108,7 @@ final class JSONEncoderTests : XCTestCase {
         XCTAssertEqual(result2, "[]")
     }
     
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func testEncodingTopLevelWithConfiguration() throws {
         // CodableTypeWithConfiguration is a struct that conforms to CodableWithConfiguration
         let value = CodableTypeWithConfiguration.testValue

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -107,6 +107,18 @@ final class JSONEncoderTests : XCTestCase {
         let result2 = String(data: try! JSONEncoder().encode(b), encoding: String._Encoding.utf8)
         XCTAssertEqual(result2, "[]")
     }
+    
+    func testEncodingTopLevelWithConfiguration() throws {
+        // CodableTypeWithConfiguration is a struct that conforms to CodableWithConfiguration
+        let value = CodableTypeWithConfiguration.testValue
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        var decoded = try decoder.decode(CodableTypeWithConfiguration.self, from: try encoder.encode(value, configuration: .init(1)), configuration: .init(1))
+        XCTAssertEqual(decoded, value)
+        decoded = try decoder.decode(CodableTypeWithConfiguration.self, from: try encoder.encode(value, configuration: CodableTypeWithConfiguration.ConfigProviding.self), configuration: CodableTypeWithConfiguration.ConfigProviding.self)
+        XCTAssertEqual(decoded, value)
+    }
 
 #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
     func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() {
@@ -3240,6 +3252,42 @@ private struct NestedContainersTestType : Encodable {
       expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 1)], "New third-level unkeyed container had unexpected codingPath.")
     }
   }
+}
+
+private struct CodableTypeWithConfiguration : CodableWithConfiguration, Equatable {
+    struct Config {
+        let num: Int
+        
+        init(_ num: Int) {
+            self.num = num
+        }
+    }
+    
+    struct ConfigProviding : EncodingConfigurationProviding, DecodingConfigurationProviding {
+        static var encodingConfiguration: Config { Config(2) }
+        static var decodingConfiguration: Config { Config(2) }
+    }
+    
+    typealias EncodingConfiguration = Config
+    typealias DecodingConfiguration = Config
+    
+    static let testValue = Self(3)
+    
+    let num: Int
+    
+    init(_ num: Int) {
+        self.num = num
+    }
+    
+    func encode(to encoder: Encoder, configuration: Config) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(num + configuration.num)
+    }
+    
+    init(from decoder: Decoder, configuration: Config) throws {
+        let container = try decoder.singleValueContainer()
+        num = try container.decode(Int.self) - configuration.num
+    }
 }
 
 // MARK: - Helper Types


### PR DESCRIPTION
This adds support for `JSONEncoder` and `JSONDecoder` to directly encode/decode a `CodableWithConfiguration` type by providing a configuration directly or by providing an appropriate configuration-providing type