### PR TITLE
Provide `Predicate.true` and `Predicate.false`

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -25,6 +25,23 @@ public struct Predicate<Input> : Sendable {
     }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension Predicate {
+    private init(value: Bool) {
+        self.variable = PredicateExpressions.Variable<Input>()
+        self.expression = PredicateExpressions.Value(value)
+    }
+    
+    public static var `true`: Self {
+        Self(value: true)
+    }
+    
+    public static var `false`: Self {
+        Self(value: false)
+    }
+}
+
+
 // Namespace for operator expressions
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @frozen @_nonSendable public enum PredicateExpressions {}

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -566,4 +566,13 @@ final class PredicateTests: XCTestCase {
         XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [0])))
         XCTAssertThrowsError(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [])))
     }
+    
+    func testStaticValues() throws {
+        func assertPredicate<T>(_ pred: Predicate<T>, value: T, expected: Bool) throws {
+            XCTAssertEqual(try pred.evaluate(value), expected)
+        }
+        
+        try assertPredicate(.true, value: "Hello", expected: true)
+        try assertPredicate(.false, value: "Hello", expected: false)
+    }
 }


### PR DESCRIPTION
This provides static `true` and `false` properties on `Predicate` so that shorthand syntax of `.true` and `.false` can be used in APIs that accept a predicate

Resolves rdar://109162593