### PR TITLE
Implicit returns from single-expression

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -62,12 +62,12 @@ extension AttributeContainer {
     }
 
     public static subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
-        return Builder(container: AttributeContainer())
+        Builder(container: AttributeContainer())
     }
 
     @_disfavoredOverload
     public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
-        return Builder(container: self)
+        Builder(container: self)
     }
 
     public struct Builder<T: AttributedStringKey> : Sendable {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -100,11 +100,11 @@ extension AttributedString.Runs {
     }
 
     public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> {
-        return AttributesSlice1<T>(runs: self)
+        AttributesSlice1<T>(runs: self)
     }
 
     public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> {
-        return AttributesSlice1<T>(runs: self)
+        AttributesSlice1<T>(runs: self)
     }
 }
 
@@ -205,7 +205,7 @@ extension AttributedString.Runs {
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>
     ) -> AttributesSlice2<T, U> {
-        return AttributesSlice2<T, U>(runs: self)
+        AttributesSlice2<T, U>(runs: self)
     }
 
     public subscript <
@@ -215,7 +215,7 @@ extension AttributedString.Runs {
         _ t: T.Type,
         _ u: U.Type
     ) -> AttributesSlice2<T, U> {
-        return AttributesSlice2<T, U>(runs: self)
+        AttributesSlice2<T, U>(runs: self)
     }
 }
 
@@ -324,7 +324,7 @@ extension AttributedString.Runs {
         _ u: KeyPath<AttributeDynamicLookup, U>,
         _ v: KeyPath<AttributeDynamicLookup, V>
     ) -> AttributesSlice3<T, U, V> {
-        return AttributesSlice3<T, U, V>(runs: self)
+        AttributesSlice3<T, U, V>(runs: self)
     }
 
     public subscript <
@@ -336,7 +336,7 @@ extension AttributedString.Runs {
         _ u: U.Type,
         _ v: V.Type
     ) -> AttributesSlice3<T, U, V> {
-        return AttributesSlice3<T, U, V>(runs: self)
+        AttributesSlice3<T, U, V>(runs: self)
     }
 }
 
@@ -456,7 +456,7 @@ extension AttributedString.Runs {
         _ v: KeyPath<AttributeDynamicLookup, V>,
         _ w: KeyPath<AttributeDynamicLookup, W>
     ) -> AttributesSlice4<T, U, V, W> {
-        return AttributesSlice4<T, U, V, W>(runs: self)
+        AttributesSlice4<T, U, V, W>(runs: self)
     }
 
     public subscript <
@@ -470,7 +470,7 @@ extension AttributedString.Runs {
         _ v: V.Type,
         _ w: W.Type
     ) -> AttributesSlice4<T, U, V, W> {
-        return AttributesSlice4<T, U, V, W>(runs: self)
+        AttributesSlice4<T, U, V, W>(runs: self)
     }
 }
 
