### PR TITLE
Work towards: Stop calling into Foundation's implementation 

### DIFF
--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -436,60 +436,6 @@ extension _StringCompareOptionsIterable {
             formIndex(&fromLoc, offsetBy: delta)
         }
 
-
-        return result
-    }
-
-    func _range<S: BidirectionalCollection>(of strToFind: S, anchored: Bool, backwards: Bool) -> Range<Index>? where S.Element == Element {
-        var result: Range<Index>? = nil
-        var fromLoc: Index
-        var toLoc: Index
-        if backwards {
-            guard let idx = _index(endIndex, backwardsOffsetByCountOf: strToFind) else {
-                // strToFind.count > string.count: bail
-                return nil
-            }
-            fromLoc = idx
-
-            toLoc = anchored ? fromLoc : startIndex
-        } else {
-            fromLoc = startIndex
-            if anchored {
-                toLoc = fromLoc
-            } else {
-                guard let idx = _index(endIndex, backwardsOffsetByCountOf: strToFind) else {
-                    return nil
-                }
-                toLoc = idx
-            }
-        }
-
-        let delta = fromLoc <= toLoc ? 1 : -1
-
-        while true {
-            var str1Index = fromLoc
-            var str2Index = strToFind.startIndex
-
-            while str2Index < strToFind.endIndex && str1Index < endIndex {
-                if self[str1Index] != strToFind[str2Index] {
-                    break
-                }
-                formIndex(after: &str1Index)
-                strToFind.formIndex(after: &str2Index)
-            }
-
-            if str2Index == strToFind.endIndex {
-                result = fromLoc..<str1Index
-                break
-            }
-
-            if fromLoc == toLoc {
-                break
-            }
-
-            formIndex(&fromLoc, offsetBy: delta)
-        }
-
         return result
     }
 }
@@ -858,23 +804,6 @@ extension ComparisonResult {
         } else {
             self = .orderedSame
         }
-    }
-}
-
-extension BidirectionalCollection {
-    // Equal to calling `index(&idx, offsetBy: -other.count)` with just one loop
-    func _index<S: BidirectionalCollection>(_ index: Index, backwardsOffsetByCountOf other: S) -> Index? {
-        var idx = index
-        var otherIdx = other.endIndex
-        while otherIdx > other.startIndex  {
-            guard idx > startIndex else {
-                // other.count > self.count: bail
-                return nil
-            }
-            other.formIndex(before: &otherIdx)
-            formIndex(before: &idx)
-        }
-        return idx
     }
 }
 

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -372,9 +372,9 @@ internal final class _Locale: Sendable, Hashable {
                 return uloc_toLanguageTag(string, buffer, size, UBool.false, &status)
             }
 
