### PR TITLE
Correct implementation of `withLockExtendingLifetimeOfState`

### DIFF
--- a/Sources/FoundationInternals/LockedState.swift
+++ b/Sources/FoundationInternals/LockedState.swift
@@ -92,11 +92,13 @@ public struct LockedState<State> {
         }
     }
 
-    // Ensures the managed state outlives the locked `body`.
+    // Ensures the managed state outlives the locked scope.
     public func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
-        try withLockUnchecked { state in
-            try withExtendedLifetime(state) {
-                try body(&state)
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            return try withExtendedLifetime(state.pointee) {
+                defer { _Lock.unlock(lock) }
+                return try body(&state.pointee)
             }
         }
     }


### PR DESCRIPTION
The method description was wrong: the `State` parameter must outlive the locked scope, not just the call to the closure. Thanks to @phausler for the pointer.

Addresses rdar://109056170