### PR TITLE
FoundationEssentials: Use dlsym instead of _typeByName in Attribute scope lookup

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -29,7 +29,7 @@ public enum AttributeScopes { }
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import Darwin
+import Darwin
 @_implementationOnly import ReflectionInternal
 
 fileprivate struct ScopeDescription : Sendable {
@@ -85,19 +85,6 @@ fileprivate struct LoadedScopeCache : Sendable {
         let type = unsafeBitCast(symbol, to: Any.Type.self) as? any AttributeScope.Type
         scopeMangledNames[name] = type
         return type
-    }
-    
-    subscript(_ name: String) -> ScopeDescription? {
-        mutating get {
-            guard let type = scopeType(for: name) else { return nil }
-            return self[type]
-        }
-        set {
-            guard let type = scopeType(for: name) else {
-                fatalError("Unable to cache scope contents for non-loaded scope")
-            }
-            self[type] = newValue
-        }
     }
     
     subscript(_ type: any AttributeScope.Type) -> ScopeDescription? {

--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -119,7 +119,7 @@ internal func _loadDefaultAttributes() -> [String : any AttributedStringKey.Type
     // AppKit
     let macUIScope = (
         "$s10Foundation15AttributeScopesO6AppKitE0dE10AttributesVN",
-        "/usr/lib/swift/libswiftAppKit.dylib"
+        "/System/Library/Frameworks/AppKit.framework/AppKit"
     )
     #else
     // UIKit on macOS


### PR DESCRIPTION
`_typeByName` is actually quite slow compared to just `dlsym` these days. Use that instead.

Resolves: rdar://109785007