### PR TITLE
FoundationEssentials: make `Decimal` build on Windows

### DIFF
--- a/Sources/FoundationEssentials/Decimal+Stub.swift
+++ b/Sources/FoundationEssentials/Decimal+Stub.swift
@@ -16,6 +16,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(ucrt)
+import ucrt
 #endif
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)


### PR DESCRIPTION
Add the import for the Windows libc.  This enables to finally build the `FoundationEssentials` module.