### PR TITLE
Defaults to conversational hour options if the locale prefers it

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -54,29 +54,13 @@ extension Date {
 
         public func format(_ v: Range<Date>) -> String {
             let formatter = Self.cache.formatter(for: self) {
-                let option: ICUPatternGenerator.HourCycleOption?
-                if locale.force24Hour {
-                    option = .force24Hour
-                } else if locale.force12Hour {
-                    option = .force12Hour
-                } else {
-                    option = nil
-                }
+                var template = symbols.formatterTemplate(overridingDayPeriodWithLocale: locale)
 
-                var template: String
-                if let option {
-                    let pattern = ICUPatternGenerator.localizedPatternForSkeleton(localeIdentifier: locale.identifier, calendarIdentifier: calendar.identifier, skeleton: symbols.formatterTemplate, hourCycleOption: option)
-                    template = pattern
-                } else {
-                    template = symbols.formatterTemplate
-                }
-
-                // If at this point template is empty, use a default style
                 if template.isEmpty {
                     let defaultSymbols = Date.FormatStyle.DateFieldCollection()
                         .collection(date: .numeric)
                         .collection(time: .shortened)
-                    template = defaultSymbols.formatterTemplate
+                    template = defaultSymbols.formatterTemplate(overridingDayPeriodWithLocale: locale)
                 }
 
                 return ICUDateIntervalFormatter(locale: locale, calendar: calendar, timeZone: timeZone, dateTemplate: template)

--- a/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateParseStrategy.swift
@@ -64,7 +64,7 @@ extension Date {
         }
 
         internal init(formatStyle: Date.FormatStyle, lenient: Bool, twoDigitStartDate: Date = Date(timeIntervalSince1970: 0)) {
-            let pattern = ICUPatternGenerator.localizedPatternForSkeleton(localeIdentifier: formatStyle.locale.identifier, calendarIdentifier: formatStyle.calendar.identifier, skeleton: formatStyle.symbols.formatterTemplate, hourCycleOption: .default)
+            let pattern = ICUPatternGenerator.localizedPattern(symbols: formatStyle.symbols, locale: formatStyle.locale, calendar: formatStyle.calendar)
             self.init(format: pattern, locale: formatStyle.locale, timeZone: formatStyle.timeZone, calendar: formatStyle.calendar, isLenient: lenient, twoDigitStartDate: twoDigitStartDate)
         }
     }

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -170,9 +170,13 @@ final class ICUPatternGeneratorTests: XCTestCase {
                  expectedPattern: "H時")
             test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
                  expectedPattern: "HH:mm")
-
+#if FOUNDATION_FRAMEWORK
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "HH:mm")
+#else
             test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
                  expectedPattern: "HH:m")
+#endif
             test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
                  expectedPattern: "HH:mm:ss")
             test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -5,10 +5,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// RUN: %target-run-simple-swift
