### PR TITLE
FoundationEssentials: port `Date` to Windows

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -256,8 +256,13 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         }
 
         var info = tm()
+#if os(Windows)
+        var time = __time64_t(self.timeIntervalSince1970)
+        _gmtime64_s(&info, &time)
+#else
         var time = time_t(self.timeIntervalSince1970)
         gmtime_r(&time, &info)
+#endif
 
         // This allocates stack space for range of 10^102 years
         // That's more than Date currently supports.


### PR DESCRIPTION
MSVCRT does not provide `gmtime_r`.  `gmtime` is re-entrant safe, but uses TLS storage.  Prefer to use `_gmtime64_s` which provides the re-entrancy with local buffers but swaps parameter orders.  Prefer to use the 64-bit time variant over the 32-bit `time_t`.