### PR TITLE
Upgrade swift-foundation-icu to 0.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(
           url: "https://github.com/apple/swift-collections",
           revision: "2ca40e2a653e5e04a1c5468a35fc7494ef6db1d3"), // on release/1.1
-        .package(url: "https://github.com/apple/swift-foundation-icu", exact: "0.0.1")
+        .package(url: "https://github.com/apple/swift-foundation-icu", exact: "0.0.2")
     ],
     targets: [
         // Foundation (umbrella)


### PR DESCRIPTION
[`swift-foundation-icu 0.0.2`](https://github.com/apple/swift-foundation-icu/releases/tag/0.0.2) contains important fixes for building on iOS. Adopting `swift-foundation-icu 0.0.2` allows  `FoundationPreview` to be built and tested on iOS simulators.