@@ -598,7 +598,7 @@ extension AttributedString.Runs {
         _ w: KeyPath<AttributeDynamicLookup, W>,
         _ x: KeyPath<AttributeDynamicLookup, X>
     ) -> AttributesSlice5<T, U, V, W, X> {
-        return AttributesSlice5<T, U, V, W, X>(runs: self)
+        AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 
     public subscript <
@@ -614,7 +614,7 @@ extension AttributedString.Runs {
         _ w: W.Type,
         _ x: X.Type
     ) -> AttributesSlice5<T, U, V, W, X> {
-        return AttributesSlice5<T, U, V, W, X>(runs: self)
+        AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 }
 
@@ -709,7 +709,7 @@ extension AttributedString.Runs {
 
     @_spi(AttributedString)
     public subscript(nsAttributedStringKeys keys: NSAttributedString.Key...) -> NSAttributesSlice {
-        return NSAttributesSlice(runs: self, keys: keys)
+        NSAttributesSlice(runs: self, keys: keys)
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -66,7 +66,7 @@ extension AttributedString.Runs.Run {
     internal var startIndex: AttributedString.Index { _range.lowerBound }
 
     internal var _attributes: _AttributeStorage {
-        return _internal.attributes
+        _internal.attributes
     }
     
     internal func run(clampedTo range: Range<AttributedString.Index>) -> Self {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -147,11 +147,11 @@ extension AttributedString.Runs: BidirectionalCollection {
     }
     
     public subscript(position: Index) -> Run {
-        return _guts.run(at: position, clampedBy: _range)
+        _guts.run(at: position, clampedBy: _range)
     }
     
     internal subscript(internal position: Index) -> _InternalRun {
-        return _guts.runs[position.rangeIndex]
+        _guts.runs[position.rangeIndex]
     }
     
     public subscript(position: AttributedString.Index) -> Run {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -213,11 +213,11 @@ extension AttributedString: AttributedStringProtocol {
     }
     
     public var startIndex : Index {
-        return _guts.startIndex
+        _guts.startIndex
     }
     
     public var endIndex : Index {
-        return _guts.endIndex
+        _guts.endIndex
     }
     
     @preconcurrency

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -35,7 +35,7 @@ extension AttributedString._AttributeStorage {
     }
 
     var constraintsInvolved: [AttributedString.AttributeRunBoundaries] {
-        return self.contents.values.compactMap(\.runBoundaries)
+        self.contents.values.compactMap(\.runBoundaries)
     }
     
     fileprivate mutating func matchStyle(of other: Self, for constraint: AttributedString.AttributeRunBoundaries) {

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -48,7 +48,7 @@ public extension EncodableAttributedStringKey where Value : Encodable {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public extension DecodableAttributedStringKey where Value : Decodable {
-    static func decode(from decoder: Decoder) throws -> Value { return try Value.init(from: decoder) }
+    static func decode(from decoder: Decoder) throws -> Value { try Value.init(from: decoder) }
 }
 
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringRunCoalescing.swift
@@ -134,7 +134,7 @@ extension AttributedString.Guts {
     }
     
     func run(containing location: Int, updateCache: Bool = true) -> AttributedString._InternalRun {
-        return runs[seekToRun(location: location, updateCache: updateCache).block]
+        runs[seekToRun(location: location, updateCache: updateCache).block]
     }
     
     func runAndLocation(containing location: Int) -> (run: AttributedString._InternalRun, location: Int) {

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -50,7 +50,7 @@ public struct AttributedSubstring: Sendable {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedSubstring {
     public var base: AttributedString {
-        return AttributedString(_guts)
+        AttributedString(_guts)
     }
 
 
@@ -153,15 +153,15 @@ extension AttributedSubstring : AttributedStringProtocol {
     }
 
     public var characters: AttributedString.CharacterView {
-        return AttributedString.CharacterView(_guts, in: _range)
+        AttributedString.CharacterView(_guts, in: _range)
     }
 
     public var unicodeScalars: AttributedString.UnicodeScalarView {
-        return AttributedString.UnicodeScalarView(_guts, in: _range)
+        AttributedString.UnicodeScalarView(_guts, in: _range)
     }
 
     public subscript(bounds: some RangeExpression<AttributedString.Index>) -> AttributedSubstring {
-        return AttributedSubstring(_guts, in: bounds.relative(to: characters))
+        AttributedSubstring(_guts, in: bounds.relative(to: characters))
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -59,7 +59,7 @@ public protocol ObjectiveCConvertibleAttributedStringKey : AttributedStringKey {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepresentable, Value.RawValue == Int, ObjectiveCValue == NSNumber {
     static func objectiveCValue(for value: Value) throws -> ObjectiveCValue {
-        return NSNumber(value: value.rawValue)
+        NSNumber(value: value.rawValue)
     }
     static func value(for object: ObjectiveCValue) throws -> Value {
         if let val = Value(rawValue: object.intValue) {
@@ -72,7 +72,7 @@ public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepre
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepresentable, Value.RawValue == String, ObjectiveCValue == NSString {
     static func objectiveCValue(for value: Value) throws -> ObjectiveCValue {
-        return value.rawValue as NSString
+        value.rawValue as NSString
     }
     static func value(for object: ObjectiveCValue) throws -> Value {
         if let val = Value(rawValue: object as String) {

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -69,7 +69,7 @@ extension AttributeScopes {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public extension AttributeDynamicLookup {
     subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes, T>) -> T {
-        return self[T.self]
+        self[T.self]
     }
 
     subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes.NumberFormatAttributes, T>) -> T { self[T.self] }

--- a/Sources/FoundationEssentials/Bundle+Stub.swift
+++ b/Sources/FoundationEssentials/Bundle+Stub.swift
@@ -15,9 +15,9 @@
 public struct Bundle: Hashable, Equatable, Sendable {
     public static let main: Bundle = Bundle()
 
-    public var localizations: [String] { return [] }
+    public var localizations: [String] { [] }
 
-    public var infoDictionary: [String : Any]? { return [:] }
+    public var infoDictionary: [String : Any]? { [:] }
 
     public static func preferredLocalizations(
         from localizationsArray: [String],

--- a/Sources/FoundationEssentials/CocoaError.swift
+++ b/Sources/FoundationEssentials/CocoaError.swift
@@ -21,10 +21,10 @@ public struct CocoaError : _BridgedStoredNSError {
         self._nsError = error
     }
     
-    public static var errorDomain: String { return NSCocoaErrorDomain }
+    public static var errorDomain: String { NSCocoaErrorDomain }
     
     public var hashValue: Int {
-        return _nsError.hashValue
+        _nsError.hashValue
     }
 }
 #else
@@ -98,26 +98,26 @@ extension CocoaError {
 public extension CocoaError {
 #if FOUNDATION_FRAMEWORK
     private var _nsUserInfo: [AnyHashable : Any] {
-        return (self as NSError).userInfo
+        (self as NSError).userInfo
     }
 #endif
 
     /// The file path associated with the error, if any.
     var filePath: String? {
 #if FOUNDATION_FRAMEWORK
-        return _nsUserInfo[NSFilePathErrorKey as NSString] as? String
+        _nsUserInfo[NSFilePathErrorKey as NSString] as? String
 #else
-        return userInfo["NSFilePathErrorKey"] as? String
+        userInfo["NSFilePathErrorKey"] as? String
 #endif
     }
 
     /// The string encoding associated with this error, if any.
     var stringEncoding: String.Encoding? {
 #if FOUNDATION_FRAMEWORK
-        return (_nsUserInfo[NSStringEncodingErrorKey as NSString] as? NSNumber)
+        (_nsUserInfo[NSStringEncodingErrorKey as NSString] as? NSNumber)
             .map { String.Encoding(rawValue: $0.uintValue) }
 #else
-        return (userInfo["NSStringEncodingErrorKey"] as? Int)
+        (userInfo["NSStringEncodingErrorKey"] as? Int)
             .map { String.Encoding(rawValue: UInt($0)) }
 #endif
     }
@@ -125,9 +125,9 @@ public extension CocoaError {
     /// The underlying error behind this error, if any.
     var underlying: Error? {
 #if FOUNDATION_FRAMEWORK
-        return _nsUserInfo[NSUnderlyingErrorKey as NSString] as? Error
+        _nsUserInfo[NSUnderlyingErrorKey as NSString] as? Error
 #else
-        return userInfo["NSUnderlyingErrorKey"] as? Error
+        userInfo["NSUnderlyingErrorKey"] as? Error
 #endif
     }
 
@@ -164,9 +164,9 @@ public extension CocoaError {
     /// The URL associated with this error, if any.
     var url: URL? {
 #if FOUNDATION_FRAMEWORK
-        return _nsUserInfo[NSURLErrorKey as NSString] as? URL
+        _nsUserInfo[NSURLErrorKey as NSString] as? URL
 #else
-        return userInfo["NSURLErrorKey"] as? URL
+        userInfo["NSURLErrorKey"] as? URL
 #endif
     }
 }
@@ -211,10 +211,10 @@ public protocol LocalizedError : Error {
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public extension LocalizedError {
-    var errorDescription: String? { return nil }
-    var failureReason: String? { return nil }
-    var recoverySuggestion: String? { return nil }
-    var helpAnchor: String? { return nil }
+    var errorDescription: String? { nil }
+    var failureReason: String? { nil }
+    var recoverySuggestion: String? { nil }
+    var helpAnchor: String? { nil }
 }
 
 /// Describes an error type that specifically provides a domain, code,
@@ -235,33 +235,33 @@ public protocol CustomNSError : Error {
 public extension CustomNSError {
     /// Default domain of the error.
     static var errorDomain: String {
-        return String(reflecting: self)
+        String(reflecting: self)
     }
 
     /// The error code within the given domain.
     var errorCode: Int {
-        return _getDefaultErrorCode(self)
+        _getDefaultErrorCode(self)
     }
 
     /// The default user-info dictionary.
     var errorUserInfo: [String : Any] {
-        return [:]
+        [:]
     }
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public extension Error where Self : CustomNSError {
     /// Default implementation for customized NSErrors.
-    var _domain: String { return Self.errorDomain }
+    var _domain: String { Self.errorDomain }
 
     /// Default implementation for customized NSErrors.
-    var _code: Int { return self.errorCode }
+    var _code: Int { self.errorCode }
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public extension Error where Self: CustomNSError, Self: RawRepresentable, Self.RawValue: FixedWidthInteger {
     /// Default implementation for customized NSErrors.
-    var _code: Int { return self.errorCode }
+    var _code: Int { self.errorCode }
 }
 
 #if FOUNDATION_FRAMEWORK
@@ -269,7 +269,7 @@ public extension Error where Self: CustomNSError, Self: RawRepresentable, Self.R
 public extension Error {
     /// Retrieve the localized description for this error.
     var localizedDescription: String {
-        return (self as NSError).localizedDescription
+        (self as NSError).localizedDescription
     }
 }
 #endif

--- a/Sources/FoundationEssentials/Data/Collections+DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/Collections+DataProtocol.swift
@@ -15,21 +15,21 @@
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Array: DataProtocol where Element == UInt8 {
     public var regions: CollectionOfOne<Array<UInt8>> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension ArraySlice: DataProtocol where Element == UInt8 {
     public var regions: CollectionOfOne<ArraySlice<UInt8>> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension ContiguousArray: DataProtocol where Element == UInt8 {
     public var regions: CollectionOfOne<ContiguousArray<UInt8>> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 }
 
@@ -38,14 +38,14 @@ extension ContiguousArray: DataProtocol where Element == UInt8 {
 //     public typealias Regions = CollectionOfOne<Data>
 //
 //     public var regions: CollectionOfOne<Data> {
-//         return CollectionOfOne<Data>(Data(self))
+//         CollectionOfOne<Data>(Data(self))
 //     }
 // }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension EmptyCollection : DataProtocol where Element == UInt8 {
     public var regions: EmptyCollection<Data> {
-        return EmptyCollection<Data>()
+        EmptyCollection<Data>()
     }
 }
 

--- a/Sources/FoundationEssentials/Data/ContiguousBytes.swift
+++ b/Sources/FoundationEssentials/Data/ContiguousBytes.swift
@@ -45,7 +45,7 @@ extension ContiguousArray : ContiguousBytes where Element == UInt8 { }
 extension UnsafeRawBufferPointer : ContiguousBytes {
     @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        return try body(self)
+        try body(self)
     }
 }
 
@@ -53,7 +53,7 @@ extension UnsafeRawBufferPointer : ContiguousBytes {
 extension UnsafeMutableRawBufferPointer : ContiguousBytes {
     @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        return try body(UnsafeRawBufferPointer(self))
+        try body(UnsafeRawBufferPointer(self))
     }
 }
 
@@ -62,7 +62,7 @@ extension UnsafeMutableRawBufferPointer : ContiguousBytes {
 extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
     @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        return try body(UnsafeRawBufferPointer(self))
+        try body(UnsafeRawBufferPointer(self))
     }
 }
 
@@ -71,7 +71,7 @@ extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
 extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
     @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        return try body(UnsafeRawBufferPointer(self))
+        try body(UnsafeRawBufferPointer(self))
     }
 }
 
@@ -80,7 +80,7 @@ extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
 extension EmptyCollection : ContiguousBytes where Element == UInt8 {
     @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        return try body(UnsafeRawBufferPointer(start: nil, count: 0))
+        try body(UnsafeRawBufferPointer(start: nil, count: 0))
     }
 }
 

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -27,14 +27,14 @@ internal func __DataInvokeDeallocatorVirtualMemory(_ mem: UnsafeMutableRawPointe
 import Glibc
 
 private func malloc_good_size(_ size: Int) -> Int {
-    return size
+    size
 }
 
 #elseif canImport(ucrt)
 import ucrt
 
 private func malloc_good_size(_ size: Int) -> Int {
-    return size
+    size
 }
 
 #endif
@@ -111,7 +111,7 @@ internal final class __DataStorage : @unchecked Sendable {
     }
 
     static func reallocate(_ ptr: UnsafeMutableRawPointer, _ newSize: Int) -> UnsafeMutableRawPointer? {
-        return realloc(ptr, newSize);
+        realloc(ptr, newSize);
     }
 #endif // !FOUNDATION_FRAMEWORK
 
@@ -134,7 +134,7 @@ internal final class __DataStorage : @unchecked Sendable {
 
     @inlinable // This is @inlinable as trivially forwarding, and does not escape the _DataStorage boundary layer.
     static func shouldAllocateCleared(_ size: Int) -> Bool {
-        return (size > (128 * 1024))
+        (size > (128 * 1024))
     }
 
     @usableFromInline var _bytes: UnsafeMutableRawPointer?
@@ -146,29 +146,29 @@ internal final class __DataStorage : @unchecked Sendable {
 
     @inlinable // This is @inlinable as trivially computable.
     var bytes: UnsafeRawPointer? {
-        return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
+        UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
     @discardableResult
     func withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        return try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
+        try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
     @discardableResult
     func withUnsafeMutableBytes<Result>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
-        return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
+        try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
     }
 
     @inlinable // This is @inlinable as trivially computable.
     var mutableBytes: UnsafeMutableRawPointer? {
-        return _bytes?.advanced(by: -_offset)
+        _bytes?.advanced(by: -_offset)
     }
 
     @inlinable // This is @inlinable as trivially computable.
     var capacity: Int {
-        return _capacity
+        _capacity
     }
 
     @inlinable // This is @inlinable as trivially computable.
@@ -185,7 +185,7 @@ internal final class __DataStorage : @unchecked Sendable {
     var isExternallyOwned: Bool {
         // all __DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
         // anything with 0 capacity means that we have not allocated this pointer and consequently mutation is not ours to make.
-        return _capacity == 0
+        _capacity == 0
     }
 
     @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
@@ -337,7 +337,7 @@ internal final class __DataStorage : @unchecked Sendable {
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func get(_ index: Int) -> UInt8 {
         // index must have already been validated by the caller
-        return _bytes!.load(fromByteOffset: index - _offset, as: UInt8.self)
+        _bytes!.load(fromByteOffset: index - _offset, as: UInt8.self)
     }
 
     @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
@@ -520,7 +520,7 @@ internal final class __DataStorage : @unchecked Sendable {
 
     @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
     func mutableCopy(_ range: Range<Int>) -> __DataStorage {
-        return __DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
+        __DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
     }
 }
 
@@ -551,11 +551,11 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially computable.
         static func canStore(count: Int) -> Bool {
-            return count <= MemoryLayout<Buffer>.size
+            count <= MemoryLayout<Buffer>.size
         }
 
         static var maximumCapacity: Int {
-            return MemoryLayout<Buffer>.size
+            MemoryLayout<Buffer>.size
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
@@ -603,7 +603,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially computable.
         var capacity: Int {
-            return MemoryLayout<Buffer>.size
+            MemoryLayout<Buffer>.size
         }
 
         @inlinable // This is @inlinable as trivially computable.
@@ -623,12 +623,12 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially computable.
         var startIndex: Int {
-            return 0
+            0
         }
 
         @inlinable // This is @inlinable as trivially computable.
         var endIndex: Int {
-            return count
+            count
         }
 
         @inlinable // This is @inlinable as a generic, trivially forwarding function.
@@ -778,7 +778,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially computable.
         static func canStore(count: Int) -> Bool {
-            return count < HalfInt.max
+            count < HalfInt.max
         }
 
         @inlinable // This is @inlinable as a convenience initializer.
@@ -850,17 +850,17 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially computable.
         var startIndex: Int {
-            return Int(slice.lowerBound)
+            Int(slice.lowerBound)
         }
 
         @inlinable // This is @inlinable as trivially computable.
         var endIndex: Int {
-            return Int(slice.upperBound)
+            Int(slice.upperBound)
         }
 
         @inlinable // This is @inlinable as trivially computable.
         var capacity: Int {
-            return storage.capacity
+            storage.capacity
         }
 
         @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
@@ -904,7 +904,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as a generic, trivially forwarding function.
         func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-            return try storage.withUnsafeBytes(in: range, apply: apply)
+            try storage.withUnsafeBytes(in: range, apply: apply)
         }
 
         @inlinable // This is @inlinable as a generic, trivially forwarding function.
@@ -995,17 +995,17 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
         var lowerBound: Int {
-            return range.lowerBound
+            range.lowerBound
         }
 
         @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
         var upperBound: Int {
-            return range.upperBound
+            range.upperBound
         }
 
         @inlinable @inline(__always) // This is @inlinable as trivially computable.
         var count: Int {
-            return range.upperBound - range.lowerBound
+            range.upperBound - range.lowerBound
         }
 
         @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
@@ -1069,17 +1069,17 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as trivially forwarding.
         var startIndex: Int {
-            return slice.range.lowerBound
+            slice.range.lowerBound
         }
 
         @inlinable // This is @inlinable as trivially forwarding.
         var endIndex: Int {
-          return slice.range.upperBound
+          slice.range.upperBound
         }
 
         @inlinable // This is @inlinable as trivially forwarding.
         var capacity: Int {
-            return storage.capacity
+            storage.capacity
         }
 
         @inlinable // This is @inlinable as trivially computable.
@@ -1109,12 +1109,12 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
         @inlinable // This is @inlinable as it is trivially forwarding.
         var range: Range<Int> {
-            return slice.range
+            slice.range
         }
 
         @inlinable // This is @inlinable as a generic, trivially forwarding function.
         func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-            return try storage.withUnsafeBytes(in: range, apply: apply)
+            try storage.withUnsafeBytes(in: range, apply: apply)
         }
 
         @inlinable // This is @inlinable as a generic, trivially forwarding function.
@@ -1965,7 +1965,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
     @inlinable // This is @inlinable as trivially computable.
     public var regions: CollectionOfOne<Data> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 
     /// Access the bytes in the data.
@@ -1980,7 +1980,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
     @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
-        return try _representation.withUnsafeBytes(body)
+        try _representation.withUnsafeBytes(body)
     }
 
     /// Mutate the bytes in the data.
@@ -1996,7 +1996,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
     @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
-        return try _representation.withUnsafeMutableBytes(body)
+        try _representation.withUnsafeMutableBytes(body)
     }
 
     // MARK: -
@@ -2332,12 +2332,12 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
     @inlinable // This is @inlinable as trivially computable.
     public func index(before i: Index) -> Index {
-        return i - 1
+        i - 1
     }
 
     @inlinable // This is @inlinable as trivially computable.
     public func index(after i: Index) -> Index {
-        return i + 1
+        i + 1
     }
 
     @inlinable // This is @inlinable as trivially computable.
@@ -2364,7 +2364,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     /// The iterator will increment byte-by-byte.
     @inlinable // This is @inlinable as trivially computable.
     public func makeIterator() -> Data.Iterator {
-        return Iterator(self, at: startIndex)
+        Iterator(self, at: startIndex)
     }
 
     public struct Iterator : IteratorProtocol, Sendable {
@@ -2566,12 +2566,12 @@ extension Data {
 extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     /// A human-readable description for the data.
     public var description: String {
-        return "\(self.count) bytes"
+        "\(self.count) bytes"
     }
 
     /// A human-readable debug description for the data.
     public var debugDescription: String {
-        return self.description
+        self.description
     }
 
     public var customMirror: Mirror {

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -87,31 +87,31 @@ public protocol MutableDataProtocol : DataProtocol, MutableCollection, RangeRepl
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension DataProtocol {
     public func firstRange<D: DataProtocol>(of data: D) -> Range<Index>? {
-        return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
+        self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
     }
 
     public func lastRange<D: DataProtocol>(of data: D) -> Range<Index>? {
-        return self.lastRange(of: data, in: self.startIndex ..< self.endIndex)
+        self.lastRange(of: data, in: self.startIndex ..< self.endIndex)
     }
 
     @discardableResult
     public func copyBytes(to ptr: UnsafeMutableRawBufferPointer) -> Int {
-        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+        copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
     }
 
     @discardableResult
     public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>) -> Int {
-        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+        copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
     }
 
     @discardableResult
     public func copyBytes(to ptr: UnsafeMutableRawBufferPointer, count: Int) -> Int {
-        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+        copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
     }
 
     @discardableResult
     public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int {
-        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+        copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
     }
 
     @discardableResult
@@ -144,7 +144,7 @@ extension DataProtocol {
 
     @discardableResult
     public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) -> Int where R.Bound == Index {
-        return self.copyBytes(to: UnsafeMutableRawBufferPointer(start: ptr.baseAddress, count: ptr.count * MemoryLayout<DestinationType>.stride), from: range)
+        self.copyBytes(to: UnsafeMutableRawBufferPointer(start: ptr.baseAddress, count: ptr.count * MemoryLayout<DestinationType>.stride), from: range)
     }
 
     private func matches<D: DataProtocol>(_ data: D, from index: Index) -> Bool {

--- a/Sources/FoundationEssentials/Data/Pointers+DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/Pointers+DataProtocol.swift
@@ -14,13 +14,13 @@
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeRawBufferPointer : DataProtocol {
     public var regions: CollectionOfOne<UnsafeRawBufferPointer> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 }
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension UnsafeBufferPointer : DataProtocol where Element == UInt8 {
     public var regions: CollectionOfOne<UnsafeBufferPointer<Element>> {
-        return CollectionOfOne(self)
+        CollectionOfOne(self)
     }
 }

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -37,7 +37,7 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
 
     /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time.
     public static var timeIntervalSinceReferenceDate : TimeInterval {
-        return Self.getCurrentAbsoluteTime()
+        Self.getCurrentAbsoluteTime()
     }
 
     /// Returns a `Date` initialized to the current date and time.
@@ -91,7 +91,7 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     - SeeAlso: `timeIntervalSinceReferenceDate`
     */
     public func timeIntervalSince(_ date: Date) -> TimeInterval {
-        return self.timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate
+        self.timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate
     }
 
     /**
@@ -104,7 +104,7 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     - SeeAlso: `timeIntervalSinceReferenceDate`
     */
     public var timeIntervalSinceNow: TimeInterval {
-        return self.timeIntervalSinceReferenceDate - Self.getCurrentAbsoluteTime()
+        self.timeIntervalSinceReferenceDate - Self.getCurrentAbsoluteTime()
     }
 
     /**
@@ -117,7 +117,7 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     - SeeAlso: `timeIntervalSinceReferenceDate`
     */
     public var timeIntervalSince1970: TimeInterval {
-        return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
+        self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
     }
 
     /// Return a new `Date` by adding a `TimeInterval` to this `Date`.
@@ -125,7 +125,7 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     /// - parameter timeInterval: The value to add, in seconds.
     /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
     public func addingTimeInterval(_ timeInterval: TimeInterval) -> Date {
-        return self + timeInterval
+        self + timeInterval
     }
 
     /// Add a `TimeInterval` to this `Date`.
@@ -171,27 +171,27 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
 
     /// Returns true if the two `Date` values represent the same point in time.
     public static func ==(lhs: Date, rhs: Date) -> Bool {
-        return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+        lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
     }
 
     /// Returns true if the left hand `Date` is earlier in time than the right hand `Date`.
     public static func <(lhs: Date, rhs: Date) -> Bool {
-        return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+        lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
     }
 
     /// Returns true if the left hand `Date` is later in time than the right hand `Date`.
     public static func >(lhs: Date, rhs: Date) -> Bool {
-        return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
+        lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
     }
 
     /// Returns a `Date` with a specified amount of time added to it.
     public static func +(lhs: Date, rhs: TimeInterval) -> Date {
-        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
+        Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
     }
 
     /// Returns a `Date` with a specified amount of time subtracted from it.
     public static func -(lhs: Date, rhs: TimeInterval) -> Date {
-        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
+        Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
     }
 
     /// Add a `TimeInterval` to a `Date`.
@@ -286,7 +286,7 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
 #endif // !FOUNDATION_FRAMEWORK
 
     public var debugDescription: String {
-        return description
+        description
     }
 
     public var customMirror: Mirror {
@@ -319,7 +319,7 @@ extension Date : ReferenceConvertible, _ObjectiveCBridgeable {
 
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSDate {
-        return NSDate(timeIntervalSinceReferenceDate: _time)
+        NSDate(timeIntervalSinceReferenceDate: _time)
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) {
@@ -346,7 +346,7 @@ extension NSDate : _HasCustomAnyHashableRepresentation {
     // Must be @nonobjc to avoid infinite recursion during bridging.
     @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as Date)
+        AnyHashable(self as Date)
     }
 }
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/DateInterval.swift
+++ b/Sources/FoundationEssentials/DateInterval.swift
@@ -98,7 +98,7 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
 
     /// Returns `true` if `self` intersects the `dateInterval`.
     public func intersects(_ dateInterval: DateInterval) -> Bool {
-        return contains(dateInterval.start) || contains(dateInterval.end) || dateInterval.contains(start) || dateInterval.contains(end)
+        contains(dateInterval.start) || contains(dateInterval.end) || dateInterval.contains(start) || dateInterval.contains(end)
     }
 
     /// Returns a DateInterval that represents the interval where the given date interval and the current instance intersect.
@@ -167,11 +167,11 @@ public struct DateInterval : Comparable, Hashable, Codable, Sendable {
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 extension DateInterval : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     public var description: String {
-        return "\(start) to \(end)"
+        "\(start) to \(end)"
     }
 
     public var debugDescription: String {
-        return description
+        description
     }
 
     public var customMirror: Mirror {
@@ -190,12 +190,12 @@ extension DateInterval : ReferenceConvertible, _ObjectiveCBridgeable {
     public typealias ReferenceType = NSDateInterval
 
     public static func _getObjectiveCType() -> Any.Type {
-        return NSDateInterval.self
+        NSDateInterval.self
     }
 
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSDateInterval {
-        return NSDateInterval(start: start, duration: duration)
+        NSDateInterval(start: start, duration: duration)
     }
 
     public static func _forceBridgeFromObjectiveC(_ dateInterval: NSDateInterval, result: inout DateInterval?) {
@@ -222,7 +222,7 @@ extension NSDateInterval : _HasCustomAnyHashableRepresentation {
     // Must be @nonobjc to avoid infinite recursion during bridging.
     @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as DateInterval)
+        AnyHashable(self as DateInterval)
     }
 }
 #endif

--- a/Sources/FoundationEssentials/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/ErrorCodes+POSIX.swift
@@ -21,10 +21,10 @@ public struct POSIXError : _BridgedStoredNSError {
         self._nsError = error
     }
 
-    public static var errorDomain: String { return NSPOSIXErrorDomain }
+    public static var errorDomain: String { NSPOSIXErrorDomain }
 
     public var hashValue: Int {
-        return _nsError.hashValue
+        _nsError.hashValue
     }
 
     public typealias Code = POSIXErrorCode
@@ -372,10 +372,10 @@ extension POSIXErrorCode : Equatable, Hashable, RawRepresentable {
 public struct POSIXError : _StoredError {
     public let code: Code
 
-    public static var errorDomain: String { return "NSPOSIXErrorDomain" }
+    public static var errorDomain: String { "NSPOSIXErrorDomain" }
 
     public var hashValue: Int {
-        return code.hashValue
+        code.hashValue
     }
 
     public typealias Code = POSIXErrorCode
@@ -390,468 +390,468 @@ extension POSIXErrorCode : _ErrorCodeProtocol {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension POSIXError {
     public static var EPERM: POSIXErrorCode {
-        return .EPERM
+        .EPERM
     }
 
     /// No such file or directory.
     public static var ENOENT: POSIXErrorCode {
-        return .ENOENT
+        .ENOENT
     }
 
     /// No such process.
     public static var ESRCH: POSIXErrorCode {
-        return .ESRCH
+        .ESRCH
     }
 
     /// Interrupted system call.
     public static var EINTR: POSIXErrorCode {
-        return .EINTR
+        .EINTR
     }
 
     /// Input/output error.
     public static var EIO: POSIXErrorCode {
-        return .EIO
+        .EIO
     }
 
     /// Device not configured.
     public static var ENXIO: POSIXErrorCode {
-        return .ENXIO
+        .ENXIO
     }
 
     /// Argument list too long.
     public static var E2BIG: POSIXErrorCode {
-        return .E2BIG
+        .E2BIG
     }
 
     /// Exec format error.
     public static var ENOEXEC: POSIXErrorCode {
-        return .ENOEXEC
+        .ENOEXEC
     }
 
     /// Bad file descriptor.
     public static var EBADF: POSIXErrorCode {
-        return .EBADF
+        .EBADF
     }
 
     /// No child processes.
     public static var ECHILD: POSIXErrorCode {
-        return .ECHILD
+        .ECHILD
     }
 
     /// Resource deadlock avoided.
     public static var EDEADLK: POSIXErrorCode {
-        return .EDEADLK
+        .EDEADLK
     }
 
     /// Cannot allocate memory.
     public static var ENOMEM: POSIXErrorCode {
-        return .ENOMEM
+        .ENOMEM
     }
 
     /// Permission denied.
     public static var EACCES: POSIXErrorCode {
-        return .EACCES
+        .EACCES
     }
 
     /// Bad address.
     public static var EFAULT: POSIXErrorCode {
-        return .EFAULT
+        .EFAULT
     }
 
     /// Block device required.
     public static var ENOTBLK: POSIXErrorCode {
-        return .ENOTBLK
+        .ENOTBLK
     }
     /// Device / Resource busy.
     public static var EBUSY: POSIXErrorCode {
-        return .EBUSY
+        .EBUSY
     }
     /// File exists.
     public static var EEXIST: POSIXErrorCode {
-        return .EEXIST
+        .EEXIST
     }
     /// Cross-device link.
     public static var EXDEV: POSIXErrorCode {
-        return .EXDEV
+        .EXDEV
     }
     /// Operation not supported by device.
     public static var ENODEV: POSIXErrorCode {
-        return .ENODEV
+        .ENODEV
     }
     /// Not a directory.
     public static var ENOTDIR: POSIXErrorCode {
-        return .ENOTDIR
+        .ENOTDIR
     }
     /// Is a directory.
     public static var EISDIR: POSIXErrorCode {
-        return .EISDIR
+        .EISDIR
     }
     /// Invalid argument.
     public static var EINVAL: POSIXErrorCode {
-        return .EINVAL
+        .EINVAL
     }
     /// Too many open files in system.
     public static var ENFILE: POSIXErrorCode {
-        return .ENFILE
+        .ENFILE
     }
     /// Too many open files.
     public static var EMFILE: POSIXErrorCode {
-        return .EMFILE
+        .EMFILE
     }
     /// Inappropriate ioctl for device.
     public static var ENOTTY: POSIXErrorCode {
-        return .ENOTTY
+        .ENOTTY
     }
     /// Text file busy.
     public static var ETXTBSY: POSIXErrorCode {
-        return .ETXTBSY
+        .ETXTBSY
     }
     /// File too large.
     public static var EFBIG: POSIXErrorCode {
-        return .EFBIG
+        .EFBIG
     }
     /// No space left on device.
     public static var ENOSPC: POSIXErrorCode {
-        return .ENOSPC
+        .ENOSPC
     }
     /// Illegal seek.
     public static var ESPIPE: POSIXErrorCode {
-        return .ESPIPE
+        .ESPIPE
     }
     /// Read-only file system.
     public static var EROFS: POSIXErrorCode {
-        return .EROFS
+        .EROFS
     }
     /// Too many links.
     public static var EMLINK: POSIXErrorCode {
-        return .EMLINK
+        .EMLINK
     }
     /// Broken pipe.
     public static var EPIPE: POSIXErrorCode {
-        return .EPIPE
+        .EPIPE
     }
 
     /// math software.
     /// Numerical argument out of domain.
     public static var EDOM: POSIXErrorCode {
-        return .EDOM
+        .EDOM
     }
     /// Result too large.
     public static var ERANGE: POSIXErrorCode {
-        return .ERANGE
+        .ERANGE
     }
 
     /// non-blocking and interrupt i/o.
     /// Resource temporarily unavailable.
     public static var EAGAIN: POSIXErrorCode {
-        return .EAGAIN
+        .EAGAIN
     }
     /// Operation would block.
     public static var EWOULDBLOCK: POSIXErrorCode {
-        return .EWOULDBLOCK
+        .EWOULDBLOCK
     }
     /// Operation now in progress.
     public static var EINPROGRESS: POSIXErrorCode {
-        return .EINPROGRESS
+        .EINPROGRESS
     }
     /// Operation already in progress.
     public static var EALREADY: POSIXErrorCode {
-        return .EALREADY
+        .EALREADY
     }
 
     /// ipc/network software -- argument errors.
     /// Socket operation on non-socket.
     public static var ENOTSOCK: POSIXErrorCode {
-        return .ENOTSOCK
+        .ENOTSOCK
     }
     /// Destination address required.
     public static var EDESTADDRREQ: POSIXErrorCode {
-        return .EDESTADDRREQ
+        .EDESTADDRREQ
     }
     /// Message too long.
     public static var EMSGSIZE: POSIXErrorCode {
-        return .EMSGSIZE
+        .EMSGSIZE
     }
     /// Protocol wrong type for socket.
     public static var EPROTOTYPE: POSIXErrorCode {
-        return .EPROTOTYPE
+        .EPROTOTYPE
     }
     /// Protocol not available.
     public static var ENOPROTOOPT: POSIXErrorCode {
-        return .ENOPROTOOPT
+        .ENOPROTOOPT
     }
     /// Protocol not supported.
     public static var EPROTONOSUPPORT: POSIXErrorCode {
-        return .EPROTONOSUPPORT
+        .EPROTONOSUPPORT
     }
     /// Socket type not supported.
     public static var ESOCKTNOSUPPORT: POSIXErrorCode {
-        return .ESOCKTNOSUPPORT
+        .ESOCKTNOSUPPORT
     }
     /// Operation not supported.
     public static var ENOTSUP: POSIXErrorCode {
-        return .ENOTSUP
+        .ENOTSUP
     }
     /// Protocol family not supported.
     public static var EPFNOSUPPORT: POSIXErrorCode {
-        return .EPFNOSUPPORT
+        .EPFNOSUPPORT
     }
     /// Address family not supported by protocol family.
     public static var EAFNOSUPPORT: POSIXErrorCode {
-        return .EAFNOSUPPORT
+        .EAFNOSUPPORT
     }
 
     /// Address already in use.
     public static var EADDRINUSE: POSIXErrorCode {
-        return .EADDRINUSE
+        .EADDRINUSE
     }
     /// Can't assign requested address.
     public static var EADDRNOTAVAIL: POSIXErrorCode {
-        return .EADDRNOTAVAIL
+        .EADDRNOTAVAIL
     }
 
     /// ipc/network software -- operational errors
     /// Network is down.
     public static var ENETDOWN: POSIXErrorCode {
-        return .ENETDOWN
+        .ENETDOWN
     }
     /// Network is unreachable.
     public static var ENETUNREACH: POSIXErrorCode {
-        return .ENETUNREACH
+        .ENETUNREACH
     }
     /// Network dropped connection on reset.
     public static var ENETRESET: POSIXErrorCode {
-        return .ENETRESET
+        .ENETRESET
     }
     /// Software caused connection abort.
     public static var ECONNABORTED: POSIXErrorCode {
-        return .ECONNABORTED
+        .ECONNABORTED
     }
     /// Connection reset by peer.
     public static var ECONNRESET: POSIXErrorCode {
-        return .ECONNRESET
+        .ECONNRESET
     }
     /// No buffer space available.
     public static var ENOBUFS: POSIXErrorCode {
-        return .ENOBUFS
+        .ENOBUFS
     }
     /// Socket is already connected.
     public static var EISCONN: POSIXErrorCode {
-        return .EISCONN
+        .EISCONN
     }
     /// Socket is not connected.
     public static var ENOTCONN: POSIXErrorCode {
-        return .ENOTCONN
+        .ENOTCONN
     }
     /// Can't send after socket shutdown.
     public static var ESHUTDOWN: POSIXErrorCode {
-        return .ESHUTDOWN
+        .ESHUTDOWN
     }
     /// Too many references: can't splice.
     public static var ETOOMANYREFS: POSIXErrorCode {
-        return .ETOOMANYREFS
+        .ETOOMANYREFS
     }
     /// Operation timed out.
     public static var ETIMEDOUT: POSIXErrorCode {
-        return .ETIMEDOUT
+        .ETIMEDOUT
     }
     /// Connection refused.
     public static var ECONNREFUSED: POSIXErrorCode {
-        return .ECONNREFUSED
+        .ECONNREFUSED
     }
 
     /// Too many levels of symbolic links.
     public static var ELOOP: POSIXErrorCode {
-        return .ELOOP
+        .ELOOP
     }
     /// File name too long.
     public static var ENAMETOOLONG: POSIXErrorCode {
-        return .ENAMETOOLONG
+        .ENAMETOOLONG
     }
 
     /// Host is down.
     public static var EHOSTDOWN: POSIXErrorCode {
-        return .EHOSTDOWN
+        .EHOSTDOWN
     }
     /// No route to host.
     public static var EHOSTUNREACH: POSIXErrorCode {
-        return .EHOSTUNREACH
+        .EHOSTUNREACH
     }
     /// Directory not empty.
     public static var ENOTEMPTY: POSIXErrorCode {
-        return .ENOTEMPTY
+        .ENOTEMPTY
     }
 
     /// quotas & mush.
     /// Too many processes.
     public static var EPROCLIM: POSIXErrorCode {
-        return .EPROCLIM
+        .EPROCLIM
     }
     /// Too many users.
     public static var EUSERS: POSIXErrorCode {
-        return .EUSERS
+        .EUSERS
     }
     /// Disc quota exceeded.
     public static var EDQUOT: POSIXErrorCode {
-        return .EDQUOT
+        .EDQUOT
     }
 
     /// Network File System.
     /// Stale NFS file handle.
     public static var ESTALE: POSIXErrorCode {
-        return .ESTALE
+        .ESTALE
     }
     /// Too many levels of remote in path.
     public static var EREMOTE: POSIXErrorCode {
-        return .EREMOTE
+        .EREMOTE
     }
     /// RPC struct is bad.
     public static var EBADRPC: POSIXErrorCode {
-        return .EBADRPC
+        .EBADRPC
     }
     /// RPC version wrong.
     public static var ERPCMISMATCH: POSIXErrorCode {
-        return .ERPCMISMATCH
+        .ERPCMISMATCH
     }
     /// RPC prog. not avail.
     public static var EPROGUNAVAIL: POSIXErrorCode {
-        return .EPROGUNAVAIL
+        .EPROGUNAVAIL
     }
     /// Program version wrong.
     public static var EPROGMISMATCH: POSIXErrorCode {
-        return .EPROGMISMATCH
+        .EPROGMISMATCH
     }
     /// Bad procedure for program.
     public static var EPROCUNAVAIL: POSIXErrorCode {
-        return .EPROCUNAVAIL
+        .EPROCUNAVAIL
     }
 
     /// No locks available.
     public static var ENOLCK: POSIXErrorCode {
-        return .ENOLCK
+        .ENOLCK
     }
     /// Function not implemented.
     public static var ENOSYS: POSIXErrorCode {
-        return .ENOSYS
+        .ENOSYS
     }
 
     /// Inappropriate file type or format.
     public static var EFTYPE: POSIXErrorCode {
-        return .EFTYPE
+        .EFTYPE
     }
     /// Authentication error.
     public static var EAUTH: POSIXErrorCode {
-        return .EAUTH
+        .EAUTH
     }
     /// Need authenticator.
     public static var ENEEDAUTH: POSIXErrorCode {
-        return .ENEEDAUTH
+        .ENEEDAUTH
     }
 
     /// Intelligent device errors.
     /// Device power is off.
     public static var EPWROFF: POSIXErrorCode {
-        return .EPWROFF
+        .EPWROFF
     }
     /// Device error, e.g. paper out.
     public static var EDEVERR: POSIXErrorCode {
-        return .EDEVERR
+        .EDEVERR
     }
 
     /// Value too large to be stored in data type.
     public static var EOVERFLOW: POSIXErrorCode {
-        return .EOVERFLOW
+        .EOVERFLOW
     }
 
     /// Program loading errors.
     /// Bad executable.
     public static var EBADEXEC: POSIXErrorCode {
-        return .EBADEXEC
+        .EBADEXEC
     }
     /// Bad CPU type in executable.
     public static var EBADARCH: POSIXErrorCode {
-        return .EBADARCH
+        .EBADARCH
     }
     /// Shared library version mismatch.
     public static var ESHLIBVERS: POSIXErrorCode {
-        return .ESHLIBVERS
+        .ESHLIBVERS
     }
     /// Malformed Macho file.
     public static var EBADMACHO: POSIXErrorCode {
-        return .EBADMACHO
+        .EBADMACHO
     }
 
     /// Operation canceled.
     public static var ECANCELED: POSIXErrorCode {
-        return .ECANCELED
+        .ECANCELED
     }
 
     /// Identifier removed.
     public static var EIDRM: POSIXErrorCode {
-        return .EIDRM
+        .EIDRM
     }
     /// No message of desired type.
     public static var ENOMSG: POSIXErrorCode {
-        return .ENOMSG
+        .ENOMSG
     }
     /// Illegal byte sequence.
     public static var EILSEQ: POSIXErrorCode {
-        return .EILSEQ
+        .EILSEQ
     }
     /// Attribute not found.
     public static var ENOATTR: POSIXErrorCode {
-        return .ENOATTR
+        .ENOATTR
     }
 
     /// Bad message.
     public static var EBADMSG: POSIXErrorCode {
-        return .EBADMSG
+        .EBADMSG
     }
     /// Reserved.
     public static var EMULTIHOP: POSIXErrorCode {
-        return .EMULTIHOP
+        .EMULTIHOP
     }
     /// No message available on STREAM.
     public static var ENODATA: POSIXErrorCode {
-        return .ENODATA
+        .ENODATA
     }
     /// Reserved.
     public static var ENOLINK: POSIXErrorCode {
-        return .ENOLINK
+        .ENOLINK
     }
     /// No STREAM resources.
     public static var ENOSR: POSIXErrorCode {
-        return .ENOSR
+        .ENOSR
     }
     /// Not a STREAM.
     public static var ENOSTR: POSIXErrorCode {
-        return .ENOSTR
+        .ENOSTR
     }
     /// Protocol error.
     public static var EPROTO: POSIXErrorCode {
-        return .EPROTO
+        .EPROTO
     }
     /// STREAM ioctl timeout.
     public static var ETIME: POSIXErrorCode {
-        return .ETIME
+        .ETIME
     }
 
     /// No such policy registered.
     public static var ENOPOLICY: POSIXErrorCode {
-        return .ENOPOLICY
+        .ENOPOLICY
     }
 
     /// State not recoverable.
     public static var ENOTRECOVERABLE: POSIXErrorCode {
-        return .ENOTRECOVERABLE
+        .ENOTRECOVERABLE
     }
     /// Previous owner died.
     public static var EOWNERDEAD: POSIXErrorCode {
-        return .EOWNERDEAD
+        .EOWNERDEAD
     }
 
     /// Interface output queue is full.
     public static var EQFULL: POSIXErrorCode {
-        return .EQFULL
+        .EQFULL
     }
 }

--- a/Sources/FoundationEssentials/ErrorCodes.swift
+++ b/Sources/FoundationEssentials/ErrorCodes.swift
@@ -12,211 +12,211 @@
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension CocoaError.Code {
     public static var fileNoSuchFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4)
+        CocoaError.Code(rawValue: 4)
     }
     public static var fileLocking: CocoaError.Code {
-        return CocoaError.Code(rawValue: 255)
+        CocoaError.Code(rawValue: 255)
     }
     public static var fileReadUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 256)
+        CocoaError.Code(rawValue: 256)
     }
     public static var fileReadNoPermission: CocoaError.Code {
-        return CocoaError.Code(rawValue: 257)
+        CocoaError.Code(rawValue: 257)
     }
     public static var fileReadInvalidFileName: CocoaError.Code {
-        return CocoaError.Code(rawValue: 258)
+        CocoaError.Code(rawValue: 258)
     }
     public static var fileReadCorruptFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 259)
+        CocoaError.Code(rawValue: 259)
     }
     public static var fileReadNoSuchFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 260)
+        CocoaError.Code(rawValue: 260)
     }
     public static var fileReadInapplicableStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 261)
+        CocoaError.Code(rawValue: 261)
     }
     public static var fileReadUnsupportedScheme: CocoaError.Code {
-        return CocoaError.Code(rawValue: 262)
+        CocoaError.Code(rawValue: 262)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileReadTooLarge: CocoaError.Code {
-        return CocoaError.Code(rawValue: 263)
+        CocoaError.Code(rawValue: 263)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileReadUnknownStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 264)
+        CocoaError.Code(rawValue: 264)
     }
 
     public static var fileWriteUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 512)
+        CocoaError.Code(rawValue: 512)
     }
     public static var fileWriteNoPermission: CocoaError.Code {
-        return CocoaError.Code(rawValue: 513)
+        CocoaError.Code(rawValue: 513)
     }
     public static var fileWriteInvalidFileName: CocoaError.Code {
-        return CocoaError.Code(rawValue: 514)
+        CocoaError.Code(rawValue: 514)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileWriteFileExists: CocoaError.Code {
-        return CocoaError.Code(rawValue: 516)
+        CocoaError.Code(rawValue: 516)
     }
 
     public static var fileWriteInapplicableStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 517)
+        CocoaError.Code(rawValue: 517)
     }
     public static var fileWriteUnsupportedScheme: CocoaError.Code {
-        return CocoaError.Code(rawValue: 518)
+        CocoaError.Code(rawValue: 518)
     }
     public static var fileWriteOutOfSpace: CocoaError.Code {
-        return CocoaError.Code(rawValue: 640)
+        CocoaError.Code(rawValue: 640)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileWriteVolumeReadOnly: CocoaError.Code {
-        return CocoaError.Code(rawValue: 642)
+        CocoaError.Code(rawValue: 642)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, unavailable)
     public static var fileManagerUnmountUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 768)
+        CocoaError.Code(rawValue: 768)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, unavailable)
     public static var fileManagerUnmountBusy: CocoaError.Code {
-        return CocoaError.Code(rawValue: 769)
+        CocoaError.Code(rawValue: 769)
     }
 
     public static var keyValueValidation: CocoaError.Code {
-        return CocoaError.Code(rawValue: 1024)
+        CocoaError.Code(rawValue: 1024)
     }
     public static var formatting: CocoaError.Code {
-        return CocoaError.Code(rawValue: 2048)
+        CocoaError.Code(rawValue: 2048)
     }
     public static var userCancelled: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3072)
+        CocoaError.Code(rawValue: 3072)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var featureUnsupported: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3328)
+        CocoaError.Code(rawValue: 3328)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableNotLoadable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3584)
+        CocoaError.Code(rawValue: 3584)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableArchitectureMismatch: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3585)
+        CocoaError.Code(rawValue: 3585)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableRuntimeMismatch: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3586)
+        CocoaError.Code(rawValue: 3586)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableLoad: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3587)
+        CocoaError.Code(rawValue: 3587)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableLink: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3588)
+        CocoaError.Code(rawValue: 3588)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadCorrupt: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3840)
+        CocoaError.Code(rawValue: 3840)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadUnknownVersion: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3841)
+        CocoaError.Code(rawValue: 3841)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadStream: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3842)
+        CocoaError.Code(rawValue: 3842)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListWriteStream: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3851)
+        CocoaError.Code(rawValue: 3851)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListWriteInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3852)
+        CocoaError.Code(rawValue: 3852)
     }
 
 #if FOUNDATION_FRAMEWORK
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionInterrupted: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4097)
+        CocoaError.Code(rawValue: 4097)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4099)
+        CocoaError.Code(rawValue: 4099)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionReplyInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4101)
+        CocoaError.Code(rawValue: 4101)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileUnavailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4353)
+        CocoaError.Code(rawValue: 4353)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileNotUploadedDueToQuota: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4354)
+        CocoaError.Code(rawValue: 4354)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileUbiquityServerNotAvailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4355)
+        CocoaError.Code(rawValue: 4355)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityHandoffFailed: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4608)
+        CocoaError.Code(rawValue: 4608)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityConnectionUnavailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4609)
+        CocoaError.Code(rawValue: 4609)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityRemoteApplicationTimedOut: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4610)
+        CocoaError.Code(rawValue: 4610)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityHandoffUserInfoTooLarge: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4611)
+        CocoaError.Code(rawValue: 4611)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
     public static var coderReadCorrupt: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4864)
