### PR TITLE
Restore support of deprecated `DateComponent.week` when calculating date

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1382,6 +1382,8 @@ internal final class _Calendar: Equatable, @unchecked Sendable {
             if let amount = components.day { _ = _locked_add(UCAL_DAY_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekOfYear { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekOfMonth { _ = _locked_add(UCAL_WEEK_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
+            // `week` is for backward compatibility only
+            if let amount = components.week { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekday { _ = _locked_add(UCAL_DAY_OF_WEEK, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekdayOrdinal { _ = _locked_add(UCAL_DAY_OF_WEEK_IN_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.hour { _ = _locked_add(UCAL_HOUR_OF_DAY, amount: amount, wrap: wrappingComponents, status: &status) }

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -564,6 +564,18 @@ final class CalendarTests : XCTestCase {
         XCTAssertTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
         XCTAssertFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
     }
+
+    func test_addingDeprecatedWeek() throws {
+        let date = try Date("2024-02-24 01:00:00 UTC", strategy: .iso8601.dateTimeSeparator(.space))
+        var dc = DateComponents()
+        dc.week = 1
+
+        let calendar = Calendar(identifier: .gregorian)
+        let oneWeekAfter = calendar.date(byAdding: dc, to: date)
+
+        let expected = date.addingTimeInterval(86400*7)
+        XCTAssertEqual(oneWeekAfter, expected)
+    }
 }
 
 // MARK: - FoundationPreview Disabled Tests


### PR DESCRIPTION
We had been supporting `DateComponent.week` in Calendar's date calculation even though it's deprecated until recently. Let's keep doing that for the sake of compatibility.

Resolves rdar://110561999
