### PR TITLE
Native implementation for initializing String with UTF16 code points

### DIFF
--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -54,7 +54,7 @@ internal func _withResizingUCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeM
                     var innerStatus = U_ZERO_ERROR
                     if let innerLen = body(innerBuffer.baseAddress!, len + 1, &innerStatus) {
                         if innerStatus.isSuccess && innerLen > 0 {
-                            return String(utf16CodeUnits: innerBuffer.baseAddress!, count: Int(innerLen))
+                            return String._tryFromUTF16(innerBuffer, len: Int(innerLen))
                         }
                     }
                     
@@ -62,7 +62,7 @@ internal func _withResizingUCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeM
                     return nil
                 }
             } else if status.isSuccess && len > 0 {
-                return String(utf16CodeUnits: buffer.baseAddress!, count: Int(len))
+                return String._tryFromUTF16(buffer, len: Int(len))
             }
         }
         
@@ -78,7 +78,7 @@ internal func _withFixedUCharBuffer(size: Int32 = ULOC_FULLNAME_CAPACITY + ULOC_
         var status = U_ZERO_ERROR
         if let len = body(buffer.baseAddress!, size, &status) {
             if status.isSuccess && !(defaultIsError && status == U_USING_DEFAULT_WARNING) && len <= size && len > 0 {
-                return String(utf16CodeUnits: buffer.baseAddress!, count: Int(len))
+                return String._tryFromUTF16(buffer, len: Int(len))
             }
         }
         

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -966,7 +966,7 @@ internal final class _Locale: Sendable, Hashable {
                 return nil
             }
 
-            let nameStr = String(utf16CodeUnits: name, count: Int(size))
+            let nameStr = String._tryFromUTF16(name, len: Int(size))
             if isChoice.boolValue {
                 let pattern = "{0,choice,\(nameStr)}"
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -478,7 +478,9 @@ internal final class _TimeZone: Sendable {
                 continue
             }
 
-            let tz = String(utf16CodeUnits: chars, count: Int(length))
+            guard let tz = String._tryFromUTF16(chars, len: Int(length)) else {
+                continue
+            }
 
             // Filter out things starting with these prefixes
             guard !(tz.starts(with: "US/") || tz.starts(with: "Etc/") || tz.starts(with: "Canada/") || tz.starts(with: "SystemV/") || tz.starts(with: "Mideast/")) else {

--- a/Sources/_FoundationInternals/String/String+Internals.swift
+++ b/Sources/_FoundationInternals/String/String+Internals.swift
@@ -16,4 +16,31 @@ extension String {
             $0.properties.isWhitespace
         })
     }
+
+    static func _tryFromUTF16(_ input: UnsafeBufferPointer<UInt16>) -> String? {
+        withUnsafeTemporaryAllocation(of: UInt8.self, capacity: input.count * 3) { contents in
+            var ptr = contents.baseAddress!
+            var count = 0
+            let error = transcode(input.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: true) { codeUnit in
+                ptr.pointee = codeUnit
+                ptr = ptr.advanced(by: 1)
+                count += 1
+            }
+
+            guard !error else {
+                return nil
+            }
+
+            return String._tryFromUTF8(UnsafeBufferPointer(rebasing: contents[..<count]))
+        }
+    }
+
+    static func _tryFromUTF16(_ input: UnsafeMutableBufferPointer<UInt16>, len: Int) -> String? {
+        _tryFromUTF16(UnsafeBufferPointer(rebasing: input[..<len]))
+    }
+
+    static func _tryFromUTF16(_ input: UnsafePointer<UInt16>, len: Int) -> String? {
+        _tryFromUTF16(UnsafeBufferPointer(start: input, count: len))
+    }
+
 }


### PR DESCRIPTION
Continue disentangling the package from system Foundation API in this PR by adding a native implementation for `String(utf16CodeUnits:count:)`

Preliminary profiling shows approximately the same performance for multi-byte strings, and 3x improvement for single-byte ones.