### PR TITLE
Implement getting calendar symbols

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar.swift
@@ -545,102 +545,9 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
     // MARK: - Symbols
-    private enum SymbolKey {
-        case eraSymbols
-        case longEraSymbols
-        case monthSymbols
-        case shortMonthSymbols
-        case veryShortMonthSymbols
-        case standaloneMonthSymbols
-        case shortStandaloneMonthSymbols
-        case veryShortStandaloneMonthSymbols
-        case weekdaySymbols
-        case shortWeekdaySymbols
-        case veryShortWeekdaySymbols
-        case standaloneWeekdaySymbols
-        case shortStandaloneWeekdaySymbols
-        case veryShortStandaloneWeekdaySymbols
-        case quarterSymbols
-        case shortQuarterSymbols
-        case standaloneQuarterSymbols
-        case shortStandaloneQuarterSymbols
-        case amSymbol
-        case pmSymbol
 
-#if FOUNDATION_FRAMEWORK
-        func toCFDateFormatterKey() -> CFDateFormatterKey {
-            switch self {
-            case .eraSymbols:
-                return .eraSymbols
-            case .longEraSymbols:
-                return .longEraSymbols
-            case .monthSymbols:
-                return .monthSymbols
-            case .shortMonthSymbols:
-                return .shortMonthSymbols
-            case .veryShortMonthSymbols:
-                return .veryShortMonthSymbols
-            case .standaloneMonthSymbols:
-                return .standaloneMonthSymbols
-            case .shortStandaloneMonthSymbols:
-                return .shortStandaloneMonthSymbols
-            case .veryShortStandaloneMonthSymbols:
-                return .veryShortStandaloneMonthSymbols
-            case .weekdaySymbols:
-                return .weekdaySymbols
-            case .shortWeekdaySymbols:
-                return .shortWeekdaySymbols
-            case .veryShortWeekdaySymbols:
-                return .veryShortWeekdaySymbols
-            case .standaloneWeekdaySymbols:
-                return .standaloneWeekdaySymbols
-            case .shortStandaloneWeekdaySymbols:
-                return .shortStandaloneWeekdaySymbols
-            case .veryShortStandaloneWeekdaySymbols:
-                return .veryShortStandaloneWeekdaySymbols
-            case .quarterSymbols:
-                return .quarterSymbols
-            case .shortQuarterSymbols:
-                return .shortQuarterSymbols
-            case .standaloneQuarterSymbols:
-                return .standaloneQuarterSymbols
-            case .shortStandaloneQuarterSymbols:
-                return .shortStandaloneQuarterSymbols
-            case .amSymbol:
-                return .amSymbol
-            case .pmSymbol:
-                return .pmSymbol
-            }
-        }
-#endif
-    }
-
-    private func symbols(for key: SymbolKey) -> [String] {
-#if FOUNDATION_FRAMEWORK
-        // TODO: (Calendar.symbols) Figure out how to replace this with modern FormatStyle
-        // rdar://71815286 (Allow formatting day/era/month symbols)
-        let cfdf = CFDateFormatterCreate(kCFAllocatorSystemDefault, (locale as? NSLocale), .noStyle, .noStyle)
-        guard let result = CFDateFormatterCopyProperty(cfdf, key.toCFDateFormatterKey()) else {
-            return []
-        }
-        return result as! [String]
-#else
-        return [""]
-#endif
-    }
-
-    private func symbol(for key: SymbolKey) -> String {
-#if FOUNDATION_FRAMEWORK
-        // TODO: (Calendar.symbols) Figure out how to replace this with modern FormatStyle
-        // rdar://71815286 (Allow formatting day/era/month symbols)
-        let cfdf = CFDateFormatterCreate(kCFAllocatorSystemDefault, (locale as? NSLocale), .noStyle, .noStyle)
-        guard let result = CFDateFormatterCopyProperty(cfdf, key.toCFDateFormatterKey()) else {
-            return ""
-        }
-        return result as! String
-#else
-        return ""
-#endif
+    private func symbols(for key: UDateFormatSymbolType) -> [String] {
+        ICUDateFormatter.cachedFormatter(for: self).symbols(for: key)
     }
 
     /// A list of eras in this calendar, localized to the Calendar's `locale`.
@@ -649,7 +556,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var eraSymbols: [String] {
-        symbols(for: .eraSymbols)
+        symbols(for: .eras)
     }
 
     /// A list of longer-named eras in this calendar, localized to the Calendar's `locale`.
@@ -658,7 +565,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var longEraSymbols: [String] {
-        symbols(for: .longEraSymbols)
+        symbols(for: .eraNames)
     }
 
     /// A list of months in this calendar, localized to the Calendar's `locale`.
@@ -667,7 +574,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var monthSymbols: [String] {
-        symbols(for: .monthSymbols)
+        symbols(for: .months)
     }
 
     /// A list of shorter-named months in this calendar, localized to the Calendar's `locale`.
@@ -676,7 +583,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortMonthSymbols: [String] {
-        symbols(for: .shortMonthSymbols)
+        symbols(for: .shortMonths)
     }
 
     /// A list of very-shortly-named months in this calendar, localized to the Calendar's `locale`.
@@ -685,7 +592,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var veryShortMonthSymbols: [String] {
-        symbols(for: .veryShortMonthSymbols)
+        symbols(for: .narrowMonths)
     }
 
     /// A list of standalone months in this calendar, localized to the Calendar's `locale`.
@@ -694,7 +601,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var standaloneMonthSymbols: [String] {
-        symbols(for: .standaloneMonthSymbols)
+        symbols(for: .standaloneMonths)
     }
 
     /// A list of shorter-named standalone months in this calendar, localized to the Calendar's `locale`.
@@ -703,7 +610,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortStandaloneMonthSymbols: [String] {
-        symbols(for: .shortStandaloneMonthSymbols)
+        symbols(for: .standaloneShortMonths)
     }
 
     /// A list of very-shortly-named standalone months in this calendar, localized to the Calendar's `locale`.
@@ -712,7 +619,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var veryShortStandaloneMonthSymbols: [String] {
-        symbols(for: .veryShortStandaloneMonthSymbols)
+        symbols(for: .standaloneNarrowMonths)
     }
 
     /// A list of weekdays in this calendar, localized to the Calendar's `locale`.
@@ -721,7 +628,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var weekdaySymbols: [String] {
-        symbols(for: .weekdaySymbols)
+        symbols(for: .weekdays)
     }
 
     /// A list of shorter-named weekdays in this calendar, localized to the Calendar's `locale`.
@@ -730,7 +637,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortWeekdaySymbols: [String] {
-        symbols(for: .shortWeekdaySymbols)
+        symbols(for: .shortWeekdays)
     }
 
     /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
@@ -739,7 +646,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var veryShortWeekdaySymbols: [String] {
-        symbols(for: .veryShortWeekdaySymbols)
+        symbols(for: .narrowWeekdays)
     }
 
     /// A list of standalone weekday names in this calendar, localized to the Calendar's `locale`.
@@ -748,7 +655,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var standaloneWeekdaySymbols: [String] {
-        symbols(for: .standaloneWeekdaySymbols)
+        symbols(for: .standaloneWeekdays)
     }
 
     /// A list of shorter-named standalone weekdays in this calendar, localized to the Calendar's `locale`.
@@ -757,7 +664,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortStandaloneWeekdaySymbols: [String] {
-        symbols(for: .shortStandaloneWeekdaySymbols)
+        symbols(for: .standaloneShortWeekdays)
     }
 
     /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
@@ -766,7 +673,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var veryShortStandaloneWeekdaySymbols: [String] {
-        symbols(for: .veryShortStandaloneWeekdaySymbols)
+        symbols(for: .standaloneNarrowWeekdays)
     }
 
     /// A list of quarter names in this calendar, localized to the Calendar's `locale`.
@@ -775,7 +682,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var quarterSymbols: [String] {
-        symbols(for: .quarterSymbols)
+        symbols(for: .quarters)
     }
 
     /// A list of shorter-named quarters in this calendar, localized to the Calendar's `locale`.
@@ -784,7 +691,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortQuarterSymbols: [String] {
-        symbols(for: .shortQuarterSymbols)
+        symbols(for: .shortQuarters)
     }
 
     /// A list of standalone quarter names in this calendar, localized to the Calendar's `locale`.
@@ -793,7 +700,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var standaloneQuarterSymbols: [String] {
-        symbols(for: .standaloneQuarterSymbols)
+        symbols(for: .standaloneQuarters)
     }
 
     /// A list of shorter-named standalone quarters in this calendar, localized to the Calendar's `locale`.
@@ -802,7 +709,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var shortStandaloneQuarterSymbols: [String] {
-        symbols(for: .shortStandaloneQuarterSymbols)
+        symbols(for: .standaloneShortQuarters)
     }
 
     /// The symbol used to represent "AM", localized to the Calendar's `locale`.
@@ -811,7 +718,8 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var amSymbol: String {
-        symbol(for: .amSymbol)
+        let amPMs = symbols(for: .amPMs)
+        return amPMs[0]
     }
 
     /// The symbol used to represent "PM", localized to the Calendar's `locale`.
@@ -820,7 +728,8 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
     public var pmSymbol: String {
-        symbol(for: .pmSymbol)
+        let amPMs = symbols(for: .amPMs)
+        return amPMs[1]
     }
 
     // MARK: -

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -191,6 +191,24 @@ final class ICUDateFormatter {
         })
     }
 
