### PR TITLE
build: define `_CRT_SECURE_NO_WARNINIGS` on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,10 @@ let package = Package(
             path: "Sources/Foundation"),
 
         // _CShims (Internal)
-        .target(name: "_CShims"),
-        
+        .target(name: "_CShims",
+                cSettings: [.define("_CRT_SECURE_NO_WARNINGS",
+                                    .when(platforms: [.windows]))]),
+
         // TestSupport (Internal)
         .target(name: "TestSupport", dependencies: [
             "FoundationEssentials",


### PR DESCRIPTION
We need to define this macro to avoid warnings due to the use of non-bounded buffer operations.  Without this, we end up with an overwhelming number of warnings.