### PR TITLE
Remove String.reserveCapacity() calls with dubious value from JSONScanners

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -910,8 +910,6 @@ extension JSON5Scanner {
         from jsonBytes: BufferView<UInt8>, appendingTo output: __owned String, fullSource: BufferView<UInt8>
     ) throws -> String {
         var output = consume output
-        // A reasonable guess as to the resulting capacity of the string is 1/4 the length of the remaining buffer. With this scheme, input full of 4 byte UTF-8 sequences won't waste a bunch of extra capacity and predominantly 1 byte UTF-8 sequences will only need to resize the buffer once or twice.
-        output.reserveCapacity(output.underestimatedCount + jsonBytes.count/4)
 
         // Continue scanning, taking into account escaped sequences and control characters
         var index = jsonBytes.startIndex

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -914,8 +914,6 @@ extension JSONScanner {
         from jsonBytes: BufferView<UInt8>, appendingTo output: __owned String, fullSource: BufferView<UInt8>
     ) throws -> String {
         var output = consume output
-        // A reasonable guess as to the resulting capacity of the string is 1/4 the length of the remaining buffer. With this scheme, input full of 4 byte UTF-8 sequences won't waste a bunch of extra capacity and predominantly 1 byte UTF-8 sequences will only need to resize the buffer once or twice.
-        output.reserveCapacity(output.underestimatedCount + jsonBytes.count/4)
 
         // Continue scanning, taking into account escaped sequences and control characters
         var index = jsonBytes.startIndex


### PR DESCRIPTION
These calls to `String.reserveCapacity()` are wrong when the accumulated input is non-ASCII, resulting in requests for smaller capacities than is already being consumed. Changing them or removing them shows little to no affect on performance in benchmarks anyway. In the interest of simplicity, let's remove them.