+    // MARK: - Getting symbols
+
+    func symbols(for key: UDateFormatSymbolType) -> [String] {
+        let symbolCount = udat_countSymbols(udateFormat, key)
+        var result = [String]()
+        for i in 0 ..< symbolCount {
+            let s = _withResizingUCharBuffer { buffer, size, status in
+                udat_getSymbols(udateFormat, key, i, buffer, size, &status)
+            }
+
+            if let s {
+                result.append(s)
+            }
+        }
+
+        return result
+    }
+
     // -- Caching support
 
     // A Date.VerbatimFormatStyle, Date.FormatStyle and Date.ParseStrategy might be able to share a ICUDateFormatter
@@ -270,6 +288,14 @@ final class ICUDateFormatter {
 
     static func cachedFormatter(for format: Date.VerbatimFormatStyle) -> ICUDateFormatter {
         let info = DateFormatInfo(localeIdentifier: format.locale?.identifier, timeZoneIdentifier: format.timeZone.identifier, calendarIdentifier: format.calendar.identifier, firstWeekday: format.calendar.firstWeekday, minimumDaysInFirstWeek: format.calendar.minimumDaysInFirstWeek, capitalizationContext: .unknown, pattern: format.formatPattern)
+        return cachedFormatter(for: info)
+    }
+
+    // Returns a formatter to retrieve localized calendar symbols
+    static func cachedFormatter(for calendar: Calendar) -> ICUDateFormatter {
+        // Currently this always uses `.unknown` for capitalization. We should
+        // consider allowing customization with rdar://71815286 
+        let info = DateFormatInfo(localeIdentifier: calendar.locale?.identifier, timeZoneIdentifier: calendar.timeZone.identifier, calendarIdentifier: calendar.identifier, firstWeekday: calendar.firstWeekday, minimumDaysInFirstWeek: calendar.minimumDaysInFirstWeek, capitalizationContext: .unknown, pattern: "")
         return cachedFormatter(for: info)
     }
 }

