### PR TITLE
build: add a workaround for Windows tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,9 +68,14 @@ let package = Package(
                 .enableExperimentalFeature("AccessLevelOnImport")
             ]
         ),
-        .testTarget(name: "FoundationInternationalizationTests", dependencies: [
-            "TestSupport",
-            "FoundationInternationalization"
-        ]),
     ]
 )
+
+#if canImport(RegexBuilder)
+package.targets.append(contentsOf: [
+    .testTarget(name: "FoundationInternationalizationTests", dependencies: [
+        "TestSupport",
+        "FoundationInternationalization"
+    ]),
+])
+#endif


### PR DESCRIPTION
This adds a conditional handling of `FoundationInternationalization` tests if the `RegexBuilder` module is available.  This currently is unavailable on Windows, which prevents building a complete set of targets.  Adjust the build to accommodate this configuration and automatically enable the tests when the module is available.