### PR TITLE
Tests: prefer `en_US` to `en_US_POSIX` on Windows

### DIFF
--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -56,7 +56,7 @@ final class DateTests : XCTestCase {
 
         XCTAssertLessThan(distantPast, currentDate)
         XCTAssertGreaterThan(currentDate, distantPast)
-        XCTAssertLessThan(currentDate.timeIntervalSince(distantPast),
+        XCTAssertLessThan(distantPast.timeIntervalSince(currentDate),
                           3600.0 * 24 * 365 * 100) /* ~1 century in seconds */
     }
 

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1368,7 +1368,11 @@ final class JSONEncoderTests : XCTestCase {
             setlocale(LC_ALL, "fr_FR")
             let data = try JSONEncoder().encode(orig)
 
+#if os(Windows)
+            setlocale(LC_ALL, "en_US")
+#else
             setlocale(LC_ALL, "en_US_POSIX")
+#endif
             let decoded = try JSONDecoder().decode(type(of: orig).self, from: data)
 
             XCTAssertEqual(orig, decoded)


### PR DESCRIPTION
Windows does not provide the POSIX variant of `en_US`.  Prefer to use the standard `en_US` locale for the test on this platform.