### PR TITLE
Update the fallback locale from en to en-001

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
@@ -317,17 +317,17 @@ struct LocaleCache : Sendable {
 #else
     func preferences() -> (LocalePreferences, Bool) {
         var prefs = LocalePreferences()
-        prefs.locale = "en_US"
-        prefs.languages = ["en-US"]
+        prefs.locale = "en_001"
+        prefs.languages = ["en-001"]
         return (prefs, true)
     }
 
     func preferredLanguages(forCurrentUser: Bool) -> [String] {
-        [Locale.canonicalLanguageIdentifier(from: "en-US")]
+        [Locale.canonicalLanguageIdentifier(from: "en-001")]
     }
     
     func preferredLocale() -> String? {
-        "en_US"
+        "en_001"
     }
 #endif
     

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -237,15 +237,14 @@ internal final class _Locale: Sendable, Hashable {
             }
         }
 
-        if ident == nil {
-            #if os(macOS)
-            ident = ""
-            #else
-            ident = "en_US"
-            #endif
+        let fixedIdent: String
+        if let ident, !ident.isEmpty {
+            fixedIdent = ident
+        } else {
+            fixedIdent = "en_001"
         }
         
-        self.identifier = Locale._canonicalLocaleIdentifier(from: ident!)
+        self.identifier = Locale._canonicalLocaleIdentifier(from: fixedIdent)
         doesNotRequireSpecialCaseHandling = Self.identifierDoesNotRequireSpecialCaseHandling(self.identifier)
         self.prefs = prefs
         lock = LockedState(initialState: State())

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -308,7 +308,11 @@ final class DateFormatStyleTests : XCTestCase {
     }
 
 #if !os(watchOS) // 99504292
-    func testNSICUDateFormatterCache() {
+    func testNSICUDateFormatterCache() throws {
+        guard Locale.autoupdatingCurrent.language.isEquivalent(to: Locale.Language(identifier: "en_US")) else {
+            throw XCTSkip("This test can only be run with the system set to the en_US language")
+        }
+
         let fixedTimeZone = TimeZone(identifier: TimeZone.current.identifier)!
         let fixedCalendar = Calendar(identifier: Calendar.current.identifier)
 


### PR DESCRIPTION
We should use `en-001` (language identifier) / `en_001` (locale identifier) as a fallback instead of "just" English.

rdar://108958839