### PR TITLE
FoundationPreview: Stop relying on CharacterSet for trimming whitespace

### DIFF
--- a/Sources/FoundationEssentials/String/BidirectionalCollection.swift
+++ b/Sources/FoundationEssentials/String/BidirectionalCollection.swift
@@ -36,3 +36,30 @@ extension BidirectionalCollection where Index == String.Index {
         return r
     }
 }
+
+extension BidirectionalCollection {
+    func _trimmingCharacters(while predicate:(Element) -> Bool) -> SubSequence {
+        var idx = startIndex
+        while idx < endIndex && predicate(self[idx]) {
+            formIndex(after: &idx)
+        }
+
+        let startOfNonTrimmedRange = idx // Points at the first char not in the set
+        guard startOfNonTrimmedRange != endIndex else {
+            return self[endIndex...]
+        }
+
+        let beforeEnd = index(before: endIndex)
+        guard startOfNonTrimmedRange < beforeEnd else {
+            return self[startOfNonTrimmedRange ..< endIndex]
+        }
+
+        var backIdx = beforeEnd
+        // No need to bound-check because we've already trimmed from the beginning, so we'd definitely break off of this loop before `backIdx` rewinds before `startIndex`
+        while predicate(self[backIdx]) {
+            formIndex(before: &backIdx)
+        }
+        return self[startOfNonTrimmedRange ... backIdx]
+    }
+
+}

--- a/Sources/FoundationEssentials/String/String+Essentials.swift
+++ b/Sources/FoundationEssentials/String/String+Essentials.swift
@@ -41,6 +41,8 @@ extension String {
         return new
     }
 
