### PR TITLE
LockedState: Fix lock not being released when body throws

### DIFF
--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -94,12 +94,9 @@ internal struct LockedState<State> {
 
     // Ensures the managed state outlives the locked `body`.
     func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
-        try _buffer.withUnsafeMutablePointers { state, lock in
-            _Lock.lock(lock)
-            return try withExtendedLifetime(state.pointee) {
-                let result = try body(&state.pointee)
-                _Lock.unlock(lock)
-                return result
+        try withLockUnchecked { state in
+            try withExtendedLifetime(state) {
+                try body(&state)
             }
         }
     }

--- a/Sources/FoundationInternationalization/LockedState.swift
+++ b/Sources/FoundationInternationalization/LockedState.swift
@@ -94,12 +94,9 @@ internal struct LockedState<State> {
 
     // Ensures the managed state outlives the locked `body`.
     func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
-        try _buffer.withUnsafeMutablePointers { state, lock in
-            _Lock.lock(lock)
-            return try withExtendedLifetime(state.pointee) {
-                let result = try body(&state.pointee)
-                _Lock.unlock(lock)
-                return result
+        try withLockUnchecked { state in
+            try withExtendedLifetime(state) {
+                try body(&state)
             }
         }
     }

--- a/Tests/FoundationEssentialsTests/LockedStateTests.swift
+++ b/Tests/FoundationEssentialsTests/LockedStateTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif
+
+final class LockedStateTests : XCTestCase {
+    final class TestObject {}
+    struct TestError: Error {}
+
+    func testWithLockDoesNotExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLock { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNil(oldState, "State object lifetime was extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanDoesExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLockExtendingLifetimeOfState { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNotNil(oldState, "State object lifetime was not extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanReleasesLockWhenBodyThrows() {
+        let lockedState = LockedState(initialState: TestObject())
+
+        XCTAssertThrowsError(
+            try lockedState.withLockExtendingLifetimeOfState { _ in
+                throw TestError()
+            },
+            "The body was expected to throw an error, but it did not."
+        )
+
+        // ⚠️ This test fails by crashing. If the lock was not properly released by the
+        // `withLockExtendingLifetimeOfState()` call above, the following `withLock()`
+        // call will abort the program.
+
+        lockedState.withLock { _ in
+            // PASS
+        }
+    }
+}

--- a/Tests/FoundationInternationalizationTests/LockedStateTests.swift
+++ b/Tests/FoundationInternationalizationTests/LockedStateTests.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#elseif canImport(FoundationInternationalization)
+@testable import FoundationInternationalization
+#endif // FOUNDATION_FRAMEWORK
+
+final class LockedStateTests : XCTestCase {
+    final class TestObject {}
+    struct TestError: Error {}
+
+    func testWithLockDoesNotExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLock { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNil(oldState, "State object lifetime was extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanDoesExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLockExtendingLifetimeOfState { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNotNil(oldState, "State object lifetime was not extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanReleasesLockWhenBodyThrows() {
+        let lockedState = LockedState(initialState: TestObject())
+
+        XCTAssertThrowsError(
+            try lockedState.withLockExtendingLifetimeOfState { _ in
+                throw TestError()
+            },
+            "The body was expected to throw an error, but it did not."
+        )
+
+        // ⚠️ This test fails by crashing. If the lock was not properly released by the
+        // `withLockExtendingLifetimeOfState()` call above, the following `withLock()`
+        // call will abort the program.
+
+        lockedState.withLock { _ in
+            // PASS
+        }
+    }
+}


### PR DESCRIPTION
#### Summary

Currently, if the `body` closure passed to `withLockExtendingLifespanOfState(_:)` throws an error, the lock is not released. This PR fixes that.

#### Change

My fix was to switch the implementation of `withLockExtendingLifespanOfState(_:)` to delegate to `withLockUnchecked(_:)`, which does properly unlock if its body throws an error.

#### Verification

Added unit tests to verify this change, and backfilled tests that verify the lifespan-extending behavior of this method.