### PR TITLE
Revert "Move count among the Collection conformance in BufferView"

### DIFF
--- a/Sources/FoundationEssentials/JSON/BufferView.swift
+++ b/Sources/FoundationEssentials/JSON/BufferView.swift
@@ -15,7 +15,7 @@
 
 internal struct BufferView<Element> {
     let start: Index
-    let end: Index
+    let count: Int
 
     private var baseAddress: UnsafeRawPointer { start._rawValue }
 
@@ -28,7 +28,7 @@ internal struct BufferView<Element> {
             )
         }
         self.start = index
-        self.end = index.advanced(by: count)
+        self.count = count
     }
 
     init(baseAddress: UnsafeRawPointer, count: Int) {
@@ -107,10 +107,7 @@ extension BufferView:
     var startIndex: Index { start }
 
     @inline(__always)
-    var endIndex: Index { end }
-
-    @inline(__always)
-    var count: Int { start.distance(to: end) }
+    var endIndex: Index { start.advanced(by: count) }
 
     @inline(__always)
     var indices: Range<Index> {


### PR DESCRIPTION
This reverts a change in the internal representation of `BufferView` which potentially has significant performance consequences. We might want to make this change, but we need to carefully evaluate its performance consequences first.

This reverts commit 6900c61344048242878ccbb9b79b0a47b2b75e80.