### PR TITLE
FoundationEssentials: implement `getCurrentAbsoluteTime` on Windows

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -214,8 +214,13 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
 extension Date {
     private static func getCurrentAbsoluteTime() -> TimeInterval {
 #if canImport(WinSDK)
-        // TODO: WinSDK Implementation
-        fatalError("getCurrentAbsoluteTime not implemented for Windows yet")
+        var ft: FILETIME = FILETIME()
+        var li: ULARGE_INTEGER = ULARGE_INTEGER()
+        GetSystemTimePreciseAsFileTime(&ft)
+        li.LowPart = ft.dwLowDateTime
+        li.HighPart = ft.dwHighDateTime
+        // FILETIME represents 100-ns intervals since January 1, 1601 (UTC)
+        return TimeInterval((li.QuadPart - 1164447360_000_000) / 1_000_000_000)
 #else
         var ts: timespec = timespec()
         clock_gettime(CLOCK_REALTIME, &ts)


### PR DESCRIPTION
Implement querying the current absolute time on Windows which was previously marked as unimplemented.  Use the
`GetSystemTimePreciseAsFileTime` to query the system time which is in 100-ns intervals since January 1, 1601 (UTC).  This partially enables the `Date` functionality on Windows.