+    // MARK: - Public API
+
     /// Creates a new string equivalent to the given bytes interpreted in the
     /// specified encoding.
     ///

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -26,7 +26,7 @@ extension FloatingPointParseStrategy: ParseStrategy {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
         let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
-        if let v = parser.parseAsDouble(value.trimmingCharacters(in: .whitespaces)) {
+        if let v = parser.parseAsDouble(value._trimmingWhitespaces()) {
             return Format.FormatInput(v)
         } else {
             let exampleString = formatStyle.format(3.14)

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -26,7 +26,7 @@ extension FloatingPointParseStrategy: ParseStrategy {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
         let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
-        if let v = parser.parseAsDouble(value._trimmingWhitespaces()) {
+        if let v = parser.parseAsDouble(value._trimmingWhitespace()) {
             return Format.FormatInput(v)
         } else {
             let exampleString = formatStyle.format(3.14)

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -25,7 +25,7 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 extension IntegerParseStrategy: ParseStrategy {
     public func parse(_ value: String) throws -> Format.FormatInput {
         let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
-        let trimmedString = value.trimmingCharacters(in: .whitespaces)
+        let trimmedString = value._trimmingWhitespaces()
         if let v = parser.parseAsInt(trimmedString) {
             return Format.FormatInput(v)
         } else if let v = parser.parseAsDouble(trimmedString) {

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -25,7 +25,7 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 extension IntegerParseStrategy: ParseStrategy {
     public func parse(_ value: String) throws -> Format.FormatInput {
         let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
-        let trimmedString = value._trimmingWhitespaces()
+        let trimmedString = value._trimmingWhitespace()
         if let v = parser.parseAsInt(trimmedString) {
             return Format.FormatInput(v)
         } else if let v = parser.parseAsDouble(trimmedString) {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -591,7 +591,7 @@ extension NumberFormatStyleConfiguration.Collection {
             s += notation.skeleton + " "
         }
 
-        return s._trimmingWhitespaces()
+        return s._trimmingWhitespace()
     }
 }
 
@@ -851,7 +851,7 @@ extension CurrencyFormatStyleConfiguration.Collection {
             s += rounding.skeleton + " "
         }
 
-        return s._trimmingWhitespaces()
+        return s._trimmingWhitespace()
     }
 
     var icuNumberFormatStyle: UNumberFormatStyle {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -591,7 +591,7 @@ extension NumberFormatStyleConfiguration.Collection {
             s += notation.skeleton + " "
         }
 
-        return s.trimmingCharacters(in: .whitespaces)
+        return s._trimmingWhitespaces()
     }
 }
 
@@ -851,7 +851,7 @@ extension CurrencyFormatStyleConfiguration.Collection {
             s += rounding.skeleton + " "
         }
 
-        return s.trimmingCharacters(in: .whitespaces)
+        return s._trimmingWhitespaces()
     }
 
     var icuNumberFormatStyle: UNumberFormatStyle {

--- a/Sources/_FoundationInternals/String/BidirectionalCollection.swift
+++ b/Sources/_FoundationInternals/String/BidirectionalCollection.swift
@@ -38,7 +38,7 @@ extension BidirectionalCollection where Index == String.Index {
 }
 
 extension BidirectionalCollection {
-    func _trimmingCharacters(while predicate:(Element) -> Bool) -> SubSequence {
+    func _trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
         var idx = startIndex
         while idx < endIndex && predicate(self[idx]) {
             formIndex(after: &idx)

--- a/Sources/_FoundationInternals/String/BidirectionalCollection.swift
+++ b/Sources/_FoundationInternals/String/BidirectionalCollection.swift
@@ -61,5 +61,4 @@ extension BidirectionalCollection {
         }
         return self[startOfNonTrimmedRange ... backIdx]
     }
-
 }

--- a/Sources/_FoundationInternals/String/String+Internals.swift
+++ b/Sources/_FoundationInternals/String/String+Internals.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_FoundationInternals/String/String+Internals.swift
+++ b/Sources/_FoundationInternals/String/String+Internals.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+    internal func _trimmingWhitespaces() -> String {
+        String(unicodeScalars._trimmingCharacters {
+            $0.properties.isWhitespace
+        })
+    }
+}

--- a/Sources/_FoundationInternals/String/String+Internals.swift
+++ b/Sources/_FoundationInternals/String/String+Internals.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension String {
-    internal func _trimmingWhitespaces() -> String {
+    internal func _trimmingWhitespace() -> String {
         String(unicodeScalars._trimmingCharacters {
             $0.properties.isWhitespace
         })

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -22,22 +22,22 @@ import TestSupport
 
 final class StringTests : XCTestCase {
     // MARK: - Case mapping
-    
+
     func testCapitalize() {
         func test(_ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(string._capitalized(), expected, file: file, line: line)
         }
-        
+
         test("iı", "Iı")
         test("ıi", "Ii")
-        
+
         // Word boundaries
         test("Th.he.EVERYWHERE",
              "Th.He.Everywhere")
         test("HELLO world\t\t\tThere.here.EVERYWHERE 78dollars",
              "Hello World\t\t\tThere.Here.Everywhere 78Dollars")
         test("GOOd Evening WOrld!", "Good Evening World!")
-        
+
         // We don't do title case, so minor words are also capitalized
         test("train your mind for peak performance: a science-based approach for achieving your goals!", "Train Your Mind For Peak Performance: A Science-Based Approach For Achieving Your Goals!")
         test("cAt! ʻeTc.", "Cat! ʻEtc.")
@@ -50,14 +50,14 @@ final class StringTests : XCTestCase {
         test("\u{00DF}", "Ss") // Sharp S
         test("\u{FB00}", "Ff") // Ligature FF
         test("\u{1F80}", "\u{1F88}")
-        
+
         // Width variants
         test("ｈｅｌｌｏ，ｗｏＲＬＤ\tｈｅｒｅ．ＴＨＥＲＥ？ｅＶｅｒＹＷＨＥＲＥ",
              "Ｈｅｌｌｏ，Ｗｏｒｌｄ\tＨｅｒｅ．Ｔｈｅｒｅ？Ｅｖｅｒｙｗｈｅｒｅ")
-        
+
         // Diacritics
         test("ĤĒḺḶŐ ẀỌṜŁÐ", "Ĥēḻḷő Ẁọṝłð")
-        
+
         // Hiragana, Katacana -- case not affected
         test("ァィゥㇳ゚ェォ ヶ゜ アイウエオ", "ァィゥㇳ゚ェォ ヶ゜ アイウエオ")
         test("ぁぃぅぇぉ ど ゕゖくけこ", "ぁぃぅぇぉ ど ゕゖくけこ")

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -22,22 +22,22 @@ import TestSupport
 
 final class StringTests : XCTestCase {
     // MARK: - Case mapping
-
+    
     func testCapitalize() {
         func test(_ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(string._capitalized(), expected, file: file, line: line)
         }
-
+        
         test("iı", "Iı")
         test("ıi", "Ii")
-
+        
         // Word boundaries
         test("Th.he.EVERYWHERE",
              "Th.He.Everywhere")
         test("HELLO world\t\t\tThere.here.EVERYWHERE 78dollars",
              "Hello World\t\t\tThere.Here.Everywhere 78Dollars")
         test("GOOd Evening WOrld!", "Good Evening World!")
-
+        
         // We don't do title case, so minor words are also capitalized
         test("train your mind for peak performance: a science-based approach for achieving your goals!", "Train Your Mind For Peak Performance: A Science-Based Approach For Achieving Your Goals!")
         test("cAt! ʻeTc.", "Cat! ʻEtc.")
@@ -45,21 +45,94 @@ final class StringTests : XCTestCase {
         test("49ERS", "49Ers")
         test("«丰(aBc)»", "«丰(Abc)»")
         test("Nat’s test can’t run", "Nat’s Test Can’t Run")
-
+        
         test("ijssEl iglOo IJSSEL", "Ijssel Igloo Ijssel")
         test("\u{00DF}", "Ss") // Sharp S
         test("\u{FB00}", "Ff") // Ligature FF
         test("\u{1F80}", "\u{1F88}")
-
+        
         // Width variants
         test("ｈｅｌｌｏ，ｗｏＲＬＤ\tｈｅｒｅ．ＴＨＥＲＥ？ｅＶｅｒＹＷＨＥＲＥ",
              "Ｈｅｌｌｏ，Ｗｏｒｌｄ\tＨｅｒｅ．Ｔｈｅｒｅ？Ｅｖｅｒｙｗｈｅｒｅ")
-
+        
         // Diacritics
         test("ĤĒḺḶŐ ẀỌṜŁÐ", "Ĥēḻḷő Ẁọṝłð")
-
+        
         // Hiragana, Katacana -- case not affected
         test("ァィゥㇳ゚ェォ ヶ゜ アイウエオ", "ァィゥㇳ゚ェォ ヶ゜ アイウエオ")
         test("ぁぃぅぇぉ ど ゕゖくけこ", "ぁぃぅぇぉ ど ゕゖくけこ")
+    }
+
+    func testTrimmingWhitespace() {
+        func test(_ str: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(str._trimmingWhitespace(), expected, file: file, line: line)
+        }
+        test(" \tABCDEFGAbc \t \t  ", "ABCDEFGAbc")
+        test("ABCDEFGAbc \t \t  ", "ABCDEFGAbc")
+        test(" \tABCDEFGAbc", "ABCDEFGAbc")
+        test(" \t\t\t    \t\t   \t", "")
+        test(" X", "X")
+        test("X ", "X")
+        test("X", "X")
+        test("", "")
+        test("X\u{00A0}", "X") // NBSP
+        test(" \u{202F}\u{00A0} X \u{202F}\u{00A0}", "X") // NBSP and narrow NBSP
+    }
+
+    func testTrimmingCharactersWithPredicate() {
+        func test(_ str: String, while predicate: (Character) -> Bool, _ expected: Substring, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(str._trimmingCharacters(while: predicate), expected, file: file, line: line)
+        }
+
+        typealias TrimmingPredicate = (Character) -> Bool
+
+        let isNewline: TrimmingPredicate = { $0.isNewline }
+
+        test("\u{2028}ABCDEFGAbc \u{2028}", while: isNewline, "ABCDEFGAbc ")
+        test("\nABCDEFGAbc \n\n", while: isNewline, "ABCDEFGAbc ")
+        test("\n\u{2028}ABCDEFGAbc \n\u{2028}\n", while: isNewline, "ABCDEFGAbc ")
+        test("\u{2029}ABCDEFGAbc \u{2029}", while: isNewline, "ABCDEFGAbc ")
+        test("\nABCDEFGAbc \n\u{2029}\n", while: isNewline, "ABCDEFGAbc ")
+        test(" \n    \n\n\t   \n\t\n", while: { $0.isNewline || $0.isWhitespace }, "")
+
+        let isNumber: TrimmingPredicate = { $0.isNumber }
+
+        test("1B", while: isNumber, "B")
+        test("11 B22", while: isNumber, " B")
+        test("11 B\u{0662}\u{0661}", while: isNumber, " B") // ARABIC-INDIC DIGIT TWO and ONE
+        test(" B 22", while: isNumber, " B ")
+        test(" B \u{0662}\u{0661}", while: isNumber, " B ")
+
+        test("11 B\u{0662}\u{0661}", while: { $0.isNumber || $0.isASCII }, "") // ARABIC-INDIC DIGIT TWO and ONE
+        test("\u{ffff}a\u{ffff}", while: { !$0.isNumber && !$0.isASCII }, "a")
+
+        let isLowercase: TrimmingPredicate = { $0.isLowercase }
+        let isLetter: TrimmingPredicate = { $0.isLetter }
+        let isUppercase: TrimmingPredicate = { $0.isUppercase }
+
+        test("AB🏳️‍🌈xyz👩‍👩‍👧‍👦ab", while: isLetter, "🏳️‍🌈xyz👩‍👩‍👧‍👦")
+        test("AB🏳️‍🌈xyz👩‍👩‍👧‍👦ab", while: isUppercase, "🏳️‍🌈xyz👩‍👩‍👧‍👦ab")
+        test("AB🏳️‍🌈xyz👩‍👩‍👧‍👦ab", while: isLowercase, "AB🏳️‍🌈xyz👩‍👩‍👧‍👦")
+
+        test("cafe\u{0301}abcABC123", while: { $0.isLetter || $0.isNumber }, "")
+        test("cafe\u{0301}abcABC123", while: isLetter, "123")
+        test("cafe\u{0301}abcABC123", while: isLowercase, "ABC123")
+
+        test("\u{0301}abc123xyz\u{0301}", while: isLetter, "\u{0301}abc123") // \u{0301} isn't a letter on its own, but it is when normalized and combined with the previous character
+        test("\u{0301}abc123xyz\u{0301}", while: isLowercase, "\u{0301}abc123")
+
+        test("+a+b+c+1+2+3++", while: { $0.isSymbol }, "a+b+c+1+2+3")
+        test("+a+b+c+1+2+3!!", while: { $0.isPunctuation }, "+a+b+c+1+2+3")
+
+        let alwaysReject: TrimmingPredicate = { _ in return false }
+
+        test("", while: alwaysReject, "")
+        test("🏳️‍🌈xyz👩‍👩‍👧‍👦", while: alwaysReject, "🏳️‍🌈xyz👩‍👩‍👧‍👦")
+        test("11 B\u{0662}\u{0661}", while: alwaysReject, "11 B\u{0662}\u{0661}")
+
+        let alwaysTrim: TrimmingPredicate = { _ in return true }
+
+        test("🏳️‍🌈xyz👩‍👩‍👧‍👦", while: alwaysTrim, "")
+        test("11 B\u{0662}\u{0661}", while: alwaysTrim, "")
     }
 }


### PR DESCRIPTION
- Generalize trimming function to take a predicate block. Move this function to FoundationEssentials.
- Call `_trimmingWhitespaces()` instead of through CharacterSet.
