### PR TITLE
Expose `PredicateExpressions.KeyPath.CommonKeyPathKind` as API

### DIFF
--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -1,0 +1,381 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+@_implementationOnly import Foundation_Private.NSExpression
+
+private struct NSPredicateConversionState {
+    private var nextLocalVariable: UInt = 1
+    private var variables: [PredicateExpressions.VariableID : NSExpression]
+    
+    init(object: PredicateExpressions.VariableID) {
+        variables = [object : NSExpression.expressionForEvaluatedObject()]
+    }
+    
+    subscript(_ id: PredicateExpressions.VariableID) -> NSExpression {
+        get {
+            variables[id]!
+        }
+        set {
+            variables[id] = newValue
+        }
+    }
+    
+    mutating func makeLocalVariable(for id: PredicateExpressions.VariableID) -> String {
+        let variable = "_local_\(nextLocalVariable)"
+        nextLocalVariable += 1
+        variables[id] = NSExpression(forVariable: variable)
+        return variable
+    }
+}
+
+private enum ExpressionOrPredicate {
+    case expression(NSExpression)
+    case predicate(NSPredicate)
+}
+
+private protocol ConvertibleExpression : PredicateExpression {
+    func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate
+}
+
+private extension NSPredicate {
+    func asExpression() -> NSExpression {
+        NSExpression(forConditional: self, trueExpression: NSExpression(forConstantValue: true), falseExpression: NSExpression(forConstantValue: false))
+    }
+}
+
+private extension NSExpression {
+    func asPredicate() -> NSPredicate {
+        NSComparisonPredicate(leftExpression: self, rightExpression: NSExpression(forConstantValue: true), modifier: .direct, type: .equalTo)
+    }
+}
+
+extension PredicateExpression {
+    private func _convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        var caughtError: Error?
+        do {
+            if let convertible = self as? any ConvertibleExpression {
+                return try convertible.convert(state: &state)
+            }
+        } catch {
+            caughtError = error
+        }
+        
+        if let collapsedValue = try? self.evaluate(PredicateBindings()), let compatibleValue = try? _expressionCompatibleValue(for: collapsedValue) {
+            return .expression(NSExpression(forConstantValue: compatibleValue))
+        } else {
+            throw caughtError ?? NSPredicateConversionError.unsupportedType
+        }
+    }
+    
+    fileprivate func convertToExpression(state: inout NSPredicateConversionState) throws -> NSExpression {
+        switch try self._convert(state: &state) {
+        case .expression(let expr): return expr
+        case .predicate(let pred): return pred.asExpression()
+        }
+    }
+    
+    fileprivate func convertToPredicate(state: inout NSPredicateConversionState) throws -> NSPredicate {
+        switch try self._convert(state: &state) {
+        case .expression(let expr): return expr.asPredicate()
+        case .predicate(let pred): return pred
+        }
+    }
+}
+
+private enum NSPredicateConversionError : Error {
+    case unsupportedKeyPath
+    case unsupportedConstant
+    case unsupportedType
+}
+
+private extension String {
+    static let subscriptSelector = "objectFrom:withIndex:"
+    static let additionSelector = "add:to:"
+    static let subtractionSelector = "from:subtract:"
+    static let multiplicationSelector = "multiply:by:"
+    static let divisionSelector = "divide:by:"
+}
+
+private func _expressionCompatibleValue(for value: Any) throws -> Any? {
+    switch value {
+    case Optional<Any>.none:
+        return nil
+    case _ as String, _ as Bool, _ as any Numeric, _ as UUID, _ as Date:
+        return value
+    case let c as Character:
+        return String(c)
+    case let sequence as any Sequence:
+        return try sequence.map(_expressionCompatibleValue(for:))
+    case let range as ClosedRange<Int>:
+        return [range.lowerBound, range.upperBound]
+    default:
+        throw NSPredicateConversionError.unsupportedConstant
+    }
+}
+
+extension PredicateExpressions.Value : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forConstantValue: try _expressionCompatibleValue(for: self.value)))
+    }
+}
+
+extension PredicateExpressions.Variable : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(state[key])
+    }
+}
+
+extension PredicateExpressions.KeyPath : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let rootExpr = try root.convertToExpression(state: &state)
+        
+        func keyPathExpr(for string: String) -> NSExpression {
+            if rootExpr.expressionType == .evaluatedObject {
+                return NSExpression(forKeyPath: string)
+            } else if rootExpr.expressionType == .keyPath {
+                return NSExpression(forKeyPath: "\(rootExpr.keyPath).\(string)")
+            } else {
+                return NSKeyPathExpression(operand: rootExpr, andKeyPath: NSExpression._newKeyPathExpression(for: string))
+            }
+        }
+        
+        let countSyntax = (Root.Output.self == String.self || Root.Output.self == Substring.self) ? "length" : "@count"
+        if let kvcString = keyPath._kvcKeyPathString {
+            return .expression(keyPathExpr(for: kvcString))
+        } else if let kind = propertyKind {
+            switch kind {
+            case .count:
+                return .expression(keyPathExpr(for: countSyntax))
+            case .isEmpty:
+                return .predicate(NSComparisonPredicate(leftExpression: keyPathExpr(for: countSyntax), rightExpression: NSExpression(forConstantValue: 0), modifier: .direct, type: .equalTo))
+            case .arrayFirst:
+                return .expression(NSExpression(forFunction: rootExpr, selectorName: .subscriptSelector, arguments: [NSExpression(forSymbolicString: "FIRST")!]))
+            case .arrayLast:
+                return .expression(NSExpression(forFunction: rootExpr, selectorName: .subscriptSelector, arguments: [NSExpression(forSymbolicString: "LAST")!]))
+            }
+        } else {
+            throw NSPredicateConversionError.unsupportedKeyPath
+        }
+    }
+}
+
+extension PredicateExpressions.Conjunction : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSCompoundPredicate(andPredicateWithSubpredicates: [try lhs.convertToPredicate(state: &state), try rhs.convertToPredicate(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.Disjunction : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSCompoundPredicate(orPredicateWithSubpredicates: [try lhs.convertToPredicate(state: &state), try rhs.convertToPredicate(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.Equal : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSComparisonPredicate(leftExpression: try lhs.convertToExpression(state: &state), rightExpression: try rhs.convertToExpression(state: &state), modifier: .direct, type: .equalTo))
+    }
+}
+
+extension PredicateExpressions.NotEqual : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSComparisonPredicate(leftExpression: try lhs.convertToExpression(state: &state), rightExpression: try rhs.convertToExpression(state: &state), modifier: .direct, type: .equalTo))
+    }
+}
+
+extension PredicateExpressions.Arithmetic : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let funcName: String = switch op {
+        case .add: .additionSelector
+        case .subtract: .subtractionSelector
+        case .multiply: .multiplicationSelector
+        }
+        return .expression(NSExpression(forFunction: funcName, arguments: [try lhs.convertToExpression(state: &state), try rhs.convertToExpression(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.UnaryMinus : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forFunction: .multiplicationSelector, arguments: [try wrapped.convertToExpression(state: &state), NSExpression(forConstantValue: -1)]))
+    }
+}
+
+extension PredicateExpressions.Comparison : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let type: NSComparisonPredicate.Operator = switch op {
+        case .greaterThan: .greaterThan
+        case .greaterThanOrEqual: .greaterThanOrEqualTo
+        case .lessThan: .lessThan
+        case .lessThanOrEqual: .lessThanOrEqualTo
+        }
+        return .predicate(NSComparisonPredicate(leftExpression: try lhs.convertToExpression(state: &state), rightExpression: try rhs.convertToExpression(state: &state), modifier: .direct, type: type))
+    }
+}
+
+extension PredicateExpressions.Negation : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSCompoundPredicate(notPredicateWithSubpredicate: try wrapped.convertToPredicate(state: &state)))
+    }
+}
+
+extension PredicateExpressions.Filter : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let local = state.makeLocalVariable(for: self.variable.key)
+        return .expression(NSExpression(forSubquery: try sequence.convertToExpression(state: &state), usingIteratorVariable: local, predicate: try filter.convertToPredicate(state: &state)))
+    }
+}
+
+extension PredicateExpressions.FloatDivision : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forFunction: .divisionSelector, arguments: [try lhs.convertToExpression(state: &state), try rhs.convertToExpression(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.ClosedRange : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forAggregate: [try lower.convertToExpression(state: &state), try upper.convertToExpression(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.SequenceContains : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSComparisonPredicate(leftExpression: try element.convertToExpression(state: &state), rightExpression: try sequence.convertToExpression(state: &state), modifier: .direct, type: (LHS.Output.self is any RangeExpression<Int>.Type) ? .between : .in))
+    }
+}
+
+extension PredicateExpressions.Conditional : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let predicate = try test.convertToPredicate(state: &state)
+        let trueExpr = try trueBranch.convertToExpression(state: &state)
+        let falseExpr = try falseBranch.convertToExpression(state: &state)
+        return .expression(NSExpression(forConditional: predicate, trueExpression: trueExpr, falseExpression: falseExpr))
+    }
+}
+
+extension PredicateExpressions.NilCoalesce : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let lhsExpr = try lhs.convertToExpression(state: &state)
+        let rhsExpr = try rhs.convertToExpression(state: &state)
+        let nullCheck = NSComparisonPredicate(leftExpression: lhsExpr, rightExpression: NSExpression(forConstantValue: nil), modifier: .direct, type: .notEqualTo)
+        return .expression(NSExpression(forConditional: nullCheck, trueExpression: lhsExpr, falseExpression: rhsExpr))
+    }
+}
+
+extension PredicateExpressions.OptionalFlatMap : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        let wrappedExpr = try wrapped.convertToExpression(state: &state)
+        state[self.variable.key] = wrappedExpr
+        let transformExpr = try transform.convertToExpression(state: &state)
+        let nullCheck = NSComparisonPredicate(leftExpression: wrappedExpr, rightExpression: NSExpression(forConstantValue: nil), modifier: .direct, type: .notEqualTo)
+        return .expression(NSExpression(forConditional: nullCheck, trueExpression: transformExpr, falseExpression: NSExpression(forConstantValue: nil)))
+    }
+}
+
+fileprivate protocol _CollectionIndexSubscriptConvertible : Collection {}
+extension Array : _CollectionIndexSubscriptConvertible {}
+
+extension PredicateExpressions.CollectionIndexSubscript : ConvertibleExpression where Wrapped.Output : _CollectionIndexSubscriptConvertible {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forFunction: .subscriptSelector, arguments: [try wrapped.convertToExpression(state: &state), try index.convertToExpression(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.DictionaryKeySubscript : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forFunction: .subscriptSelector, arguments: [try wrapped.convertToExpression(state: &state), try key.convertToExpression(state: &state)]))
+    }
+}
+
+extension PredicateExpressions.CollectionContainsCollection : ConvertibleExpression where Base.Output : StringProtocol, Other.Output : StringProtocol {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSComparisonPredicate(leftExpression: try base.convertToExpression(state: &state), rightExpression: try other.convertToExpression(state: &state), modifier: .direct, type: .contains))
+    }
+}
+
+extension PredicateExpressions.SequenceStartsWith : ConvertibleExpression where Base.Output : StringProtocol, Prefix.Output : StringProtocol {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .predicate(NSComparisonPredicate(leftExpression: try base.convertToExpression(state: &state), rightExpression: try prefix.convertToExpression(state: &state), modifier: .direct, type: .beginsWith))
+    }
+}
+
+private protocol OverwritingInitializable {
+    init(existing: Self)
+}
+
+extension OverwritingInitializable {
+    init(existing: Self) {
+        self = existing
+    }
+}
+
+extension NSPredicate : OverwritingInitializable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension NSPredicate {
+    public convenience init?<Input>(_ predicate: Predicate<Input>) where Input : NSObject {
+        var state = NSPredicateConversionState(object: predicate.variable.key)
+        guard let converted = try? predicate.expression.convertToPredicate(state: &state) else {
+            return nil
+        }
+        self.init(existing: converted as! Self)
+    }
+}
+
+fileprivate extension PredicateExpressions.KeyPath {
+    enum CollectionProperty {
+        case count
+        case isEmpty
+        case arrayFirst
+        case arrayLast
+    }
+    
+    var propertyKind: CollectionProperty? {
+        guard let collectionType = Root.Output.self as? any Collection.Type else {
+            return nil
+        }
+        return Self.kind_collection(keyPath, collectionType)
+    }
+    
+    private static func kind_collection<C: Collection, Root>(_ anyKP: PartialKeyPath<Root>, _ collType: C.Type) -> CollectionProperty? {
+        let kp = anyKP as! PartialKeyPath<C>
+        switch kp {
+        case \String.count, \Substring.count, \Array<C.Element>.count:
+            return .count
+        case \String.isEmpty, \Substring.isEmpty, \Array<C.Element>.isEmpty:
+            return .isEmpty
+        case \Array<C.Element>.first:
+            return .arrayFirst
+        case \Array<C.Element>.last:
+            return .arrayLast
+        default:
+            if let hashableElem = C.Element.self as? any Hashable.Type {
+                return Self.kind_collection_hashableElement(kp, hashableElem)
+            }
+            return nil
+        }
+    }
+    
+    private static func kind_collection_hashableElement<C: Collection, Element: Hashable>(_ kp: PartialKeyPath<C>, _ e: Element.Type) -> CollectionProperty? {
+        switch kp {
+        case \Set<Element>.count:
+            return .count
+        case \Set<Element>.isEmpty:
+            return .isEmpty
+        default:
+            return nil
+        }
+    }
+}
+
+#endif

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -25,6 +25,10 @@ public struct Predicate<Input> : Sendable {
     }
 }
 