+        CocoaError.Code(rawValue: 4864)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
     public static var coderValueNotFound: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4865)
+        CocoaError.Code(rawValue: 4865)
     }
 
     public static var coderInvalidValue: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4866)
+        CocoaError.Code(rawValue: 4866)
     }
 #endif
 }
@@ -224,211 +224,211 @@ extension CocoaError.Code {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension CocoaError {
     public static var fileNoSuchFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4)
+        CocoaError.Code(rawValue: 4)
     }
     public static var fileLocking: CocoaError.Code {
-        return CocoaError.Code(rawValue: 255)
+        CocoaError.Code(rawValue: 255)
     }
     public static var fileReadUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 256)
+        CocoaError.Code(rawValue: 256)
     }
     public static var fileReadNoPermission: CocoaError.Code {
-        return CocoaError.Code(rawValue: 257)
+        CocoaError.Code(rawValue: 257)
     }
     public static var fileReadInvalidFileName: CocoaError.Code {
-        return CocoaError.Code(rawValue: 258)
+        CocoaError.Code(rawValue: 258)
     }
     public static var fileReadCorruptFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 259)
+        CocoaError.Code(rawValue: 259)
     }
     public static var fileReadNoSuchFile: CocoaError.Code {
-        return CocoaError.Code(rawValue: 260)
+        CocoaError.Code(rawValue: 260)
     }
     public static var fileReadInapplicableStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 261)