--- a/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
@@ -31,6 +31,39 @@ extension UBool {
     }
 }
 
+extension UDateFormatSymbolType {
+    static let eras = UDAT_ERAS
+    static let months = UDAT_MONTHS
+    static let shortMonths = UDAT_SHORT_MONTHS
+    static let weekdays = UDAT_WEEKDAYS
+    static let shortWeekdays = UDAT_SHORT_WEEKDAYS
+    static let amPMs = UDAT_AM_PMS
+    static let localizedCharacters = UDAT_LOCALIZED_CHARS
+    static let eraNames = UDAT_ERA_NAMES
+    static let narrowMonths = UDAT_NARROW_MONTHS
+    static let narrowWeekdays = UDAT_NARROW_WEEKDAYS
+    static let standaloneMonths = UDAT_STANDALONE_MONTHS
+    static let standaloneShortMonths = UDAT_STANDALONE_SHORT_MONTHS
+    static let standaloneNarrowMonths = UDAT_STANDALONE_NARROW_MONTHS
+    static let standaloneWeekdays = UDAT_STANDALONE_WEEKDAYS
+    static let standaloneShortWeekdays = UDAT_STANDALONE_SHORT_WEEKDAYS
+    static let standaloneNarrowWeekdays = UDAT_STANDALONE_NARROW_WEEKDAYS
+    static let quarters = UDAT_QUARTERS
+    static let shortQuarters = UDAT_SHORT_QUARTERS
+    static let standaloneQuarters = UDAT_STANDALONE_QUARTERS
+    static let standaloneShortQuarters = UDAT_STANDALONE_SHORT_QUARTERS
+    static let shorterWeekdays = UDAT_SHORTER_WEEKDAYS
+    static let standaloneShorterWeekdays = UDAT_STANDALONE_SHORTER_WEEKDAYS
+    static let cyclicYearsWide = UDAT_CYCLIC_YEARS_WIDE
+    static let cyclicYearsAbbreviated = UDAT_CYCLIC_YEARS_ABBREVIATED
+    static let cyclicYearsNarrow = UDAT_CYCLIC_YEARS_NARROW
+    static let zodiacNamesWide = UDAT_ZODIAC_NAMES_WIDE
+    static let zodiacNamesAbbreviated = UDAT_ZODIAC_NAMES_ABBREVIATED
+    static let zodiacNamesNarrow = UDAT_ZODIAC_NAMES_NARROW
+    static let narrowQuarters = UDAT_NARROW_QUARTERS
+    static let standaloneNarrowQuarters = UDAT_STANDALONE_NARROW_QUARTERS
+}
+
 extension UDisplayContext {
     static let beginningOfSentence = UDISPCTX_CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE
     static let listItem = UDISPCTX_CAPITALIZATION_FOR_UI_LIST_OR_MENU

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -576,12 +576,7 @@ final class CalendarTests : XCTestCase {
         let expected = date.addingTimeInterval(86400*7)
         XCTAssertEqual(oneWeekAfter, expected)
     }
-}
 