-            if let canonicalized = bcp47?.replacingOccurrences(of: "-", with: "_") {
+            if let canonicalized = bcp47?.replacing("-", with: "_") {
                 if canonicalized == "und" {
-                    result = canonicalized.replacingOccurrences(of: "und", with: "root")
+                    result = canonicalized.replacing("und", with: "root")
                 } else {
                     result = canonicalized
                 }

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
@@ -118,7 +118,7 @@ struct TimeZoneCache : Sendable {
 #else
                     let lookFor = _TimeZone.TZDIR + "/"
 #endif
-                    if let rangeOfZoneInfo = file.range(of: lookFor) {
+                    if let rangeOfZoneInfo = file._range(of: lookFor) {
                         let name = file[rangeOfZoneInfo.upperBound...]
                         if let result = fixed(String(name)) {
                             return result

--- a/Sources/_FoundationInternals/String/BidirectionalCollection.swift
+++ b/Sources/_FoundationInternals/String/BidirectionalCollection.swift
@@ -61,4 +61,72 @@ extension BidirectionalCollection {
         }
         return self[startOfNonTrimmedRange ... backIdx]
     }
+
+    // Equal to calling `index(&idx, offsetBy: -other.count)` with just one loop
+    func _index<S: BidirectionalCollection>(_ index: Index, backwardsOffsetByCountOf other: S) -> Index? {
+        var idx = index
+        var otherIdx = other.endIndex
+        while otherIdx > other.startIndex  {
+            guard idx > startIndex else {
+                // other.count > self.count: bail
+                return nil
+            }
+            other.formIndex(before: &otherIdx)
+            formIndex(before: &idx)
+        }
+        return idx
+    }
+
+    func _range<S: BidirectionalCollection>(of other: S, anchored: Bool = false, backwards: Bool = false) -> Range<Index>? where S.Element == Element, Element : Equatable {
+        var result: Range<Index>? = nil
+        var fromLoc: Index
+        var toLoc: Index
+        if backwards {
+            guard let idx = _index(endIndex, backwardsOffsetByCountOf: other) else {
+                // other.count > string.count: bail
+                return nil
+            }
+            fromLoc = idx
+
+            toLoc = anchored ? fromLoc : startIndex
+        } else {
+            fromLoc = startIndex
+            if anchored {
+                toLoc = fromLoc
+            } else {
+                guard let idx = _index(endIndex, backwardsOffsetByCountOf: other) else {
+                    return nil
+                }
+                toLoc = idx
+            }
+        }
+
+        let delta = fromLoc <= toLoc ? 1 : -1
+
+        while true {
+            var str1Index = fromLoc
+            var str2Index = other.startIndex
+
+            while str2Index < other.endIndex && str1Index < endIndex {
+                if self[str1Index] != other[str2Index] {
+                    break
+                }
+                formIndex(after: &str1Index)
+                other.formIndex(after: &str2Index)
+            }
+
+            if str2Index == other.endIndex {
+                result = fromLoc..<str1Index
+                break
+            }
+
+            if fromLoc == toLoc {
+                break
+            }
+
+            formIndex(&fromLoc, offsetBy: delta)
+        }
+
+        return result
+    }
 }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -135,4 +135,109 @@ final class StringTests : XCTestCase {
         test("🏳️‍🌈xyz👩‍👩‍👧‍👦", while: alwaysTrim, "")
         test("11 B\u{0662}\u{0661}", while: alwaysTrim, "")
     }
+
+    func _testRangeOfString(_ tested: String, string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+        let result = tested._range(of: string, anchored: anchored, backwards: backwards)
+        var exp: Range<String.Index>?
+        if let expectation {
+            exp = tested.index(tested.startIndex, offsetBy: expectation.lowerBound) ..< tested.index(tested.startIndex, offsetBy: expectation.upperBound)
+        } else {
+            exp = nil
+        }
+
+        var message: String
+        if let result {
+            let readableRange = tested.distance(from: tested.startIndex, to: result.lowerBound)..<tested.distance(from: tested.startIndex, to: result.upperBound)
+            message = "Actual: \(readableRange)"
+        } else {
+            message = "Actual: nil"
+        }
+        XCTAssertEqual(result, exp, message, file: file, line: line)
+    }
+
+    func testRangeOfString() {
+        var tested: String
+        func testASCII(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+        }
+
+        tested = "ABCDEFGAbcABCDE"
+        testASCII("", anchored: false, backwards: false, 0..<0)
+        testASCII("A", anchored: false, backwards: false, 0..<1)
+        testASCII("B", anchored: false, backwards: false, 1..<2)
+        testASCII("b", anchored: false, backwards: false, 8..<9)
+        testASCII("FG", anchored: false, backwards: false, 5..<7)
+        testASCII("FGH", anchored: false, backwards: false, nil)
+        testASCII("cde", anchored: false, backwards: false, nil)
+        testASCII("CDE", anchored: false, backwards: false, 2..<5)
+
+        testASCII("", anchored: true, backwards: false, 0..<0)
+        testASCII("AB", anchored: true, backwards: false, 0..<2)
+        testASCII("ab", anchored: true, backwards: false, nil)
+        testASCII("BC", anchored: true, backwards: false, nil)
+        testASCII("bc", anchored: true, backwards: false, nil)
+
+        testASCII("", anchored: false, backwards: true, 15..<15)
+        testASCII("A", anchored: false, backwards: true, 10..<11)
+        testASCII("B", anchored: false, backwards: true, 11..<12)
+        testASCII("b", anchored: false, backwards: true, 8..<9)
+        testASCII("FG", anchored: false, backwards: true, 5..<7)
+        testASCII("FGH", anchored: false, backwards: true, nil)
+        testASCII("cde", anchored: false, backwards: true, nil)
+        testASCII("CDE", anchored: false, backwards: true, 12..<15)
+
+        testASCII("", anchored: true, backwards: true, 15..<15)
+        testASCII("AB", anchored: true, backwards: true, nil)
+        testASCII("ab", anchored: true, backwards: true, nil)
+        testASCII("BC", anchored: true, backwards: true, nil)
+        testASCII("bc", anchored: true, backwards: true, nil)
+        testASCII("bcd", anchored: true, backwards: true, nil)
+        testASCII("B", anchored: true, backwards: true, nil)
+        testASCII("b", anchored: true, backwards: true, nil)
+        testASCII("FG", anchored: true, backwards: true, nil)
+        testASCII("FGH", anchored: true, backwards: true, nil)
+        testASCII("cde", anchored: true, backwards: true, nil)
+        testASCII("CDE", anchored: true, backwards: true, 12..<15)
+        testASCII("ABCDE", anchored: true, backwards: true, 10..<15)
+        testASCII("E", anchored: true, backwards: true, 14..<15)
+
+        tested = ""
+        testASCII("ABCDER", anchored: false, backwards: false, nil)
+    }
+
+    func testRangeOfString_graphemeCluster() {
+        var tested: String
+        func test(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+        }
+
+        do {
+            // 🏳️‍🌈 = U+1F3F3 U+FE0F U+200D U+1F308
+            // 👩‍👩‍👧‍👦 = U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466
+            // 🕵️‍♀️ = U+1F575 U+FE0F U+200D U+2640 U+FE0F
+            tested = "🏳️‍🌈AB👩‍👩‍👧‍👦ab🕵️‍♀️"
+
+            test("🏳️‍🌈", anchored: false, backwards: false, 0..<1)
+            test("🏳", anchored: false, backwards: false, nil) // U+1F3F3
+
+            test("🏳️‍🌈A", anchored: false, backwards: false, 0..<2)
+
+            test("B👩‍👩‍👧‍👦a", anchored: false, backwards: false, 2..<5)
+            test("b🕵️‍♀️", anchored: false, backwards: false, 5..<7)
+
+
+            test("🏳️‍🌈A", anchored: true, backwards: false, 0..<2)
+            test("ＡＢ", anchored: true, backwards: false, nil)
+            test("B👩‍👩‍👧‍👦a", anchored: true, backwards: false, nil)
+            test("b🕵️‍♀️", anchored: true, backwards: false, nil)
+
+            test("🏳️‍🌈", anchored: true, backwards: true, nil)
+            test("B👩‍👩‍👧‍👦a", anchored: true, backwards: true, nil)
+            test("🕵️‍♀️", anchored: true, backwards: true, 6..<7)
+            test("b🕵️‍♀️", anchored: true, backwards: true, 5..<7)
+            test("B🕵️‍♀️", anchored: true, backwards: true, nil)
+
+        }
+    }
+
 }

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 #endif
 
 #if canImport(FoundationEssentials)
-@testable import FoundationEssentials
+import FoundationEssentials
 @testable import FoundationInternationalization
 #endif
 
@@ -28,12 +28,6 @@ import TestSupport
 #else
 import _RopeModule
 #endif
-
-extension AttributedString {
-    fileprivate var string: String {
-        String(self._guts.string)
-    }
-}
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class DateFormatStyleTests : XCTestCase {
@@ -492,11 +486,15 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         let date = Date(timeIntervalSinceReferenceDate: 639932672.0)
         let zhTW = Locale(identifier: "zh_TW")
 
-        XCTAssertEqual(date.formatted(.dateTime.weekday().locale(enUSLocale).attributed).string, "Mon")
-        XCTAssertEqual(date.formatted(.dateTime.weekday().locale(zhTW).attributed).string, "週一")
+        func test(_ attributedResult: AttributedString, _ expected: [Segment], file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(attributedResult, expected.attributedString, file: file, line: line)
+        }
 
-        XCTAssertEqual(date.formatted(.dateTime.weekday().attributed.locale(enUSLocale)).string, "Mon")
-        XCTAssertEqual(date.formatted(.dateTime.weekday().attributed.locale(zhTW)).string, "週一")
+        test(date.formatted(.dateTime.weekday().locale(enUSLocale).attributed), [("Mon", .weekday)])
+        test(date.formatted(.dateTime.weekday().locale(zhTW).attributed), [("週一", .weekday)])
+
+        test(date.formatted(.dateTime.weekday().attributed.locale(enUSLocale)), [("Mon", .weekday)])
+        test(date.formatted(.dateTime.weekday().attributed.locale(zhTW)),  [("週一", .weekday)])
     }
 
     func testFormattingWithPrefsOverride() {
@@ -934,7 +932,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
 
     func testMatchPartialRangesFromBeginning() {
         func verify(_ string: String, matches format: Date.FormatString, expectedMatch: String, expectedDate: TimeInterval, file: StaticString = #file, line: UInt = #line) {
-            let occurrenceRange = string.range(of: expectedMatch)!
+            let occurrenceRange = string._range(of: expectedMatch)!
             _verifyString(string, matches: format, start: string.startIndex, in: string.startIndex..<string.endIndex, expectedUpperBound: occurrenceRange.upperBound, expectedDate: Date(timeIntervalSinceReferenceDate: expectedDate), file: file, line: line)
         }
 


### PR DESCRIPTION
We continue disentangling the package from system Foundation API in this PR

- Use stdlib's `replacing(:with:)` instead of NSString's `replacingOccurrences(of:with:)`
- Move internal implementation of `_range(of:anchored:backwards:)` to _FoundationInternals. Update callsites to use this instead of NSString's `range(of:)` implementation.
