### PR TITLE
Tests: correct memory management in `test_localeDecimalPolicyIndependence`

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1361,7 +1361,14 @@ final class JSONEncoderTests : XCTestCase {
         if let localePtr = setlocale(LC_ALL, nil) {
             currentLocale = strdup(localePtr)
         }
-        
+
+        defer {
+            if let currentLocale {
+                setlocale(LC_ALL, currentLocale)
+                free(currentLocale)
+            }
+        }
+
         let orig = ["decimalValue" : 1.1]
 
         do {
@@ -1378,11 +1385,6 @@ final class JSONEncoderTests : XCTestCase {
             XCTAssertEqual(orig, decoded)
         } catch {
             XCTFail("Error: \(error)")
-        }
-        
-        if let currentLocale {
-            setlocale(LC_ALL, currentLocale)
-            currentLocale.deallocate()
         }
     }
 


### PR DESCRIPTION
The current locale returned by `setlocale` is being duplicated
explicitly by `strdup` in the code.  The contract for `strdup` states
that the memory allocated by `strdup` must be released by `free`.  We
were previously using `.deallocate` on the `UnsafeRawPointer`.  This is
not guaranteed to be backed as `free` as it makes certain guarantees
about pointer alignment which do not hold with `strdup`.

As a concrete example of a failure, Windows uses `_aligned_free` to
release the memory which assumes that the memory has been allocated by
`_aligned_malloc` which is what is used by
`UnsafeMutableRawPointer.allocate`.  This would thus fail with an
invalid `free`.

Take the opportunity to colocate the memory management with the
allocation by using a `defer` statement.  This is a small stylistic
improvement to help readability of the test.