### PR TITLE
Fix StringProtocol.lineRange(for:)/paragraphRange(for:)

### DIFF
--- a/Sources/FoundationEssentials/String/StringBlocks.swift
+++ b/Sources/FoundationEssentials/String/StringBlocks.swift
@@ -181,3 +181,26 @@ extension BidirectionalCollection where Element == UTF8.CodeUnit {
         return _StringBlock(start: start, end: end, contentsEnd: contentsEnd)
     }
 }
+
+extension Substring.UTF8View {
+    // Note: we could have these defined on BidirectionalCollection<UInt8>, like _getBlock.
+    // However, all current call sites are funneling through Substring.UTF8View, and it makes
+    // sense to avoid dealing with generics unless we're forced to. Feel free to convert these
+    // utilities to generic functions if needed.
+
+    internal func _lineBounds(
+        around range: Range<Index>
+    ) -> (start: Index, end: Index, contentsEnd: Index) {
+        let result = _getBlock(
+            for: [.findStart, .findEnd, .findContentsEnd, .stopAtLineSeparators], in: range)
+        return (result.start!, result.end!, result.contentsEnd!)
+    }
+
+    internal func _paragraphBounds(
+        around range: Range<Index>
+    ) -> (start: Index, end: Index, contentsEnd: Index) {
+        let result = _getBlock(
+            for: [.findStart, .findEnd, .findContentsEnd], in: range)
+        return (result.start!, result.end!, result.contentsEnd!)
+    }
+}

--- a/Sources/_FoundationInternals/String/BidirectionalCollection.swift
+++ b/Sources/_FoundationInternals/String/BidirectionalCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,19 +12,16 @@
 
 extension BidirectionalCollection where Index == String.Index {
     internal func _alignIndex(roundingDown i: Index) -> Index {
-        return i < endIndex ? index(before: index(after: i)) : i
+        index(i, offsetBy: 0)
     }
 
     internal func _alignIndex(roundingUp i: Index) -> Index {
         let truncated = _alignIndex(roundingDown: i)
-        if i > truncated && i < endIndex {
-            return index(after: i)
-        } else {
-            return i
-        }
+        guard i > truncated && truncated < endIndex else { return truncated }
+        return index(after: truncated)
     }
 
-    internal func _boundaryAlignedRange<R: RangeExpression>(_ r: R) -> Range<Index> where R.Bound == String.Index {
+    internal func _boundaryAlignedRange(_ r: some RangeExpression<Index>) -> Range<Index> {
         let range = r.relative(to: self)
         return _alignIndex(roundingDown: range.lowerBound)..<_alignIndex(roundingUp: range.upperBound)
     }


### PR DESCRIPTION
These started by converting `self` into a `String`. This lead to crashes when `self` happened to be a Substring, as the input range isn’t necessarily a valid index range in the resulting string in that case.

While I’m here, review related helper functions to improve performance and to avoid more correctness issues.

Resolves rdar://109907151&110477287 