### PR TITLE
canonicalLocaleIdentifierFromString crashes with invalid input

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -1080,7 +1080,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     @available(watchOS, deprecated: 9, renamed: "identifier(_:from:)")
     public static func canonicalIdentifier(from string: String) -> String {
 #if FOUNDATION_FRAMEWORK
-        CFLocaleCreateCanonicalLocaleIdentifierFromString(kCFAllocatorSystemDefault, string as CFString).rawValue as String
+        return _canonicalLocaleIdentifier(from: string)
 #else
         // TODO: (Locale.canonicalIdentifier) implement in Swift: https://github.com/apple/swift-foundation/issues/45
         return string


### PR DESCRIPTION
`CFLocaleCreateCanonicalLocaleIdentifierFromString` may return nil, so it crashes when we force cast it to `String`. We're already handling this properly in the internal function, so just call into that one.

Resolves rdar://110547526