-// REQUIRES: executable_test
-// REQUIRES: objc_interop
 
 #if canImport(TestSupport)
 import TestSupport

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -14,6 +14,10 @@ import TestSupport
 @testable import FoundationInternationalization
 #endif
 
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#endif
+
 final class ICUPatternGeneratorTests: XCTestCase {
 
     typealias DateFieldCollection = Date.FormatStyle.DateFieldCollection

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -1,0 +1,242 @@
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if canImport(FoundationInternationalization)
+@testable import FoundationInternationalization
+#endif
+
+final class ICUPatternGeneratorTests: XCTestCase {
+
+    typealias DateFieldCollection = Date.FormatStyle.DateFieldCollection
+    func testConversationalDayPeriodsOverride() {
+
+        var locale: Locale
+        var calendar: Calendar
+        func test(symbols: Date.FormatStyle.DateFieldCollection, expectedPattern: String, file: StaticString = #file, line: UInt = #line) {
+            let pattern = ICUPatternGenerator.localizedPattern(symbols: symbols, locale: locale, calendar: calendar)
+            XCTAssertEqual(pattern, expectedPattern, file: file, line: line)
+
+            // We should not see any kind of day period designator ("a" or "B") when showing 24-hour hour ("H").
+            if (expectedPattern.contains("H") || pattern.contains("H")) && (pattern.contains("a") || pattern.contains("B")) {
+                XCTFail("Pattern should not contain day period", file: file, line: line)
+            }
+        }
+
+        // We should get conversational day periods (pattern "B") when the symbol contains hour options instead of non-conversational day periods (pattern "a")
+        do {
+            locale = Locale(identifier: "zh_TW")
+            calendar = Calendar(identifier: .gregorian)
+
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsWithWideAMPM),
+                 expectedPattern: "y/M/d BBBBh時")
+
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bh:mm")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bh:mm:ss")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBh時")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
+                 expectedPattern: "BBBBBh:mm")
+
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bhh:mm:ss")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBBhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM),
+                 expectedPattern: "BBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBhh:mm")
+
+            // We would not get "B" if not showing AM/PM at all
+            test(symbols: .init(hour: .twoDigitsNoAMPM), expectedPattern: "hh時")
+            test(symbols: .init(hour: .defaultDigitsNoAMPM), expectedPattern: "h時")
+            test(symbols: .init(year: .defaultDigits),
+                 expectedPattern: "y年")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits),
+                 expectedPattern: "y/M")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits),
+                 expectedPattern: "y/M/d")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsNoAMPM),
+                 expectedPattern: "y/M/d h時")
+        }
+
+        // This should also work with calendar besides gregorian
+        do {
+            locale = Locale(identifier: "zh_TW")
+            calendar = Calendar(identifier: .republicOfChina)
+
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsWithWideAMPM),
+                 expectedPattern: "G y/M/d BBBBh時")
+
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bh:mm")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bh:mm:ss")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBh時")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
+                 expectedPattern: "BBBBBh:mm")
+
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bhh:mm:ss")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBBhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM),
+                 expectedPattern: "BBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBhh:mm")
+        }
+
+        do {
+            locale = Locale(identifier: "zh_TW")
+            calendar = Calendar(identifier: .gregorian)
+
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsWithWideAMPM),
+                 expectedPattern: "y/M/d BBBBh時")
+
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bh:mm")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bh:mm:ss")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBh時")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
+                 expectedPattern: "BBBBBh:mm")
+
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "Bhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "Bhh:mm:ss")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),
+                 expectedPattern: "BBBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBBhh:mm")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM),
+                 expectedPattern: "BBBBhh時")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM, minute: .twoDigits),
+                 expectedPattern: "BBBBhh:mm")
+
+            // We would not get "B" if not showing AM/PM at all
+            test(symbols: .init(hour: .twoDigitsNoAMPM), expectedPattern: "hh時")
+            test(symbols: .init(hour: .defaultDigitsNoAMPM), expectedPattern: "h時")
+            test(symbols: .init(year: .defaultDigits),
+                 expectedPattern: "y年")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits),
+                 expectedPattern: "y/M")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits),
+                 expectedPattern: "y/M/d")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsNoAMPM),
+                 expectedPattern: "y/M/d h時")
+        }
+
+        // We should not see any kind of day period designator ("a" or "B") when showing 24-hour hour ("H").
+        do {
+            var localeUsing24hour = Locale.Components(identifier: "zh_TW")
+            localeUsing24hour.hourCycle = .zeroToTwentyThree
+            locale = Locale(components: localeUsing24hour)
+
+            calendar = Calendar(identifier: .gregorian)
+
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsWithWideAMPM),
+                 expectedPattern: "y/M/d H時")
+
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "HH:mm")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "HH:mm:ss")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM),
+                 expectedPattern: "H時")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
+                 expectedPattern: "HH:mm")
+
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "HH:m")
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "HH:mm:ss")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),
+                 expectedPattern: "HH時")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM, minute: .twoDigits),
+                 expectedPattern: "HH:mm")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM),
+                 expectedPattern: "HH時")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM, minute: .twoDigits),
+                 expectedPattern: "HH:mm")
+
+            // We would not get "B" if not showing AM/PM at all
+            test(symbols: .init(hour: .twoDigitsNoAMPM), expectedPattern: "HH時")
+            test(symbols: .init(hour: .defaultDigitsNoAMPM), expectedPattern: "H時")
+            test(symbols: .init(year: .defaultDigits),
+                 expectedPattern: "y年")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits),
+                 expectedPattern: "y/M")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits),
+                 expectedPattern: "y/M/d")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsNoAMPM),
+                 expectedPattern: "y/M/d H時")
+        }
+
+        // We do not override locales other than those in TW
+        do {
+            locale = Locale(identifier: "zh_HK")
+            calendar = Calendar(identifier: .gregorian)
+
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits, hour: .defaultDigitsWithWideAMPM),
+                 expectedPattern: "d/M/y aaaah時")
+
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "ah:mm")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "ah:mm:ss")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM),
+                 expectedPattern: "aaaaah時")
+            test(symbols: .init(hour: .defaultDigitsWithNarrowAMPM, minute: .defaultDigits),
+                 expectedPattern: "aaaaah:mm")
+
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "ahh:mm")
+            test(symbols: .init(hour: .twoDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "ahh:mm:ss")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM),
+                 expectedPattern: "aaaaahh時")
+            test(symbols: .init(hour: .twoDigitsWithNarrowAMPM, minute: .twoDigits),
+                 expectedPattern: "aaaaahh:mm")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM),
+                 expectedPattern: "aaaahh時")
+            test(symbols: .init(hour: .twoDigitsWithWideAMPM, minute: .twoDigits),
+                 expectedPattern: "aaaahh:mm")
+
+            // We would not get "B" if not showing AM/PM at all
+            test(symbols: .init(hour: .twoDigitsNoAMPM), expectedPattern: "hh時")
+            test(symbols: .init(hour: .defaultDigitsNoAMPM), expectedPattern: "h時")
+            test(symbols: .init(year: .defaultDigits),
+                 expectedPattern: "y年")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits),
+                 expectedPattern: "M/y")
+            test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits),
+                 expectedPattern: "d/M/y")
+        }
+    }
+
+}


### PR DESCRIPTION
Some locales prefer conversational day periods, ie. "12 at noon" to "12 pm". Currently clients need to use one of the `conversational` hour option to get this behavior, such as

```swift
let str = Date.now.formatted(.dateTime.hour(.conversationalDefaultDigits(amPM: .wide))
```

In some locales this is in fact the desired behavior, and should be the default. This PR adds a hook to swap "regular" hour with conversational one if we know the locale prefers it.

While we're here, clean up `ICUPatternGenerator`'s function interface and extra steps in `IntervalFormatStyle` that's now unnecessary.

rdar://110180766
