### PR TITLE
Replace `BufferViewIndex<Element>` with `Index` in BufferView.

### DIFF
--- a/Sources/FoundationEssentials/JSON/BufferView.swift
+++ b/Sources/FoundationEssentials/JSON/BufferView.swift
@@ -178,12 +178,12 @@ extension BufferView:
     }
 
     @inline(__always)
-    func distance(from start: BufferViewIndex<Element>, to end: BufferViewIndex<Element>) -> Int {
+    func distance(from start: Index, to end: Index) -> Int {
         start.distance(to: end)
     }
 
     @inline(__always)
-    subscript(position: BufferViewIndex<Element>) -> Element {
+    subscript(position: Index) -> Element {
         get {
             _checkBounds(position)
             return self[unchecked: position]
@@ -191,7 +191,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(unchecked position: BufferViewIndex<Element>) -> Element {
+    subscript(unchecked position: Index) -> Element {
         get {
             if _isPOD(Element.self) {
                 return position._rawValue.loadUnaligned(as: Element.self)
@@ -202,7 +202,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(bounds: Range<BufferViewIndex<Element>>) -> Self {
+    subscript(bounds: Range<Index>) -> Self {
         get {
             _checkBounds(bounds)
             return self[unchecked: bounds]
@@ -210,7 +210,7 @@ extension BufferView:
     }
 
     @inline(__always)
-    subscript(unchecked bounds: Range<BufferViewIndex<Element>>) -> Self {
+    subscript(unchecked bounds: Range<Index>) -> Self {
         get { BufferView(start: bounds.lowerBound, count: bounds.count) }
     }
 

--- a/Sources/FoundationEssentials/JSON/BufferView.swift
+++ b/Sources/FoundationEssentials/JSON/BufferView.swift
@@ -14,12 +14,14 @@
 // contains initialized `Element` instances.
 
 internal struct BufferView<Element> {
-    let start: BufferViewIndex<Element>
+    typealias Index = BufferViewIndex<Element>
+
+    let start: Index
     let count: Int
 
     private var baseAddress: UnsafeRawPointer { start._rawValue }
 
-    init(start index: BufferViewIndex<Element>, count: Int) {
+    init(start index: Index, count: Int) {
         precondition(count >= 0, "Count must not be negative")
         if !_isPOD(Element.self) {
             precondition(
@@ -100,7 +102,8 @@ extension BufferView:
     RandomAccessCollection {
 
     typealias Element = Element
-    typealias Index = BufferViewIndex<Element>
+    // Index is already defined
+    // typealias Index = BufferViewIndex<Element>
     typealias SubSequence = Self
 
     @inline(__always)
@@ -379,7 +382,7 @@ extension BufferView {
         return BufferView(start: start, count: nc)
     }
 
-    func prefix(upTo index: BufferViewIndex<Element>) -> BufferView {
+    func prefix(upTo index: Index) -> BufferView {
         _checkBounds(Range(uncheckedBounds: (startIndex, index)))
         return BufferView(
             start: start,
@@ -387,7 +390,7 @@ extension BufferView {
         )
     }
 
-    func suffix(from index: BufferViewIndex<Element>) -> BufferView {
+    func suffix(from index: Index) -> BufferView {
         _checkBounds(Range(uncheckedBounds: (index, endIndex)))
         return BufferView(
             start: index,


### PR DESCRIPTION
This PR replaces `BufferViewIndex<Element>` with `Index` that is typealias of Collection in BufferView.