### PR TITLE
Foundationinternationalization: add `Codable` conformance

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -485,7 +485,7 @@ extension FloatingPointRoundingRule {
     }
 }
 
-#if os(Linux) || FOUNDATION_FRAMEWORK
+#if os(Linux) || os(Windows) || FOUNDATION_FRAMEWORK
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointRoundingRule : Codable { }
 #endif


### PR DESCRIPTION
Add the missing conformance for `Codable` to Windows.  This fixes a large set of warnings when building the package.