### PR TITLE
Fix NSPredicate conversion for != operator

### DIFF
--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -190,7 +190,7 @@ extension PredicateExpressions.Equal : ConvertibleExpression {
 
 extension PredicateExpressions.NotEqual : ConvertibleExpression {
     fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
-        .predicate(NSComparisonPredicate(leftExpression: try lhs.convertToExpression(state: &state), rightExpression: try rhs.convertToExpression(state: &state), modifier: .direct, type: .equalTo))
+        .predicate(NSComparisonPredicate(leftExpression: try lhs.convertToExpression(state: &state), rightExpression: try rhs.convertToExpression(state: &state), modifier: .direct, type: .notEqualTo))
     }
 }
 

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -167,6 +167,36 @@ final class NSPredicateConversionTests: XCTestCase {
         XCTAssertFalse(converted!.evaluate(with: obj))
     }
     
+    func testEquality() {
+        var predicate = Predicate<ObjCObject> {
+            // $0.a == 0
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.a
+                ),
+                rhs: PredicateExpressions.build_Arg(0)
+            )
+        }
+        var converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "a == 0"))
+        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.a != 0
+            PredicateExpressions.build_NotEqual(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.a
+                ),
+                rhs: PredicateExpressions.build_Arg(0)
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "a != 0"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+    }
+    
     func testNonObjC() {
         let predicate = Predicate<ObjCObject> {
             // $0.nonObjCKeypath == 2


### PR DESCRIPTION
This fixes a typo in `Predicate` to `NSPredicate` conversion that accidentally converted the != operator to ==