### PR TITLE
Tests: extend test skipping to Windows

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1139,8 +1139,8 @@ final class JSONEncoderTests : XCTestCase {
     }
 
     func test_JSONUnicodeEscapes() throws {
-#if os(Linux)
-        throw XCTSkip("current development swift builds cause a stack overflow")
+#if os(Linux) || os(Windows)
+        throw XCTSkip("#148 - current development swift builds cause a stack overflow")
 #endif
         let testCases = [
             // e-acute and greater-than-or-equal-to


### PR DESCRIPTION
Skip the `test_JSONUnicodeEncodings` test on Windows similar to Linux as it exhibits the same issue with a stack overflow.