### PR TITLE
Foundationinternationalization: Implement date range formatted methods

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -143,3 +143,24 @@ public extension FormatStyle where Self == Date.IntervalFormatStyle {
         return Date.IntervalFormatStyle()
     }
 }
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+extension Range where Bound == Date {
+    
+    /// Formats the date range as an interval.
+    func formatted() -> String {
+        return Date.IntervalFormatStyle().format(self)
+    }
+    
+    /// Formats the date range using the specified date and time format styles.
+    func formatted(date: Date.IntervalFormatStyle.DateStyle, time: Date.IntervalFormatStyle.TimeStyle) -> String {
+        return Date.IntervalFormatStyle.init(date: date, time: time).format(self)
+    }
+    
+    /// Formats the date range using the specified style.
+    func formatted<S>(_ style: S) -> S.FormatOutput where S : FormatStyle, S.FormatInput == Range<Date> {
+        return style.format(self)
+    }
+    
+}
+

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -149,17 +149,17 @@ extension Range where Bound == Date {
     
     /// Formats the date range as an interval.
     public func formatted() -> String {
-        return Date.IntervalFormatStyle().format(self)
+        Date.IntervalFormatStyle().format(self)
     }
     
     /// Formats the date range using the specified date and time format styles.
     public func formatted(date: Date.IntervalFormatStyle.DateStyle, time: Date.IntervalFormatStyle.TimeStyle) -> String {
-        return Date.IntervalFormatStyle.init(date: date, time: time).format(self)
+        Date.IntervalFormatStyle(date: date, time: time).format(self)
     }
     
     /// Formats the date range using the specified style.
     public func formatted<S>(_ style: S) -> S.FormatOutput where S : FormatStyle, S.FormatInput == Range<Date> {
-        return style.format(self)
+        style.format(self)
     }
     
 }

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -148,17 +148,17 @@ public extension FormatStyle where Self == Date.IntervalFormatStyle {
 extension Range where Bound == Date {
     
     /// Formats the date range as an interval.
-    func formatted() -> String {
+    public func formatted() -> String {
         return Date.IntervalFormatStyle().format(self)
     }
     
     /// Formats the date range using the specified date and time format styles.
-    func formatted(date: Date.IntervalFormatStyle.DateStyle, time: Date.IntervalFormatStyle.TimeStyle) -> String {
+    public func formatted(date: Date.IntervalFormatStyle.DateStyle, time: Date.IntervalFormatStyle.TimeStyle) -> String {
         return Date.IntervalFormatStyle.init(date: date, time: time).format(self)
     }
     
     /// Formats the date range using the specified style.
-    func formatted<S>(_ style: S) -> S.FormatOutput where S : FormatStyle, S.FormatInput == Range<Date> {
+    public func formatted<S>(_ style: S) -> S.FormatOutput where S : FormatStyle, S.FormatInput == Range<Date> {
         return style.format(self)
     }
     

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -107,12 +107,13 @@ final class DateIntervalFormatStyleTests: XCTestCase {
         XCTAssertEqual(noAMPMStyle.format(date..<date + day * 32), "1/1/2001, 12:00 – 2/2/2001, 12:00")
     }
 
-#if FOUNDATION_FRAMEWORK
     func testLeadingDotSyntax() {
-        let _ = (date..<date + hour).formatted(.interval)
-        let _ = (date..<date + hour).formatted()
+        let range = (date ..< date + hour)
+        
+        XCTAssertEqual(range.formatted(), Date.IntervalFormatStyle().format(range))
+        XCTAssertEqual(range.formatted(date: .numeric, time: .shortened), Date.IntervalFormatStyle(date: .numeric, time: .shortened).format(range))
+        XCTAssertEqual(range.formatted(.interval.day().month().year()), Date.IntervalFormatStyle().day().month().year().format(range))
     }
-#endif
 
     func testForcedHourCycle() {
 


### PR DESCRIPTION
This add the missing `formatted` methods to `Range<Date>`.

https://developer.apple.com/documentation/swift/range/formatted()
https://developer.apple.com/documentation/swift/range/formatted(date:time:)
https://developer.apple.com/documentation/swift/range/formatted(_:)