+        CocoaError.Code(rawValue: 261)
     }
     public static var fileReadUnsupportedScheme: CocoaError.Code {
-        return CocoaError.Code(rawValue: 262)
+        CocoaError.Code(rawValue: 262)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileReadTooLarge: CocoaError.Code {
-        return CocoaError.Code(rawValue: 263)
+        CocoaError.Code(rawValue: 263)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileReadUnknownStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 264)
+        CocoaError.Code(rawValue: 264)
     }
 
     public static var fileWriteUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 512)
+        CocoaError.Code(rawValue: 512)
     }
     public static var fileWriteNoPermission: CocoaError.Code {
-        return CocoaError.Code(rawValue: 513)
+        CocoaError.Code(rawValue: 513)
     }
     public static var fileWriteInvalidFileName: CocoaError.Code {
-        return CocoaError.Code(rawValue: 514)
+        CocoaError.Code(rawValue: 514)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileWriteFileExists: CocoaError.Code {
-        return CocoaError.Code(rawValue: 516)
+        CocoaError.Code(rawValue: 516)
     }
 
     public static var fileWriteInapplicableStringEncoding: CocoaError.Code {
-        return CocoaError.Code(rawValue: 517)
+        CocoaError.Code(rawValue: 517)
     }
     public static var fileWriteUnsupportedScheme: CocoaError.Code {
-        return CocoaError.Code(rawValue: 518)
+        CocoaError.Code(rawValue: 518)
     }
     public static var fileWriteOutOfSpace: CocoaError.Code {
-        return CocoaError.Code(rawValue: 640)
+        CocoaError.Code(rawValue: 640)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var fileWriteVolumeReadOnly: CocoaError.Code {
-        return CocoaError.Code(rawValue: 642)
+        CocoaError.Code(rawValue: 642)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, unavailable)
     public static var fileManagerUnmountUnknown: CocoaError.Code {
-        return CocoaError.Code(rawValue: 768)
+        CocoaError.Code(rawValue: 768)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, unavailable)
     public static var fileManagerUnmountBusy: CocoaError.Code {
-        return CocoaError.Code(rawValue: 769)
+        CocoaError.Code(rawValue: 769)
     }
 
     public static var keyValueValidation: CocoaError.Code {
-        return CocoaError.Code(rawValue: 1024)
+        CocoaError.Code(rawValue: 1024)
     }
     public static var formatting: CocoaError.Code {
-        return CocoaError.Code(rawValue: 2048)
+        CocoaError.Code(rawValue: 2048)
     }
     public static var userCancelled: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3072)
+        CocoaError.Code(rawValue: 3072)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var featureUnsupported: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3328)
+        CocoaError.Code(rawValue: 3328)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableNotLoadable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3584)
+        CocoaError.Code(rawValue: 3584)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableArchitectureMismatch: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3585)
+        CocoaError.Code(rawValue: 3585)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableRuntimeMismatch: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3586)
+        CocoaError.Code(rawValue: 3586)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableLoad: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3587)
+        CocoaError.Code(rawValue: 3587)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var executableLink: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3588)
+        CocoaError.Code(rawValue: 3588)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadCorrupt: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3840)
+        CocoaError.Code(rawValue: 3840)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadUnknownVersion: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3841)
+        CocoaError.Code(rawValue: 3841)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListReadStream: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3842)
+        CocoaError.Code(rawValue: 3842)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListWriteStream: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3851)
+        CocoaError.Code(rawValue: 3851)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var propertyListWriteInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 3852)
+        CocoaError.Code(rawValue: 3852)
     }
 
 #if FOUNDATION_FRAMEWORK
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionInterrupted: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4097)
+        CocoaError.Code(rawValue: 4097)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4099)
+        CocoaError.Code(rawValue: 4099)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var xpcConnectionReplyInvalid: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4101)
+        CocoaError.Code(rawValue: 4101)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileUnavailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4353)
+        CocoaError.Code(rawValue: 4353)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileNotUploadedDueToQuota: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4354)
+        CocoaError.Code(rawValue: 4354)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var ubiquitousFileUbiquityServerNotAvailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4355)
+        CocoaError.Code(rawValue: 4355)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityHandoffFailed: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4608)
+        CocoaError.Code(rawValue: 4608)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityConnectionUnavailable: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4609)
+        CocoaError.Code(rawValue: 4609)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityRemoteApplicationTimedOut: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4610)
+        CocoaError.Code(rawValue: 4610)
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public static var userActivityHandoffUserInfoTooLarge: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4611)
+        CocoaError.Code(rawValue: 4611)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
     public static var coderReadCorrupt: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4864)
