### PR TITLE
_CShims: add Windows variant of the string functions

### DIFF
--- a/Sources/_CShims/include/string_shims.h
+++ b/Sources/_CShims/include/string_shims.h
@@ -20,6 +20,10 @@
 #include <xlocale.h>
 #endif
 
+#if defined(_WIN32)
+#define locale_t _locale_t
+#endif
+
 int _cshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
 
 double _cshims_strtod_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);


### PR DESCRIPTION
Add a Windows path for the string functions that deal with locales. This is the first step towards supporting the Windows platform.