### PR TITLE
Zero in "0 byte" displays like latn "O" in Chinese simplified.

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -133,31 +133,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
             guard let languageCode = locale.language.languageCode?._normalizedIdentifier else { return false }
 
             switch languageCode {
-            case "ar":
-                return true
-            case "da":
-                return true
-            case "el":
-                return true
-            case "en":
-                return true
-            case "fr":
-                return true
-            case "hi":
-                return true
-            case "hr":
-                return true
-            case "id":
-                return true
-            case "it":
-                return true
-            case "ms":
-                return true
-            case "pt":
-                return true
-            case "ro":
-                return true
-            case "th":
+            case "ar", "da", "el", "en", "fr",  "hi", "hr", "id", "it", "ms", "pt", "ro", "th":
                 return true
             default:
                 break
@@ -167,9 +143,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
 
             // These only uses spellout zero with byte but not with kilobyte
             switch languageCode {
-            case "ca":
-                return true
-            case "no":
+            case "ca", "no":
                 return true
             default:
                 break

--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -127,22 +127,75 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
         fileprivate static let maxDecimalSizes = [999, 999499, 999949999, 999994999999, 999994999999999, Int64.max]
         fileprivate static let maxBinarySizes = [1023, 1048063, 1073689395, 1099506259066, 1125894409284485, Int64.max]
 
-        func _format(_ value: ICUNumberFormatter.Value) -> AttributedString {
-            if spellsOutZero && value.isZero {
-                let unit: Unit = allowedUnits.contains(.kb) ? .kilobyte : .byte
+        func useSpelloutZero(forLocale locale: Locale, unit: Unit) -> Bool {
+            guard unit == .byte || unit == .kilobyte else { return false }
 
-                let configuration = DescriptiveNumberFormatConfiguration.Collection(presentation: .spellOut, capitalizationContext: .beginningOfSentence)
+            guard let languageCode = locale.language.languageCode?._normalizedIdentifier else { return false }
+
+            switch languageCode {
+            case "ar":
+                return true
+            case "da":
+                return true
+            case "el":
+                return true
+            case "en":
+                return true
+            case "fr":
+                return true
+            case "hi":
+                return true
+            case "hr":
+                return true
+            case "id":
+                return true
+            case "it":
+                return true
+            case "ms":
+                return true
+            case "pt":
+                return true
+            case "ro":
+                return true
+            case "th":
+                return true
+            default:
+                break
+            }
+
+            guard unit == .byte else { return false }
+
+            // These only uses spellout zero with byte but not with kilobyte
+            switch languageCode {
+            case "ca":
+                return true
+            case "no":
+                return true
+            default:
+                break
+            }
+
+            return false
+        }
+
+        func _format(_ value: ICUNumberFormatter.Value) -> AttributedString {
+            let unit: Unit = allowedUnits.contains(.kb) ? .kilobyte : .byte
+            if spellsOutZero && value.isZero {
+                let numberFormatter = ICUByteCountNumberFormatter.create(for: "measure-unit/digital-\(unit.name)\(unit == .byte ? " unit-width-full-name" : "")", locale: locale)
+                guard var attributedFormat = numberFormatter?.attributedFormat(.integer(.zero), unit: unit) else {
+                    // fallback to English if ICU formatting fails
+                    return unit == .byte ? "Zero bytes" : "Zero kB"
+                }
+
+                guard useSpelloutZero(forLocale: locale, unit: unit) else {
+                    return attributedFormat
+                }
+
+                let configuration = DescriptiveNumberFormatConfiguration.Collection(presentation: .cardinal, capitalizationContext: .beginningOfSentence)
                 let spellOutFormatter = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: .descriptive(configuration), locale: locale)
 
-                let numberFormatter = ICUByteCountNumberFormatter.create(for: "measure-unit/digital-\(unit.name) \(unit == .byte ? "unit-width-full-name" : "")", locale: locale)
-
-                guard var attributedFormat = numberFormatter?.attributedFormat(.integer(.zero), unit: unit), let zeroFormatted = spellOutFormatter.format(Int64.zero) else {
-                    // fallback to English
-                    if unit == .byte {
-                        return "Zero bytes"
-                    } else {
-                        return "Zero kB"
-                    }
+                guard let zeroFormatted = spellOutFormatter.format(Int64.zero) else {
+                    return attributedFormat
                 }
 
                 var attributedZero = AttributedString(zeroFormatted)

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -54,6 +54,13 @@ internal final class ICULegacyNumberFormatter {
         unum_setAttribute(uformatter, attr, value ? 1 : 0)
     }
 
+    func setTextAttribute(_ attr: UNumberFormatTextAttribute, value: String) throws {
+        let uvalue = Array(value.utf16)
+        var status = U_ZERO_ERROR
+        unum_setTextAttribute(uformatter, attr, uvalue, Int32(uvalue.count), &status)
+        try status.checkSuccess()
+    }
+
     func parseAsInt(_ string: some StringProtocol) -> Int64? {
         let arr = Array(string.utf16)
         var status = U_ZERO_ERROR
@@ -244,7 +251,7 @@ internal final class ICULegacyNumberFormatter {
             case .currency(let config):
                 icuType = config.icuNumberFormatStyle
             case .descriptive(let config):
-                icuType = config.icuFormatStyle
+                icuType = config.icuNumberFormatStyle
             }
 
             let formatter = try! ICULegacyNumberFormatter(type: icuType, locale: locale)
@@ -286,14 +293,26 @@ internal final class ICULegacyNumberFormatter {
                         break
                     }
                 }
-
+                
             case .descriptive(let config):
                 if let capitalizationContext = config.capitalizationContext {
                     formatter.setCapitalizationContext(capitalizationContext)
                 }
+                
+                switch config.presentation.option {
+                case .spellOut:
+                    break
+                case .ordinal:
+                    break
+                case .cardinal:
+                    do {
+                        try formatter.setTextAttribute(.defaultRuleSet, value: "%spellout-cardinal")
+                    } catch {
+                        // the general cardinal rule isn't supported, so try a gendered cardinal. Note that a proper fix requires using the gender of the subsequent noun
+                        try? formatter.setTextAttribute(.defaultRuleSet, value: "%spellout-cardinal-masculine")
+                    }
+                }
             }
-
-
             return formatter
         }
     }

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -385,6 +385,7 @@ public enum DescriptiveNumberFormatConfiguration {
         internal enum Option : Int, Codable, Hashable {
             case spellOut = 1
             case ordinal = 2
+            case cardinal = 3
 
             #if FOUNDATION_FRAMEWORK
             fileprivate var numberFormatterStyle : NumberFormatter.Style {
@@ -393,6 +394,8 @@ public enum DescriptiveNumberFormatConfiguration {
                     return .spellOut
                 case .ordinal:
                     return .ordinal
+                case .cardinal:
+                    return .spellOut // cardinal is a special case spellout style
                 }
             }
             #endif // FOUNDATION_FRAMEWORK
@@ -401,7 +404,8 @@ public enum DescriptiveNumberFormatConfiguration {
 
         public static var spellOut: Self { Presentation(rawValue: 1) }
         public static var ordinal: Self { Presentation(rawValue: 2) }
-
+        internal static var cardinal: Self { Presentation(rawValue: 3) }
+        
         internal init(rawValue: Int) {
             option = Option(rawValue: rawValue)!
         }
@@ -411,20 +415,14 @@ public enum DescriptiveNumberFormatConfiguration {
         var presentation: Presentation
         var capitalizationContext: CapitalizationContext?
 
-        var icuFormatStyle: UNumberFormatStyle {
-            switch presentation.option {
-            case .spellOut:
-                return .spellout
-            case .ordinal:
-                return .ordinal
-            }
-        }
         var icuNumberFormatStyle: UNumberFormatStyle {
             switch presentation.option {
             case .spellOut:
                 return .spellout
             case .ordinal:
                 return .ordinal
+            case .cardinal:
+                return .spellout // cardinal is a special case spellout stype
             }
         }
     }

--- a/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
@@ -72,6 +72,10 @@ extension UNumberFormatAttribute {
     static let signAlwaysShown = UNUM_SIGN_ALWAYS_SHOWN
 }
 
+extension UNumberFormatTextAttribute {
+    static let defaultRuleSet = UNUM_DEFAULT_RULESET
+}
+
 extension UDateRelativeDateTimeFormatterStyle {
     static let long = UDAT_STYLE_LONG
     static let short = UDAT_STYLE_SHORT

--- a/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
@@ -16,18 +16,19 @@ import TestSupport
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class ByteCountFormatStyleTests : XCTestCase {
-    let locales = [Locale(identifier: "en_US"), .init(identifier: "fr_FR"), .init(identifier: "zh_TW"), .init(identifier: "ar")]
+    let locales = [Locale(identifier: "en_US"), .init(identifier: "fr_FR"), .init(identifier: "zh_TW"), .init(identifier: "zh_CN"), .init(identifier: "ar")]
 
     func test_zeroSpelledOutKb() {
         let localizedZerosSpelledOutKb: [Locale: String] = [
             Locale(identifier: "en_US"): "Zero kB",
             Locale(identifier: "fr_FR"): "Zéro ko",
-            Locale(identifier: "zh_TW"): "〇 kB",
+            Locale(identifier: "zh_TW"): "0 kB",
+            Locale(identifier: "zh_CN"): "0 kB",
             Locale(identifier: "ar"): "صفر كيلوبايت",
         ]
 
         for locale in locales {
-            XCTAssertEqual(0.formatted(.byteCount(style: .memory, spellsOutZero: true).locale(locale)), localizedZerosSpelledOutKb[locale])
+            XCTAssertEqual(0.formatted(.byteCount(style: .memory, spellsOutZero: true).locale(locale)), localizedZerosSpelledOutKb[locale], "locale: \(locale.identifier) failed expectation" )
         }
     }
 
@@ -35,12 +36,13 @@ final class ByteCountFormatStyleTests : XCTestCase {
         let localizedZerosSpelledOutBytes: [Locale: String] = [
             Locale(identifier: "en_US"): "Zero bytes",
             Locale(identifier: "fr_FR"): "Zéro octet",
-            Locale(identifier: "zh_TW"): "〇 byte",
+            Locale(identifier: "zh_TW"): "0 byte",
+            Locale(identifier: "zh_CN"): "0字节",
             Locale(identifier: "ar"): "صفر بايت",
         ]
 
         for locale in locales {
-            XCTAssertEqual(0.formatted(.byteCount(style: .memory, allowedUnits: .bytes, spellsOutZero: true).locale(locale)), localizedZerosSpelledOutBytes[locale])
+            XCTAssertEqual(0.formatted(.byteCount(style: .memory, allowedUnits: .bytes, spellsOutZero: true).locale(locale)), localizedZerosSpelledOutBytes[locale], "locale: \(locale.identifier) failed expectation")
         }
     }
 
@@ -62,6 +64,14 @@ final class ByteCountFormatStyleTests : XCTestCase {
         "1 Po",
         ],
         Locale(identifier: "zh_TW"): [
+        "1 byte",
+        "1 kB",
+        "1 MB",
+        "1 GB",
+        "1 TB",
+        "1 PB",
+        ],
+        Locale(identifier: "zh_CN"): [
         "1 byte",
         "1 kB",
         "1 MB",


### PR DESCRIPTION
Only a small number of languages prefer spelling out number in this context according to localization team. Chinese wasn't one of those, hence this bug. Fix it by hard-coding a list of language codes where we should format number 0 as a spellout number.

Also were using a rule-based number formatter to format number 0 into spellout "Zero", which defaults to an ordinal number. That default rule was incorrect. The number should be formatted as a cardinal number instead.
