### PR TITLE
Use `__owned` parameter modifier

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -902,8 +902,9 @@ extension JSON5Scanner {
     }
 
     static func _slowpath_stringValue(
-        from jsonBytes: BufferView<UInt8>, appendingTo output: consuming String, fullSource: BufferView<UInt8>
+        from jsonBytes: BufferView<UInt8>, appendingTo output: __owned String, fullSource: BufferView<UInt8>
     ) throws -> String {
+        var output = consume output
         // A reasonable guess as to the resulting capacity of the string is 1/4 the length of the remaining buffer. With this scheme, input full of 4 byte UTF-8 sequences won't waste a bunch of extra capacity and predominantly 1 byte UTF-8 sequences will only need to resize the buffer once or twice.
         output.reserveCapacity(output.underestimatedCount + jsonBytes.count/4)
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -907,8 +907,9 @@ extension JSONScanner {
     }
 
     static func _slowpath_stringValue(
-        from jsonBytes: BufferView<UInt8>, appendingTo output: consuming String, fullSource: BufferView<UInt8>
+        from jsonBytes: BufferView<UInt8>, appendingTo output: __owned String, fullSource: BufferView<UInt8>
     ) throws -> String {
+        var output = consume output
         // A reasonable guess as to the resulting capacity of the string is 1/4 the length of the remaining buffer. With this scheme, input full of 4 byte UTF-8 sequences won't waste a bunch of extra capacity and predominantly 1 byte UTF-8 sequences will only need to resize the buffer once or twice.
         output.reserveCapacity(output.underestimatedCount + jsonBytes.count/4)
 


### PR DESCRIPTION
Using the `consuming` parameter modifier for copyable (aka normal) types is deferred from swift 5.9. This uses the older `__owned` modifier instead, and consumes the parameter into a `var` as the first statement. This should generate the same code. This fixes a compilation error in `swift-foundation`'s Linux CI.