-// MARK: - FoundationPreview Disabled Tests
-#if FOUNDATION_FRAMEWORK
-extension CalendarTests {
-    // Re-enable once (Calendar.symbols) is implemented
     func test_symbols() {
         var c = Calendar(identifier: .gregorian)
         // Use english localization
@@ -609,8 +604,57 @@ extension CalendarTests {
         XCTAssertEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.standaloneWeekdaySymbols)
         XCTAssertEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.weekdaySymbols)
     }
+
+    func test_symbols_not_gregorian() {
+        var c = Calendar(identifier: .hebrew)
+        c.locale = Locale(identifier: "en_US")
+        c.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+
+        XCTAssertEqual("AM", c.amSymbol)
+        XCTAssertEqual("PM", c.pmSymbol)
+        XCTAssertEqual( [ "1st quarter", "2nd quarter", "3rd quarter", "4th quarter" ], c.quarterSymbols)
+        XCTAssertEqual( [ "1st quarter", "2nd quarter", "3rd quarter", "4th quarter" ], c.standaloneQuarterSymbols)
+        XCTAssertEqual( [ "AM" ], c.eraSymbols)
+        XCTAssertEqual( [ "AM" ], c.longEraSymbols)
+        XCTAssertEqual( [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "7" ], c.veryShortMonthSymbols)
+        XCTAssertEqual( [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "7" ], c.veryShortStandaloneMonthSymbols)
+        XCTAssertEqual( [ "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar", "Nisan", "Iyar", "Sivan", "Tamuz", "Av", "Elul", "Adar II" ], c.shortMonthSymbols)
+        XCTAssertEqual( [ "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar", "Nisan", "Iyar", "Sivan", "Tamuz", "Av", "Elul", "Adar II" ], c.shortStandaloneMonthSymbols)
+        XCTAssertEqual( [ "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar", "Nisan", "Iyar", "Sivan", "Tamuz", "Av", "Elul", "Adar II"  ], c.monthSymbols)
+        XCTAssertEqual( [ "Tishri", "Heshvan", "Kislev", "Tevet", "Shevat", "Adar I", "Adar", "Nisan", "Iyar", "Sivan", "Tamuz", "Av", "Elul", "Adar II"  ], c.standaloneMonthSymbols)
+        XCTAssertEqual( [ "Q1", "Q2", "Q3", "Q4" ], c.shortQuarterSymbols)
+        XCTAssertEqual( [ "Q1", "Q2", "Q3", "Q4" ], c.shortStandaloneQuarterSymbols)
+        XCTAssertEqual( [ "S", "M", "T", "W", "T", "F", "S" ], c.veryShortStandaloneWeekdaySymbols)
+        XCTAssertEqual( [ "S", "M", "T", "W", "T", "F", "S" ], c.veryShortWeekdaySymbols)
+        XCTAssertEqual( [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ], c.shortStandaloneWeekdaySymbols)
+        XCTAssertEqual( [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ], c.shortWeekdaySymbols)
+        XCTAssertEqual( [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ], c.standaloneWeekdaySymbols)
+        XCTAssertEqual( [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ], c.weekdaySymbols)
+
+        c.locale = Locale(identifier: "es_ES")
+        XCTAssertEqual("a.\u{202f}m.", c.amSymbol)
+        XCTAssertEqual("p.\u{202f}m.", c.pmSymbol)
+        XCTAssertEqual( [ "1.er trimestre", "2.\u{00ba} trimestre", "3.er trimestre", "4.\u{00ba} trimestre" ], c.quarterSymbols)
+        XCTAssertEqual( [ "1.er trimestre", "2.\u{00ba} trimestre", "3.er trimestre", "4.\u{00ba} trimestre" ], c.standaloneQuarterSymbols)
+        XCTAssertEqual( [ "AM" ], c.eraSymbols)
+        XCTAssertEqual( [ "AM" ], c.longEraSymbols)
+        XCTAssertEqual( [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "7" ], c.veryShortMonthSymbols)
+        XCTAssertEqual( [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "7" ], c.veryShortStandaloneMonthSymbols)
+        XCTAssertEqual( [ "tishri", "heshvan", "kislev", "tevet", "shevat", "adar I", "adar", "nisan", "iyar", "sivan", "tamuz", "av", "elul", "adar II" ], c.shortMonthSymbols)
+        XCTAssertEqual( [ "tishri", "heshvan", "kislev", "tevet", "shevat", "adar I", "adar", "nisan", "iyar", "sivan", "tamuz", "av", "elul", "adar II" ], c.shortStandaloneMonthSymbols)
+        XCTAssertEqual( [ "tishri", "heshvan", "kislev", "tevet", "shevat", "adar I", "adar", "nisan", "iyar", "sivan", "tamuz", "av", "elul", "adar II" ], c.monthSymbols)
+        XCTAssertEqual( [ "tishri", "heshvan", "kislev", "tevet", "shevat", "adar I", "adar", "nisan", "iyar", "sivan", "tamuz", "av", "elul", "adar II" ], c.standaloneMonthSymbols)
+        XCTAssertEqual( [ "T1", "T2", "T3", "T4" ], c.shortQuarterSymbols)
+        XCTAssertEqual( [ "T1", "T2", "T3", "T4" ], c.shortStandaloneQuarterSymbols)
+        XCTAssertEqual( [ "D", "L", "M", "X", "J", "V", "S" ], c.veryShortStandaloneWeekdaySymbols)
+        XCTAssertEqual( [ "D", "L", "M", "X", "J", "V", "S" ], c.veryShortWeekdaySymbols)
+        XCTAssertEqual( [ "dom", "lun", "mar", "mi\u{00e9}", "jue", "vie", "s\u{00e1}b" ], c.shortStandaloneWeekdaySymbols)
+        XCTAssertEqual( [ "dom", "lun", "mar", "mi\u{00e9}", "jue", "vie", "s\u{00e1}b" ], c.shortWeekdaySymbols)
+        XCTAssertEqual( [ "domingo", "lunes", "martes", "mi\u{00e9}rcoles", "jueves", "viernes", "s\u{00e1}bado" ], c.standaloneWeekdaySymbols)
+        XCTAssertEqual( [ "domingo", "lunes", "martes", "mi\u{00e9}rcoles", "jueves", "viernes", "s\u{00e1}bado" ], c.weekdaySymbols)
+    }
 }
-#endif
+
 
 // MARK: - Bridging Tests
 #if FOUNDATION_FRAMEWORK


### PR DESCRIPTION
We should include the calendar identifier via the "ca" keyword when getting calendar symbols from ICU, such as "en_US@ca=hebrew". It was mistakenly dropped when we rewrote Calendar, so now we always return the symbols of the default calendar of the locale.

We can fix this by updating the existing implementation with the correct identifier, but we can also just use `ICUDateFormatter`, bypassing `CFDateFormatter` altogether. We chose the latter approach here.

Fixes rdar://110585721
