### PR TITLE
FoundationInternationalization: adjust the libc imports

### DIFF
--- a/Sources/FoundationInternationalization/BinaryFloatingPoint.swift
+++ b/Sources/FoundationInternationalization/BinaryFloatingPoint.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 extension BinaryFloatingPoint {

--- a/Sources/FoundationInternationalization/BinaryInteger.swift
+++ b/Sources/FoundationInternationalization/BinaryInteger.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 extension FixedWidthInteger {

--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -18,6 +18,10 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if canImport(CRT)
+import CRT
+#endif
+
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
 #else

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -18,6 +18,10 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if canImport(CRT)
+import CRT
+#endif
+
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
 #else

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -99,7 +99,7 @@ extension Locale {
                 return
             }
             var status = U_ZERO_ERROR
-            #if canImport(Glibc)
+            #if canImport(Glibc) || canImport(ucrt)
             // Glibc doesn't support strlcpy
             strcpy(buf, identifier)
             #else

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(ucrt)
+import ucrt
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -18,6 +18,10 @@ import FoundationEssentials
 import Glibc
 #endif
 
+#if canImport(ucrt)
+import ucrt
+#endif
+
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import FoundationICU
 #else


### PR DESCRIPTION
Adjust the importing of the system libc library for Windows.  When possible, prefer to import the underlying C library interface through the `ucrt` (clang) module.  When needed, resort to use `CRT` which has an overlay which provides certain overloads for math functions.