### PR TITLE
Update `Date.description` tests for Foundation Framework

### DIFF
--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -85,7 +85,11 @@ final class DateTests : XCTestCase {
     }
 
     func testDescriptionDistantPast() {
+#if FOUNDATION_FRAMEWORK
+        XCTAssertEqual("0001-01-01 00:00:00 +0000", Date.distantPast.description)
+#else
         XCTAssertEqual("0000-12-30 00:00:00 +0000", Date.distantPast.description)
+#endif
     }
 
     func testDescriptionDistantFuture() {
@@ -94,14 +98,20 @@ final class DateTests : XCTestCase {
 
     func testDescriptionBeyondDistantPast() {
         let date = Date.distantPast.addingTimeInterval(TimeInterval(-1))
-
+#if FOUNDATION_FRAMEWORK
+        XCTAssertEqual("0000-12-31 23:59:59 +0000", date.description)
+#else
         XCTAssertEqual("<description unavailable>", date.description)
+#endif
     }
 
     func testDescriptionBeyondDistantFuture() {
         let date = Date.distantFuture.addingTimeInterval(TimeInterval(1))
-
+#if FOUNDATION_FRAMEWORK
+        XCTAssertEqual("4001-01-01 00:00:01 +0000", date.description)
+#else
         XCTAssertEqual("<description unavailable>", date.description)
+#endif
     }
 }
 


### PR DESCRIPTION
We use ICU for date calculation for Foundation Framework, and `gmtime` otherwise. It appears that the result starts to diverge at some time in Gregorian year 1582, which happens to be the year when Gregorian calendar went into effect. That in turn results in disparate representations of `Date` before year 1582.

It's not clear how `tm` and `strtime` handles before-Gregorian dates since it's entirely in the implementation details. This PR simply update test expectations accordingly.
