### PR TITLE
Revert "Create FoundationInternals, an internal module to host shared files used by FoundationInternationalization and FoundationEssentials (#101)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,14 +30,6 @@ let package = Package(
 
         // _CShims (Internal)
         .target(name: "_CShims"),
-
-        // FoundationInternals (Internal)
-        .target(name: "FoundationInternals"),
-        .testTarget(name: "FoundationInternalsTests", dependencies: [
-            "FoundationInternals",
-            "TestSupport",
-        ]),
-
         // TestSupport (Internal)
         .target(name: "TestSupport", dependencies: [
             "FoundationEssentials",
@@ -46,16 +38,12 @@ let package = Package(
 
         // FoundationEssentials
         .target(
-            name: "FoundationEssentials",
-            dependencies: [
-                "_CShims",
-                "FoundationInternals",
-                .product(name: "_RopeModule", package: "swift-collections"),
-            ],
-            swiftSettings: [
-                .enableExperimentalFeature("VariadicGenerics"),
-                .enableExperimentalFeature("AccessLevelOnImport"),
-            ]
+          name: "FoundationEssentials",
+          dependencies: [
+            "_CShims",
+            .product(name: "_RopeModule", package: "swift-collections"),
+          ],
+          swiftSettings: [.enableExperimentalFeature("VariadicGenerics")]
         ),
         .testTarget(name: "FoundationEssentialsTests", dependencies: [
             "TestSupport",
@@ -63,19 +51,11 @@ let package = Package(
         ]),
 
         // FoundationInternationalization
-        .target(
-            name: "FoundationInternationalization",
-            dependencies: [
-                .target(name: "FoundationEssentials"),
-                .target(name: "_CShims"),
-                .target(name: "FoundationInternals"),
-                .product(name: "FoundationICU", package: "swift-foundation-icu"),
-            ],
-            swiftSettings: [
-                .enableExperimentalFeature("AccessLevelOnImport"),
-            ]
-        ),
-
+        .target(name: "FoundationInternationalization", dependencies: [
+            .target(name: "FoundationEssentials"),
+            .target(name: "_CShims"),
+            .product(name: "FoundationICU", package: "swift-foundation-icu")
+        ]),
         .testTarget(name: "FoundationInternationalizationTests", dependencies: [
             "TestSupport",
             "FoundationInternationalization"

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -16,10 +16,6 @@
 import _RopeModule
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
     internal struct _InternalRun : Hashable, Sendable {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -16,10 +16,6 @@
 import _RopeModule
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributedString : Sendable {

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -16,12 +16,7 @@ import Darwin
 import Glibc
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import _CShims
-
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -14,10 +14,6 @@
 // JSON Encoder
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 /// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
 // NOTE: older overlays had Foundation.JSONEncoder as the ObjC name.
 // The two must coexist, so it was renamed. The old name must not be

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -59,10 +59,6 @@ import Darwin
 import Glibc
 #endif // canImport(Darwin)
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import _CShims
 
 internal class JSONMap {

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -16,7 +16,7 @@
 import Glibc
 #endif
 
-public struct LockedState<State> {
+internal struct LockedState<State> {
 
     // Internal implementation for a cheap lock to aid sharing code across platforms
     private struct _Lock {
@@ -71,7 +71,7 @@ public struct LockedState<State> {
 
     private let _buffer: ManagedBuffer<State, _Lock.Primitive>
 
-    public init(initialState: State) {
+    init(initialState: State) {
         _buffer = _Buffer.create(minimumCapacity: 1, makingHeaderWith: { buf in
             buf.withUnsafeMutablePointerToElements {
                 _Lock.initialize($0)
@@ -80,11 +80,11 @@ public struct LockedState<State> {
         })
     }
 
-    public func withLock<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+    func withLock<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
         try withLockUnchecked(body)
     }
     
-    public func withLockUnchecked<T>(_ body: (inout State) throws -> T) rethrows -> T {
+    func withLockUnchecked<T>(_ body: (inout State) throws -> T) rethrows -> T {
         try _buffer.withUnsafeMutablePointers { state, lock in
             _Lock.lock(lock)
             defer { _Lock.unlock(lock) }
@@ -92,36 +92,34 @@ public struct LockedState<State> {
         }
     }
 
-    // Ensures the managed state outlives the locked scope.
-    public func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
-        try _buffer.withUnsafeMutablePointers { state, lock in
-            _Lock.lock(lock)
-            return try withExtendedLifetime(state.pointee) {
-                defer { _Lock.unlock(lock) }
-                return try body(&state.pointee)
+    // Ensures the managed state outlives the locked `body`.
+    func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try withLockUnchecked { state in
+            try withExtendedLifetime(state) {
+                try body(&state)
             }
         }
     }
 }
 
 extension LockedState where State == Void {
-    public init() {
+    init() {
         self.init(initialState: ())
     }
 
-    public func withLock<R: Sendable>(_ body: @Sendable () throws -> R) rethrows -> R {
+    func withLock<R: Sendable>(_ body: @Sendable () throws -> R) rethrows -> R {
         return try withLock { _ in
             try body()
         }
     }
 
-    public func lock() {
+    func lock() {
         _buffer.withUnsafeMutablePointerToElements { lock in
             _Lock.lock(lock)
         }
     }
 
-    public func unlock() {
+    func unlock() {
         _buffer.withUnsafeMutablePointerToElements { lock in
             _Lock.unlock(lock)
         }

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public protocol PredicateExpression<Output> {
     associatedtype Output

--- a/Sources/FoundationEssentials/String/RegexPatternCache.swift
+++ b/Sources/FoundationEssentials/String/RegexPatternCache.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 struct RegexPatternCache: @unchecked Sendable {
     private struct Key : Sendable, Hashable {
         var pattern: String

--- a/Sources/FoundationInternationalization/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_Cache.swift
@@ -17,10 +17,6 @@
 import CoreFoundation
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 /// Singleton which listens for notifications about preference changes for Calendar and holds cached singletons for the current locale, calendar, and time zone.
 struct CalendarCache : Sendable {
     struct State {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -20,10 +20,6 @@ import Glibc
 
 @_implementationOnly import FoundationICU
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 internal final class _Calendar: Equatable, @unchecked Sendable {
     let lock: LockedState<Void>
     let identifier: Calendar.Identifier

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -14,10 +14,6 @@
 import FoundationEssentials
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import FoundationICU
 
 typealias UChar = UInt16

--- a/Sources/FoundationInternationalization/Formatting/FormatterCache.swift
+++ b/Sources/FoundationInternationalization/Formatting/FormatterCache.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 internal struct FormatterCache<Format : Hashable & Sendable, FormattingType: Sendable>: Sendable {
 
     let countLimit = 100

--- a/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import FoundationICU
 
 extension ICU {

--- a/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
@@ -21,10 +21,6 @@ import CoreFoundation
 @_implementationOnly import _CShims
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 /// Singleton which listens for notifications about preference changes for Locale and holds cached singletons.
 struct LocaleCache : Sendable {
     struct State {

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -21,10 +21,6 @@ import FoundationEssentials
 @_implementationOnly import os
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import FoundationICU
 
 let MAX_ICU_NAME_SIZE: Int32 = 1024

--- a/Sources/FoundationInternationalization/LockedState.swift
+++ b/Sources/FoundationInternationalization/LockedState.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+@_implementationOnly import os
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+internal struct LockedState<State> {
+
+    // Internal implementation for a cheap lock to aid sharing code across platforms
+    private struct _Lock {
+#if canImport(Darwin)
+        typealias Primitive = os_unfair_lock
+#elseif canImport(Glibc)
+        typealias Primitive = pthread_mutex_t
+#endif
+
+        typealias PlatformLock = UnsafeMutablePointer<Primitive>
+        var _platformLock: PlatformLock
+
+        fileprivate static func initialize(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            platformLock.initialize(to: os_unfair_lock())
+#elseif canImport(Glibc)
+            pthread_mutex_init(platformLock, nil)
+#endif
+        }
+
+        fileprivate static func deinitialize(_ platformLock: PlatformLock) {
+#if canImport(Glibc)
+            pthread_mutex_destroy(platformLock)
+#endif
+            platformLock.deinitialize(count: 1)
+        }
+
+        static fileprivate func lock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            os_unfair_lock_lock(platformLock)
+#elseif canImport(Glibc)
+            pthread_mutex_lock(platformLock)
+#endif
+        }
+
+        static fileprivate func unlock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+            os_unfair_lock_unlock(platformLock)
+#elseif canImport(Glibc)
+            pthread_mutex_unlock(platformLock)
+#endif
+        }
+    }
+
+    private class _Buffer: ManagedBuffer<State, _Lock.Primitive> {
+        deinit {
+            withUnsafeMutablePointerToElements {
+                _Lock.deinitialize($0)
+            }
+        }
+    }
+
+    private let _buffer: ManagedBuffer<State, _Lock.Primitive>
+
+    init(initialState: State) {
+        _buffer = _Buffer.create(minimumCapacity: 1, makingHeaderWith: { buf in
+            buf.withUnsafeMutablePointerToElements {
+                _Lock.initialize($0)
+            }
+            return initialState
+        })
+    }
+
+    func withLock<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try withLockUnchecked(body)
+    }
+    
+    func withLockUnchecked<T>(_ body: (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            defer { _Lock.unlock(lock) }
+            return try body(&state.pointee)
+        }
+    }
+
+    // Ensures the managed state outlives the locked scope.
+    func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            return try withExtendedLifetime(state.pointee) {
+                defer { _Lock.unlock(lock) }
+                return try body(&state.pointee)
+            }
+        }
+    }
+}
+
+extension LockedState where State == Void {
+    init() {
+        self.init(initialState: ())
+    }
+
+    func withLock<R: Sendable>(_ body: @Sendable () throws -> R) rethrows -> R {
+        return try withLock { _ in
+            try body()
+        }
+    }
+
+    func lock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.lock(lock)
+        }
+    }
+
+    func unlock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.unlock(lock)
+        }
+    }
+}
+
+extension LockedState: @unchecked Sendable where State: Sendable {}

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
@@ -21,10 +21,6 @@ import Glibc
 @_implementationOnly import CoreFoundation_Private.CFNotificationCenter
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 /// Singleton which listens for notifications about preference changes for TimeZone and holds cached values for current, fixed time zones, etc.
 struct TimeZoneCache : Sendable {
     struct State {

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -18,10 +18,6 @@ import FoundationEssentials
 import Glibc
 #endif
 
-#if canImport(FoundationInternals)
-package import FoundationInternals
-#endif
-
 @_implementationOnly import FoundationICU
 
 let MIN_TIMEZONE_UDATE = -2177452800000.0  // 1901-01-01 00:00:00 +0000

--- a/Tests/FoundationEssentialsTests/LockedStateTests.swift
+++ b/Tests/FoundationEssentialsTests/LockedStateTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif
+
+final class LockedStateTests : XCTestCase {
+    final class TestObject {}
+    struct TestError: Error {}
+
+    func testWithLockDoesNotExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLock { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNil(oldState, "State object lifetime was extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanDoesExtendLifetimeOfState() {
+        weak var state: TestObject?
+        let lockedState: LockedState<TestObject>
+
+        (state, lockedState) = {
+            let state = TestObject()
+            return (state, LockedState(initialState: state))
+        }()
+
+        lockedState.withLockExtendingLifetimeOfState { state in
+            weak var oldState = state
+            state = TestObject()
+            XCTAssertNotNil(oldState, "State object lifetime was not extended after reassignment within body")
+        }
+
+        XCTAssertNil(state, "State object lifetime was extended beyond end of call")
+    }
+
+    func testWithLockExtendingLifespanReleasesLockWhenBodyThrows() {
+        let lockedState = LockedState(initialState: TestObject())
+
+        XCTAssertThrowsError(
+            try lockedState.withLockExtendingLifetimeOfState { _ in
+                throw TestError()
+            },
+            "The body was expected to throw an error, but it did not."
+        )
+
+        // ⚠️ This test fails by crashing. If the lock was not properly released by the
+        // `withLockExtendingLifetimeOfState()` call above, the following `withLock()`
+        // call will abort the program.
+
+        lockedState.withLock { _ in
+            // PASS
+        }
+    }
+}

--- a/Tests/FoundationInternationalizationTests/LockedStateTests.swift
+++ b/Tests/FoundationInternationalizationTests/LockedStateTests.swift
@@ -14,9 +14,11 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternals)
-@testable import FoundationInternals
-#endif
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#elseif canImport(FoundationInternationalization)
+@testable import FoundationInternationalization
+#endif // FOUNDATION_FRAMEWORK
 
 final class LockedStateTests : XCTestCase {
     final class TestObject {}


### PR DESCRIPTION
- Revert "Create FoundationInternals, an internal module to host shared files used by FoundationInternationalization and FoundationEssentials (#101)"
- Reapply fb718cd3fb9f058a5fd6d736cec9c2b99d6f7dc6 fix to the other restored LockedState
