### PR TITLE
Guard an optional String before using it in String interpolation

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -966,7 +966,10 @@ internal final class _Locale: Sendable, Hashable {
                 return nil
             }
 
-            let nameStr = String(_utf16: name, count: Int(size))
+            guard let nameStr = String(_utf16: name, count: Int(size)) else {
+                return nil
+            }
+
             if isChoice.boolValue {
                 let pattern = "{0,choice,\(nameStr)}"
 


### PR DESCRIPTION
`String(_utf16:count:)` returns an optional String. Guard it before using it.
