### PR TITLE
Introduce Locale.identifierCapturingPreferences to capture preferences in a single identifier

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -39,7 +39,7 @@ internal class ICUNumberFormatterBase {
         self.skeleton = skeleton
         let ustr = Array(skeleton.utf16)
         var status = U_ZERO_ERROR
-        let formatter = unumf_openForSkeletonAndLocale(ustr, Int32(ustr.count), locale.identifier, &status)
+        let formatter = unumf_openForSkeletonAndLocale(ustr, Int32(ustr.count), locale.identifierCapturingPreferences, &status)
 
         guard let formatter else {
             return nil

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -298,14 +298,10 @@ extension Locale {
         }
 
         private mutating func applyPreferencesOverride(_ locale: Locale) {
-            if hourCycle == nil {
-                if locale.force24Hour {
-                    // Respect 24-hour override if both force24hour and force12hour are true
-                    hourCycle = .zeroToTwentyThree
-                } else if locale.force12Hour {
-                    hourCycle = .oneToTwelve
-                }
+            if hourCycle == nil, let hc = locale.forceHourCycle {
+                hourCycle = hc
             }
+            
             if measurementSystem == nil, let ms = locale.forceMeasurementSystem {
                 measurementSystem = ms
             }

--- a/Sources/FoundationInternationalization/Locale/Locale+Components.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components.swift
@@ -280,7 +280,8 @@ extension Locale {
             if let id = firstDayOfWeek?.rawValue { keywords[Weekday.legacyKeywordKey] = id }
             if let id = hourCycle?.rawValue { keywords[HourCycle.legacyKeywordKey] = id }
             if let id = measurementSystem?._normalizedIdentifier { keywords[MeasurementSystem.legacyKeywordKey] = id }
-            if let region = region {
+            // No need for redundant region keyword
+            if let region = region, region != languageComponents.region {
                 // rg keyword value is actually a subdivision code
                 keywords[Region.legacyKeywordKey] = Subdivision.subdivision(for: region)._normalizedIdentifier
             }

--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -810,22 +810,12 @@ public struct Locale : Hashable, Equatable, Sendable {
 
     // MARK: - Preferences support (Internal)
 
-    internal var force24Hour: Bool {
+    internal var forceHourCycle: HourCycle? {
         switch kind {
-        case .autoupdating: return LocaleCache.cache.current.force24Hour
-        case .fixed(let l): return l.force24Hour
+        case .autoupdating: return LocaleCache.cache.current.forceHourCycle
+        case .fixed(let l): return l.forceHourCycle
 #if FOUNDATION_FRAMEWORK
-        case .bridged(_): return false
-#endif
-        }
-    }
-
-    internal var force12Hour: Bool {
-        switch kind {
-        case .autoupdating: return LocaleCache.cache.current.force12Hour
-        case .fixed(let l): return l.force12Hour
-#if FOUNDATION_FRAMEWORK
-        case .bridged(_): return false
+        case .bridged(_): return nil
 #endif
         }
     }

--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -909,6 +909,18 @@ public struct Locale : Hashable, Equatable, Sendable {
     }
 #endif
 
+    // Returns an identifier that includes preferences as keywords, such as "en_US@measure=metric" or "en_GB@hours=h12"
+    internal var identifierCapturingPreferences: String {
+        switch kind {
+        case .autoupdating: return LocaleCache.cache.current.identifierCapturingPreferences
+        case .fixed(let l): return l.identifierCapturingPreferences
+#if FOUNDATION_FRAMEWORK
+        case .bridged(let l): return l.identifier
+#endif
+        }
+    }
+
+
     // MARK: -
     //
 

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -400,6 +400,8 @@ internal final class _Locale: Sendable, Hashable {
         }
     }
 
+    // This only includes a subset of preferences that are representable by
+    // CLDR keywords: https://www.unicode.org/reports/tr35/#Key_Type_Definitions
     internal var identifierCapturingPreferences: String {
         lock.withLock { state in
             if let result = state.identifierCapturingPreferences {


### PR DESCRIPTION
- Part 1: Clean up various usages of force-12-hour and force-24-hour
Consolidate `force24Hour` and `force12Hour` to `forceHourCycle`. Use this as the universal override option.
    
- Part 2: Introduce `identifierCapturingPreferences`
Add `Locale.identifierCapturingPreferences` to return a string identifier with preferences encoded in. This allows us to pass this identifier to ICU functions to request overrides rather than specifying options in individual API. This PR also adopts this identifier for `ICUNumberFormatter`.

Work towards resolving rdar://110211953
