### PR TITLE
Replace @_implementationOnly imports with package imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
 
         // _CShims (Internal)
         .target(name: "_CShims"),
+        
         // TestSupport (Internal)
         .target(name: "TestSupport", dependencies: [
             "FoundationEssentials",
@@ -43,7 +44,10 @@ let package = Package(
             "_CShims",
             .product(name: "_RopeModule", package: "swift-collections"),
           ],
-          swiftSettings: [.enableExperimentalFeature("VariadicGenerics")]
+          swiftSettings: [
+            .enableExperimentalFeature("VariadicGenerics"),
+            .enableExperimentalFeature("AccessLevelOnImport")
+          ]
         ),
         .testTarget(name: "FoundationEssentialsTests", dependencies: [
             "TestSupport",
@@ -51,11 +55,17 @@ let package = Package(
         ]),
 
         // FoundationInternationalization
-        .target(name: "FoundationInternationalization", dependencies: [
-            .target(name: "FoundationEssentials"),
-            .target(name: "_CShims"),
-            .product(name: "FoundationICU", package: "swift-foundation-icu")
-        ]),
+        .target(
+            name: "FoundationInternationalization",
+            dependencies: [
+                .target(name: "FoundationEssentials"),
+                .target(name: "_CShims"),
+                .product(name: "FoundationICU", package: "swift-foundation-icu")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("AccessLevelOnImport")
+            ]
+        ),
         .testTarget(name: "FoundationInternationalizationTests", dependencies: [
             "TestSupport",
             "FoundationInternationalization"

--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -14,7 +14,7 @@
 @_implementationOnly import ReflectionInternal
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 // MARK: AttributedStringKey API

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 // MARK: AttributedStringKey

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -13,7 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -16,7 +16,7 @@ import Darwin
 @_implementationOnly import os
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 extension String {

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -16,7 +16,7 @@
 @_implementationOnly import Foundation_Private.NSAttributedString
 @_implementationOnly @_spi(Unstable) import CollectionsInternal
 #else
-import _RopeModule
+package import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/BuiltInUnicodeScalarSet.swift
@@ -9,7 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import _CShims
+#else
+package import _CShims
+#endif
 
 // Native implementation of CFCharacterSet.
 // Represents sets of unicode scalars of those whose bitmap data we own.

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -16,7 +16,12 @@ import Darwin
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import _CShims
+#else
+package import _CShims
+#endif
+
 
 internal struct JSON5Scanner {
     let options: Options

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -16,7 +16,11 @@ import Darwin
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import _CShims
+#else
+package import _CShims
+#endif
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -59,7 +59,11 @@ import Darwin
 import Glibc
 #endif // canImport(Darwin)
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import _CShims
+#else
+package import _CShims
+#endif
 
 internal class JSONMap {
     enum TypeDescriptor : Int {

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -9,7 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import _CShims // uuid.h
+#else
+package import _CShims // uuid.h
+#endif
 
 public typealias uuid_t = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 public typealias uuid_string_t = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)

--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -18,7 +18,11 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 /**
  `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.

--- a/Sources/FoundationInternationalization/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_Cache.swift
@@ -10,11 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import FoundationICU
 
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import _ForSwiftFoundation
+@_implementationOnly import FoundationICU
 import CoreFoundation
+#else
+package import FoundationICU
 #endif
 
 /// Singleton which listens for notifications about preference changes for Calendar and holds cached singletons for the current locale, calendar, and time zone.

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -18,7 +18,11 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 internal final class _Calendar: Equatable, @unchecked Sendable {
     let lock: LockedState<Void>

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -13,7 +13,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 #if canImport(Glibc)
 import Glibc

--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ByteCountFormatStyle: FormatStyle, Sendable {

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 typealias CalendarComponentAndValue = (component: Calendar.Component, value: Int)
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 typealias UChar = UInt16
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 final class ICUDateIntervalFormatter : Hashable {
     let locale: Locale

--- a/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICURelativeDateFormatter {

--- a/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICUListFormatter {

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICULegacyNumberFormatter {

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 typealias ICUNumberFormatterSkeleton = String
 

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberAttributedFormat.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberAttributedFormat.swift
@@ -13,8 +13,11 @@
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #endif
-
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension AttributeScopes.FoundationAttributes.NumberFormatAttributes.SymbolAttribute.Symbol {
     init?(unumberFormatField: UNumberFormatFields) {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -14,7 +14,11 @@
 import FoundationEssentials
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {

--- a/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension ICU {
     final class CaseMap : @unchecked Sendable {

--- a/Sources/FoundationInternationalization/ICU/ICU+Enumeration.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enumeration.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension ICU {
 

--- a/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension UBool {
     static let `true` = UBool(1)

--- a/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension ICU {
     final class FieldPositer {

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 enum ICU { }
 

--- a/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
+++ b/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 final class ICUPatternGenerator {
 

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -14,7 +14,11 @@
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension Locale {
 

--- a/Sources/FoundationInternationalization/Locale/Locale+Language.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Language.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 extension Locale {
 

--- a/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
@@ -15,10 +15,9 @@
 import CoreFoundation
 @_implementationOnly import CoreFoundation_Private.CFNotificationCenter
 @_implementationOnly import os
-#endif
-
-#if canImport(_CShims)
 @_implementationOnly import _CShims
+#else
+package import _CShims
 #endif
 
 /// Singleton which listens for notifications about preference changes for Locale and holds cached singletons.

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -19,9 +19,10 @@ import FoundationEssentials
 @_implementationOnly import _ForSwiftFoundation
 // For Logger
 @_implementationOnly import os
-#endif
-
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 let MAX_ICU_NAME_SIZE: Int32 = 1024
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -18,7 +18,11 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
 
 let MIN_TIMEZONE_UDATE = -2177452800000.0  // 1901-01-01 00:00:00 +0000
 let MAX_TIMEZONE_UDATE = 4133980800000.0  // 2101-01-01 00:00:00 +0000

--- a/Sources/_FoundationInternals/LockedState.swift
+++ b/Sources/_FoundationInternals/LockedState.swift
@@ -11,7 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
+#if FOUNDATION_FRAMEWORK
 @_implementationOnly import os
+#else
+package import os
+#endif
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -29,7 +29,7 @@ import TestSupport
 #endif
 
 #if canImport(_CShims)
-@_implementationOnly import _CShims
+import _CShims
 #endif
 
 // MARK: - Test Suite


### PR DESCRIPTION
This change adjusts our imports to use `package import` in FoundationPreview, while still using the stricter but non-resilient-module-incompatible `@_implementationOnly import` in `FOUNDATION_FRAMEWORK` sections. Using `@_implementationOnly` in a non-resilient module like `FoundationEssentials` happens to work in some cases, but in others it produces miscompiles that have proven to be quite challenging to diagnose. We already use `package import` for the `FoundationInternals` module, and this change expands that usage to other internal imports like `FoundationICU`, `os`, `_RopeModule`, and `_CShims`.

Resolves rdar://105902981