### PR TITLE
FoundationInternationalization: add explicit type signature

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1147,7 +1147,7 @@ internal final class _Calendar: Equatable, @unchecked Sendable {
     }
 
     func weekendRange() -> WeekendRange? {
-        return lock.withLock {
+        return lock.withLock { () -> WeekendRange? in
             var result = WeekendRange(start: 0, end: 0)
 
             var weekdaysIndex : [UInt32] = [0, 0, 0, 0, 0, 0, 0]


### PR DESCRIPTION
Add an explicit type signature for the closure as it was being inferred as `() -> WeekendRange` rather than `() -> WeekendRange?` which results in a failure to build as `nil` does not conform to `WeekendRange`.