+        CocoaError.Code(rawValue: 4864)
     }
 
     @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
     public static var coderValueNotFound: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4865)
+        CocoaError.Code(rawValue: 4865)
     }
 
     public static var coderInvalidValue: CocoaError.Code {
-        return CocoaError.Code(rawValue: 4866)
+        CocoaError.Code(rawValue: 4866)
     }
 #endif
 }
@@ -437,45 +437,45 @@ extension CocoaError {
 extension CocoaError {
     @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
     public var isCoderError: Bool {
-        return code.rawValue >= 4864 && code.rawValue <= 4991
+        code.rawValue >= 4864 && code.rawValue <= 4991
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public var isExecutableError: Bool {
-        return code.rawValue >= 3584 && code.rawValue <= 3839
+        code.rawValue >= 3584 && code.rawValue <= 3839
     }
 
     public var isFileError: Bool {
-        return code.rawValue >= 0 && code.rawValue <= 1023
+        code.rawValue >= 0 && code.rawValue <= 1023
     }
 
     public var isFormattingError: Bool {
-        return code.rawValue >= 2048 && code.rawValue <= 2559
+        code.rawValue >= 2048 && code.rawValue <= 2559
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public var isPropertyListError: Bool {
-        return code.rawValue >= 3840 && code.rawValue <= 4095
+        code.rawValue >= 3840 && code.rawValue <= 4095
     }
 
     public var isValidationError: Bool {
-        return code.rawValue >= 1024 && code.rawValue <= 2047
+        code.rawValue >= 1024 && code.rawValue <= 2047
     }
     
 #if FOUNDATION_FRAMEWORK
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public var isUbiquitousFileError: Bool {
-        return code.rawValue >= 4352 && code.rawValue <= 4607
+        code.rawValue >= 4352 && code.rawValue <= 4607
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public var isUserActivityError: Bool {
-        return code.rawValue >= 4608 && code.rawValue <= 4863
+        code.rawValue >= 4608 && code.rawValue <= 4863
     }
 
     @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
     public var isXPCConnectionError: Bool {
-        return code.rawValue >= 4096 && code.rawValue <= 4224
+        code.rawValue >= 4096 && code.rawValue <= 4224
     }
 #endif
 }

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -32,7 +32,7 @@ private protocol _JSONStringDictionaryDecodableMarker {
 }
 
 extension Dictionary : _JSONStringDictionaryDecodableMarker where Key == String, Value: Decodable {
-    static var elementType: Decodable.Type { return Value.self }
+    static var elementType: Decodable.Type { Value.self }
 }
 
 //===----------------------------------------------------------------------===//
@@ -1311,11 +1311,11 @@ extension JSONDecoderImpl {
         }
 
         func superDecoder() throws -> Decoder {
-            return decoderForKeyNoThrow(_JSONKey.super)
+            decoderForKeyNoThrow(_JSONKey.super)
         }
 
         func superDecoder(forKey key: K) throws -> Decoder {
-            return decoderForKeyNoThrow(key)
+            decoderForKeyNoThrow(key)
         }
 
         private func decoderForKeyNoThrow(_ key: some CodingKey) -> JSONDecoderImpl {

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -412,7 +412,7 @@ private class __JSONEncoder : Encoder {
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey : Any] {
-        return self.options.userInfo
+        self.options.userInfo
     }
 
     /// The path to the current point in encoding.
@@ -440,7 +440,7 @@ private class __JSONEncoder : Encoder {
         //
         // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
         // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
-        return self.storage.count == self.codingPathDepth
+        self.storage.count == self.codingPathDepth
     }
 
     // MARK: - Encoder Methods
@@ -478,7 +478,7 @@ private class __JSONEncoder : Encoder {
     }
 
     public func singleValueContainer() -> SingleValueEncodingContainer {
-        return self
+        self
     }
 
     // Instead of creating a new __JSONEncoder for passing to methods that take Encoder arguments, wrap the access in this method, which temporarily mutates this __JSONEncoder instance with the additional nesting depth and its coding path.
@@ -622,7 +622,7 @@ private struct _JSONEncodingStorage {
     // MARK: - Modifying the Stack
 
     var count: Int {
-        return self.refs.count
+        self.refs.count
     }
 
     mutating func pushKeyedContainer() -> JSONReference {
@@ -781,11 +781,11 @@ private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContain
     }
 
     public mutating func superEncoder() -> Encoder {
-        return __JSONReferencingEncoder(referencing: self.encoder, key: _JSONKey.super, convertedKey: _converted(_JSONKey.super), codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
+        __JSONReferencingEncoder(referencing: self.encoder, key: _JSONKey.super, convertedKey: _converted(_JSONKey.super), codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
     }
 
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return __JSONReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
+        __JSONReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
     }
 }
 
@@ -862,7 +862,7 @@ private struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     }
 
     public mutating func superEncoder() -> Encoder {
-        return __JSONReferencingEncoder(referencing: self.encoder, at: self.reference.count, codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
+        __JSONReferencingEncoder(referencing: self.encoder, at: self.reference.count, codingPathNode: self.encoder.encoderCodingPathNode, wrapping: self.reference)
     }
 }
 
@@ -1105,7 +1105,7 @@ private extension __JSONEncoder {
     }
 
     func wrap(_ value: Encodable, for codingPathNode: _JSONCodingPathNode, _ additionalKey: (some CodingKey)? = _JSONKey?.none) throws -> JSONReference {
-        return try self.wrapGeneric(value, for: codingPathNode, additionalKey) ?? .emptyObject
+        try self.wrapGeneric(value, for: codingPathNode, additionalKey) ?? .emptyObject
     }
 
     func wrapGeneric<T: Encodable>(_ value: T, for node: _JSONCodingPathNode, _ additionalKey: (some CodingKey)? = _JSONKey?.none) throws -> JSONReference? {
@@ -1223,7 +1223,7 @@ private class __JSONReferencingEncoder : __JSONEncoder {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.
-        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
+        self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
     }
 
     // MARK: - Deinitialization

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -245,7 +245,7 @@ internal class JSONMap {
     }
 
     func makeObjectIterator(from offset: Int) -> ObjectIterator {
-        return .init(currentOffset: offset, map: self)
+        .init(currentOffset: offset, map: self)
     }
 }
 

--- a/Sources/FoundationEssentials/JSON/JSONWriter.swift
+++ b/Sources/FoundationEssentials/JSON/JSONWriter.swift
@@ -88,7 +88,7 @@ extension String {
 
 extension JSONReference {
     static func number(from num: any (FixedWidthInteger & CustomStringConvertible)) -> JSONReference {
-        return .number(num.description)
+        .number(num.description)
     }
 
     static func number<T: BinaryFloatingPoint & CustomStringConvertible>(from float: T, with options: JSONEncoder.NonConformingFloatEncodingStrategy, for codingPathNode: _JSONCodingPathNode, _ additionalKey: (some CodingKey)? = Optional<_JSONKey>.none) throws -> JSONReference {

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -32,11 +32,11 @@ internal struct Platform {
     static var pageSize: Int = _pageSize
 
     static func roundDownToMultipleOfPageSize(_ size: Int) -> Int {
-        return size & ~(self.pageSize - 1)
+        size & ~(self.pageSize - 1)
     }
 
     static func roundUpToMultipleOfPageSize(_ size: Int) -> Int {
-        return (self.pageSize + size - 1) & ~(self.pageSize - 1)
+        (self.pageSize + size - 1) & ~(self.pageSize - 1)
     }
 
     static func copyMemoryPages(_ source: UnsafeRawPointer, _ dest: UnsafeMutableRawPointer, _ length: Int) {

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -136,7 +136,7 @@ extension PredicateExpressions {
         }
         
         public func evaluate(_ bindings: PredicateBindings) throws -> Output {
-            return try root.evaluate(bindings)[keyPath: keyPath as Swift.KeyPath<Root.Output, Output>]
+            try root.evaluate(bindings)[keyPath: keyPath as Swift.KeyPath<Root.Output, Output>]
         }
     }
 
@@ -148,7 +148,7 @@ extension PredicateExpressions {
         }
         
         public func evaluate(_ bindings: PredicateBindings) -> Output {
-            return self.value
+            self.value
         }
     }
     

--- a/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
@@ -25,7 +25,7 @@ extension PredicateExpressions {
         }
         
         public func evaluate(_ bindings: PredicateBindings) throws -> Output {
-            return try input.evaluate(bindings) as? Desired
+            try input.evaluate(bindings) as? Desired
         }
     }
     
@@ -63,7 +63,7 @@ extension PredicateExpressions {
         }
         
         public func evaluate(_ bindings: PredicateBindings) throws -> Output {
-            return try input.evaluate(bindings) is Desired
+            try input.evaluate(bindings) is Desired
         }
     }
 }

--- a/Sources/FoundationEssentials/String/String+Encoding.swift
+++ b/Sources/FoundationEssentials/String/String+Encoding.swift
@@ -15,7 +15,7 @@
 // should drop it here. <rdar://problem/14497260> (need support
 // for CF bridging)
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
-public var kCFStringEncodingASCII: CFStringEncoding { return 0x0600 }
+public var kCFStringEncodingASCII: CFStringEncoding { 0x0600 }
 #endif // FOUNDATION_FRAMEWORK
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
@@ -69,7 +69,7 @@ extension String.Encoding : Hashable {
         // Note: This is effectively the same hashValue definition that
         // RawRepresentable provides on its own. We only need to keep this to
         // ensure ABI compatibility with 5.0.
-        return rawValue.hashValue
+        rawValue.hashValue
     }
 
     @_alwaysEmitIntoClient // Introduced in 5.1
@@ -90,7 +90,7 @@ extension String.Encoding : Hashable {
         // Note: This is effectively the same == definition that
         // RawRepresentable provides on its own. We only need to keep this to
         // ensure ABI compatibility with 5.0.
-        return lhs.rawValue == rhs.rawValue
+        lhs.rawValue == rhs.rawValue
     }
 }
 
@@ -98,9 +98,9 @@ extension String.Encoding : Hashable {
 extension String.Encoding : CustomStringConvertible {
     public var description: String {
 #if FOUNDATION_FRAMEWORK
-        return String.localizedName(of: self)
+        String.localizedName(of: self)
 #else
-        return "\(self)"
+        "\(self)"
 #endif
     }
 }

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -150,14 +150,14 @@ extension StringProtocol {
     /// containing a given range.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public func lineRange<R : RangeExpression>(for aRange: R) -> Range<Index> where R.Bound == Index {
-        return String(self).lineRange(for: aRange)
+        String(self).lineRange(for: aRange)
     }
 
     /// Returns the range of characters representing the
     /// paragraph or paragraphs containing a given range.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public func paragraphRange<R : RangeExpression>(for aRange: R) -> Range<Index> where R.Bound == Index {
-        return String(self).paragraphRange(for: aRange)
+        String(self).paragraphRange(for: aRange)
     }
 }
 

--- a/Sources/FoundationEssentials/String/UnicodeScalar.swift
+++ b/Sources/FoundationEssentials/String/UnicodeScalar.swift
@@ -31,11 +31,11 @@ extension UnicodeScalar {
     }
 
     var _isGraphemeExtend: Bool {
-        return BuiltInUnicodeScalarSet.graphemeExtends.contains(self)
+        BuiltInUnicodeScalarSet.graphemeExtends.contains(self)
     }
 
     var _isCanonicalDecomposable: Bool {
-        return BuiltInUnicodeScalarSet.canonicalDecomposables.contains(self)
+        BuiltInUnicodeScalarSet.canonicalDecomposables.contains(self)
     }
 
     func _stripDiacritics() -> Self {

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -73,15 +73,15 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
     }
 
     public var description: String {
-        return uuidString
+        uuidString
     }
 
     public var debugDescription: String {
-        return description
+        description
     }
 
     public static func ==(lhs: UUID, rhs: UUID) -> Bool {
-        return lhs.uuid.0 == rhs.uuid.0 &&
+        lhs.uuid.0 == rhs.uuid.0 &&
             lhs.uuid.1 == rhs.uuid.1 &&
             lhs.uuid.2 == rhs.uuid.2 &&
             lhs.uuid.3 == rhs.uuid.3 &&


### PR DESCRIPTION
Proposal: [SE-0255](https://github.com/apple/swift-evolution/blob/main/proposals/0255-omit-return.md) states that single expression can be Implicitly return.

Behaviour like this 
```
func foo() -> String {
    return "foo"
}
```
can be rewritten as:
```
func foo() -> String {
    "foo"
}
```
Other Impact: 
This also make code consistent.