### PR TITLE
FoundationEssentials: correct `PlatformKey` for Windows

### DIFF
--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -24,7 +24,7 @@ struct _ThreadLocal {
 #if canImport(Darwin) || canImport(Glibc)
     fileprivate typealias PlatformKey = pthread_key_t
 #elseif canImport(WinSDK)
-    fileprivate typealias PlatformKey = UInt
+    fileprivate typealias PlatformKey = DWORD
 #endif
     
     struct Key<Value> {


### PR DESCRIPTION
Windows prefers to use FLS (fibre local storage) for TLS (thread local storage).  The FLS key is of type `DWORD` rather than `UInt`.  Update the `typealias` for Windows.