### PR TITLE
Upgrade swift-foundation-icu to avoid package resources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,11 @@ let package = Package(
     ],
     dependencies: [
         .package(
-          url: "https://github.com/apple/swift-collections",
-          revision: "2ca40e2a653e5e04a1c5468a35fc7494ef6db1d3"), // on release/1.1
-        .package(url: "https://github.com/apple/swift-foundation-icu", exact: "0.0.2")
+            url: "https://github.com/apple/swift-collections",
+            revision: "2ca40e2a653e5e04a1c5468a35fc7494ef6db1d3"), // on release/1.1
+        .package(
+            url: "https://github.com/apple/swift-foundation-icu",
+            revision: "0c1de7149a39a9ff82d4db66234dec587b30a3ad")
     ],
     targets: [
         // Foundation (umbrella)

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -123,7 +123,7 @@ internal final class ICULegacyNumberFormatter {
         }
         guard status.isSuccess else { return nil }
 
-        guard let str = String(utf8String: decNumChars) else {
+        guard let str = String(validatingUTF8: decNumChars) else {
             return nil
         }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -483,10 +483,8 @@ extension FloatingPointRoundingRule {
     }
 }
 
-#if os(Linux) || os(Windows) || FOUNDATION_FRAMEWORK
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FloatingPointRoundingRule : Codable { }
-#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension NumberFormatStyleConfiguration.RoundingIncrement: Codable {

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -25,7 +25,7 @@ internal struct ICUError: Error, CustomDebugStringConvertible {
     }
 
     var debugDescription: String {
-        String(utf8String: u_errorName(code)) ?? "Unknown ICU error \(code.rawValue)"
+        String(validatingUTF8: u_errorName(code)) ?? "Unknown ICU error \(code.rawValue)"
     }
 }
 
@@ -123,7 +123,7 @@ internal func _withFixedCharBuffer(size: Int32 = ULOC_FULLNAME_CAPACITY + ULOC_K
         if let len = body(buffer.baseAddress!, size, &status) {
             if status.isSuccess && len > 0 {
                 buffer[Int(len + 1)] = 0
-                return String(utf8String: buffer.baseAddress!)
+                return String(validatingUTF8: buffer.baseAddress!)
             }
         }
         

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -603,7 +603,7 @@ extension Locale {
                 return nil
             }
 
-            guard let code = String(utf8String: uregion_getRegionCode(containingRegion)) else {
+            guard let code = String(validatingUTF8: uregion_getRegionCode(containingRegion)) else {
                 return nil
             }
 
@@ -623,7 +623,7 @@ extension Locale {
                 return nil
             }
 
-            guard let code = String(utf8String: uregion_getRegionCode(containingContinent)) else {
+            guard let code = String(validatingUTF8: uregion_getRegionCode(containingContinent)) else {
                 return nil
             }
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
@@ -86,7 +86,7 @@ struct TimeZoneCache : Sendable {
         /// Reads from environment variables `TZFILE`, `TZ` and finally the symlink pointed at by the C macro `TZDEFAULT` to figure out what the current (aka "system") time zone is.
         mutating func findCurrentTimeZone() -> TimeZone {
             if let tzenv = getenv("TZFILE") {
-                if let name = String(utf8String: tzenv) {
+                if let name = String(validatingUTF8: tzenv) {
                     if let result = fixed(name) {
                         return result
                     }
@@ -94,7 +94,7 @@ struct TimeZoneCache : Sendable {
             }
 
             if let tz = getenv("TZ") {
-                if let name = String(utf8String: tz) {
+                if let name = String(validatingUTF8: tz) {
                     // Try as an abbreviation first
                     // Use cached function here to avoid recursive lock
                     if let name2 = timeZoneAbbreviations()[name] {
@@ -135,7 +135,7 @@ struct TimeZoneCache : Sendable {
             if ret >= 0 {
                 // Null-terminate the value
                 buffer[ret] = 0
-                if let file = String(utf8String: buffer.baseAddress!) {
+                if let file = String(validatingUTF8: buffer.baseAddress!) {
 #if targetEnvironment(simulator) && (os(iOS) || os(tvOS) || os(watchOS))
                     let lookFor = "zoneinfo/"
 #else

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -237,7 +237,7 @@ internal final class _TimeZone: Sendable {
 
     static var timeZoneDataVersion: String {
         var status = U_ZERO_ERROR
-        guard let version = ucal_getTZDataVersion(&status), status.isSuccess, let str = String(utf8String: version) else {
+        guard let version = ucal_getTZDataVersion(&status), status.isSuccess, let str = String(validatingUTF8: version) else {
             return ""
         }
         return str


### PR DESCRIPTION
Swift Package Manager automatically generates a `package_resource_accessor.swift` file when there are resources present in the package. This behavior creates an issue for `SwiftFoundation` because `package_resource_accessor.swift` imports the system Foundation, thus creating an "ambiguous symbol look up" problem for `SwiftFoundation` (since all public symbols will be present in both system Foundation and this package). 

https://github.com/apple/swift-foundation-icu/pull/14 on `SwiftFoundationICU` changed how ICU data files are bundled -- now they are embedded in the binary itself, therefore omitting any package resources. Upgrading to this version allows us to finally remove the implicit `Foundation` import.

**NOTE**: I decided to not tag `SwiftFoundationICU` yet as I integrate these changes back to https://github.com/apple-oss-distributions/ICU. For now, we'll just use `.package(url:revision:)` until it gets a new tag.