### PR TITLE
FoundationEssentials: allow `Data` to build on Windows

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -30,10 +30,25 @@ private func malloc_good_size(_ size: Int) -> Int {
     return size
 }
 
+#elseif canImport(ucrt)
+import ucrt
+
+private func malloc_good_size(_ size: Int) -> Int {
+    return size
+}
+
+#endif
+
+#if os(Windows)
+import func WinSDK.UnmapViewOfFile
 #endif
 
 internal func __DataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
+#if os(Windows)
+    _ = UnmapViewOfFile(mem)
+#else
     munmap(mem, length)
+#endif
 }
 
 internal func __DataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif os(Linux)
 import Glibc
+#elseif os(Windows)
+import ucrt
 #endif
 
 //===--- DataProtocol -----------------------------------------------------===//


### PR DESCRIPTION
`unmap` is a non-portable function as it is not part of the C standard. The correct spelling for this on Windows is `UnmapViewOfFile` which expects that the data to be mapped by `MapViewOfFile`.  This cannot be used for freeing memory in general.