### PR TITLE
Date: protect against invalid use of `_gmtime_s`

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -263,7 +263,8 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
         var info = tm()
 #if os(Windows)
         var time = __time64_t(self.timeIntervalSince1970)
-        _gmtime64_s(&info, &time)
+        let errno: errno_t = _gmtime64_s(&info, &time)
+        guard errno == 0 else { return unavailable }
 #else
         var time = time_t(self.timeIntervalSince1970)
         gmtime_r(&time, &info)


### PR DESCRIPTION
In the case that `_gmtime_s` fails, the return value is initialised to an invalid value that will fail when invoking `_strftime`.