### PR TITLE
Update README for toolchain requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Later this year, the porting effort will continue. It will bring high quality Sw
 
 ## Building and Testing
 
-Building the Foundation package requires the under-development [Swift 5.9 toolchain](https://www.swift.org/download/#swift-59-development) on macOS and Linux.
+Building the Foundation package requires the under-development [Swift 5.9 toolchain](https://www.swift.org/download/#swift-59-development) on or later than May 3rd 2023 (607f4eb), on macOS and Linux. 
 ### macOS
 
 macOS Ventura 13.3.1 is the minimum supported version.


### PR DESCRIPTION
The `consume` keyword requires `-enable-experimental-move-only` frontend flag, which was only enabled in recent snapshots. Specify a snapshot version that we know works in README.