+@freestanding(expression)
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public macro Predicate<Input>(_ body: (Input) -> Bool) -> Predicate<Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
+
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension Predicate {
     private init(value: Bool) {

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -25,9 +25,11 @@ public struct Predicate<Input> : Sendable {
     }
 }
 
+#if !os(Linux) && !os(Windows)
 @freestanding(expression)
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public macro Predicate<Input>(_ body: (Input) -> Bool) -> Predicate<Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
+#endif
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension Predicate {

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -1,0 +1,446 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+final class NSPredicateConversionTests: XCTestCase {
+    @objc class ObjCObject: NSObject {
+        @objc var a: Int
+        @objc var b: String
+        @objc var c: Double
+        @objc var d: Int
+        @objc var f: Bool
+        @objc var g: [Int]
+        @objc var h: [String : Int]
+        @objc var i: Date
+        @objc var j: String?
+        @objc var k: UUID
+        var nonObjCKeypath: Int
+        
+        override init() {
+            a = 1
+            b = "Hello"
+            c = 2.3
+            d = 4
+            f = true
+            g = [5, 6, 7, 8, 9]
+            h = ["A" : 1, "B" : 2]
+            i = Date.distantFuture
+            j = nil
+            k = UUID()
+            nonObjCKeypath = 8
+            super.init()
+        }
+    }
+    
+    struct NonObjCStruct : Codable, Sendable {
+        var a: Int
+        var b: [Int]
+    }
+    
+    func testBasics() {
+        let obj = ObjCObject()
+        let compareTo = 2
+        var predicate = Predicate<ObjCObject> {
+            // $0.a == compareTo
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.a
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(compareTo)
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "a == 2"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.a + 2 == 4
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_Arithmetic(
+                        lhs: PredicateExpressions.build_Arg(
+                            PredicateExpressions.build_KeyPath(
+                                root: $0,
+                                keyPath: \.a
+                            )
+                        ),
+                        rhs: PredicateExpressions.build_Arg(2),
+                        op: .add
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(4)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "a + 2 == 4"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.b.count == 5
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_KeyPath(
+                            root: $0,
+                            keyPath: \.b
+                        ),
+                        keyPath: \.count
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(5)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "b.length == 5"))
+        XCTAssertTrue(converted!.evaluate(with: obj))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.g.count == 5
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_KeyPath(
+                            root: $0,
+                            keyPath: \.g
+                        ),
+                        keyPath: \.count
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(5)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "g.@count == 5"))
+        XCTAssertTrue(converted!.evaluate(with: obj))
+        
+        predicate = Predicate<ObjCObject> { object in
+            /*object.g.filter {
+                $0 == object.d
+            }.count > 0*/
+            
+            PredicateExpressions.build_Comparison(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_filter(
+                            PredicateExpressions.build_Arg(
+                                PredicateExpressions.build_KeyPath(
+                                    root: object,
+                                    keyPath: \.g
+                                )
+                            ),
+                            {
+                                PredicateExpressions.build_Equal(
+                                    lhs: PredicateExpressions.build_Arg($0),
+                                    rhs: PredicateExpressions.build_Arg(
+                                        PredicateExpressions.build_KeyPath(
+                                            root: object,
+                                            keyPath: \.d
+                                        )
+                                    )
+                                )
+                            }
+                        ),
+                        keyPath: \.count
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(0),
+                op: .greaterThan
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == d).@count > 0"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+    }
+    
+    func testNonObjC() {
+        let predicate = Predicate<ObjCObject> {
+            // $0.nonObjCKeypath == 2
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Arg(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.nonObjCKeypath
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(2)
+            )
+        }
+        XCTAssertNil(NSPredicate(predicate))
+    }
+    
+    func testNonObjCConstantKeyPath() {
+        let nonObjC = NonObjCStruct(a: 1, b: [1, 2, 3])
+        var predicate = Predicate<ObjCObject> {
+            // $0.a == nonObjC.a
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: $0,
+                    keyPath: \.a
+                ),
+                rhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg(nonObjC),
+                    keyPath: \.a
+                )
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "a == 1"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.f == nonObjC.b.contains([1, 2])
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: $0,
+                    keyPath: \.f
+                ),
+                rhs: PredicateExpressions.build_contains(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(nonObjC),
+                        keyPath: \.b
+                    ),
+                    PredicateExpressions.build_Arg([1, 2])
+                )
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+    }
+    
+    func testSubscripts() {
+        let obj = ObjCObject()
+        var predicate = Predicate<ObjCObject> {
+            // $0.g[0] == 2
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.g
+                    ),
+                    PredicateExpressions.build_Arg(0)
+                ),
+                rhs: PredicateExpressions.build_Arg(2)
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "(SELF.g)[0] == 2"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.h["A"] == 1
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.h
+                    ),
+                    PredicateExpressions.build_Arg("A")
+                ),
+                rhs: PredicateExpressions.build_Arg(1)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "(SELF.h)['A'] == 1"))
+        XCTAssertTrue(converted!.evaluate(with: obj))
+    }
+    
+    func testStringSearching() {
+        let obj = ObjCObject()
+        var predicate = Predicate<ObjCObject> {
+            // $0.b.contains("foo")
+            PredicateExpressions.build_contains(
+                PredicateExpressions.build_KeyPath(
+                    root: $0,
+                    keyPath: \.b
+                ),
+                PredicateExpressions.build_Arg("foo")
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "b CONTAINS 'foo'"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+        
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.b.contains("foo")
+            PredicateExpressions.build_starts(
+                PredicateExpressions.build_KeyPath(
+                    root: $0,
+                    keyPath: \.b
+                ),
+                with: PredicateExpressions.build_Arg("foo")
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "b BEGINSWITH 'foo'"))
+        XCTAssertFalse(converted!.evaluate(with: obj))
+    }
+    
+    func testExpressionEnforcement() {
+        var predicate = Predicate<ObjCObject> { _ in
+            PredicateExpressions.build_Arg(true)
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "YES == YES"))
+        XCTAssertTrue(converted!.evaluate(with: "Hello"))
+        
+        predicate = Predicate<ObjCObject> { _ in
+            PredicateExpressions.build_Arg(false)
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "NO == YES"))
+        XCTAssertFalse(converted!.evaluate(with: "Hello"))
+        
+        predicate = Predicate<ObjCObject> { _ in
+            PredicateExpressions.build_Conjunction(
+                lhs: PredicateExpressions.build_Arg(true),
+                rhs: PredicateExpressions.build_Arg(false)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "(YES == YES) && (NO == YES)"))
+        XCTAssertFalse(converted!.evaluate(with: "Hello"))
+        
+        predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_KeyPath(
+                root: PredicateExpressions.build_Arg($0),
+                keyPath: \.f
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        
+        predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_Conjunction(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.f
+                    ),
+                    rhs: PredicateExpressions.build_Arg(true)
+                ),
+                rhs: PredicateExpressions.build_Arg(false)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES AND YES == YES, YES, NO) == NO"))
+        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+    }
+    
+    func testConditional() {
+        let predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_Conditional(
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.f
+                ),
+                PredicateExpressions.build_Arg(true),
+                PredicateExpressions.build_Arg(false)
+            )
+        }
+        let converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES, YES, NO) == YES"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+    }
+    
+    func testOptionals() {
+        var predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_KeyPath(
+                root: PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.j
+                    ),
+                    rhs: PredicateExpressions.build_Arg("")
+                ),
+                keyPath: \.isEmpty
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(j != NULL, j, '').length == 0"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+        
+        predicate = Predicate<ObjCObject> {
+            // ($0.j?.count ?? -1) > 1
+            PredicateExpressions.build_Comparison(
+                lhs: PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg($0),
+                            keyPath: \.j
+                        ),
+                        {
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg($0),
+                                keyPath: \.count
+                            )
+                        }
+                    ),
+                    rhs: PredicateExpressions.build_Arg(-1)
+                ),
+                rhs: PredicateExpressions.build_Arg(1),
+                op: .greaterThan
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), -1) > 1"))
+        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+    }
+    
+    func testUUID() {
+        let obj = ObjCObject()
+        let uuid = obj.k
+        let predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.k
+                ),
+                rhs: PredicateExpressions.build_Arg(uuid)
+            )
+        }
+        
+        let converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "k == %@", uuid as NSUUID))
+        XCTAssertTrue(converted!.evaluate(with: obj))
+        let obj2 = ObjCObject()
+        XCTAssertNotEqual(obj2.k, uuid)
+        XCTAssertFalse(converted!.evaluate(with: obj2))
+    }
+    
+    func testDate() {
+        let now = Date.now
+        let predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_Comparison(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.i
+                ),
+                rhs: PredicateExpressions.build_Arg(now),
+                op: .greaterThan
+            )
+        }
+        
+        let converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "i > %@", now as NSDate))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR ports our `Predicate` -> `NSPredicate` conversion code to FoundationPreview behind `#if FOUNDATION_FRAMEWORK`, and exposes one of our utilities for that code for detecting common collection-based key paths as API.

Resolves rdar://108006317