### PR TITLE
Remove randomness from a test

### DIFF
--- a/Tests/FoundationEssentialsTests/BufferViewTests.swift
+++ b/Tests/FoundationEssentialsTests/BufferViewTests.swift
@@ -167,12 +167,7 @@ final class BufferViewTests: XCTestCase {
 
     func testElementsEqual() {
         let capacity = 4
-        let a = [Int](unsafeUninitializedCapacity: capacity) {
-            for i in $0.indices {
-                $0.initializeElement(at: i, to: .random(in: 0..<10))
-            }
-            $1 = $0.count
-        }
+        let a = Array(0..<capacity)
         a.withUnsafeBufferPointer {
             let v1 = BufferView(unsafeBufferPointer: $0)!
 


### PR DESCRIPTION
This test contained randomness which led to a 0.1% probability of spurious failure. I don’t know why I thought it was a good idea. At least 1 CI run errored because of it.