### PR TITLE
Addressed compiler warnings and updated the incorrect license headers

### DIFF
--- a/Sources/Foundation/Foundation.swift
+++ b/Sources/Foundation/Foundation.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/AttributedString/String.Index+ABI.swift
+++ b/Sources/FoundationEssentials/AttributedString/String.Index+ABI.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/BuiltInUnicodeScalarSet.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/CocoaError.swift
+++ b/Sources/FoundationEssentials/CocoaError.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
  //
- // This source file is part of the Swift Collections open source project
+ // This source file is part of the Swift.org open source project
  //
  // Copyright (c) 2022 Apple Inc. and the Swift project authors
  // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/ErrorCodes+POSIX.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
  //
- // This source file is part of the Swift Collections open source project
+ // This source file is part of the Swift.org open source project
  //
  // Copyright (c) 2022 Apple Inc. and the Swift project authors
  // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/ErrorCodes.swift
+++ b/Sources/FoundationEssentials/ErrorCodes.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
  //
- // This source file is part of the Swift Collections open source project
+ // This source file is part of the Swift.org open source project
  //
  // Copyright (c) 2022 Apple Inc. and the Swift project authors
  // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -244,7 +244,7 @@ extension PredicateExpressions.KeyPath {
         return Self.kind(keyPath, collectionType: collectionType)
     }
     
-    private static func kind<C: Collection, Root>(_ anyKP: PartialKeyPath<Root>, collectionType: C.Type) -> CommonKeyPathKind? {
+    private static func kind<C: Collection>(_ anyKP: AnyKeyPath, collectionType: C.Type) -> CommonKeyPathKind? {
         let kp = anyKP as! PartialKeyPath<C>
         switch kp {
         case \String.count, \Substring.count, \Array<C.Element>.count:

--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // MARK: - Exported Types
+@available(macOS 10.0, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension String {
 #if FOUNDATION_FRAMEWORK
     public typealias CompareOptions = NSString.CompareOptions

--- a/Sources/FoundationEssentials/String/StringBlocks.swift
+++ b/Sources/FoundationEssentials/String/StringBlocks.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationEssentials/UUID_Wrappers.swift
+++ b/Sources/FoundationEssentials/UUID_Wrappers.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
  //
- // This source file is part of the Swift Collections open source project
+ // This source file is part of the Swift.org open source project
  //
  // Copyright (c) 2022 Apple Inc. and the Swift project authors
  // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationInternationalization/CocoaError+Stub.swift
+++ b/Sources/FoundationInternationalization/CocoaError+Stub.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationInternationalization/Date+Locale.swift
+++ b/Sources/FoundationInternationalization/Date+Locale.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationInternationalization/String/String+Locale.swift
+++ b/Sources/FoundationInternationalization/String/String+Locale.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
+++ b/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift Collections open source project
+// This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception


### PR DESCRIPTION
This PR adds the missing `@available` maker to `Swift+Comparisons.swift` and fixed all the incorrect license headers.

Addresses: rdar://108001698, rdar://108968799