### PR TITLE
Add support for non-Codable nil literals in Predicates

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -372,6 +372,7 @@ extension PredicateCodableConfiguration {
         configuration.allowPartialType(PredicateExpressions.ForceCast<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.ForceCast")
         configuration.allowPartialType(PredicateExpressions.TypeCheck<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.TypeCheck")
         configuration.allowPartialType(PredicateExpressions.UnaryMinus<PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.UnaryMinus")
+        configuration.allowPartialType(PredicateExpressions.NilLiteral<Int>.self, identifier: "PredicateExpressions.NilLiteral")
         
         configuration.allowPartialType(PredicateExpressions.KeyPath<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.KeyPath")
         configuration.allowPartialType(PredicateExpressions.Variable<Int>.self, identifier: "PredicateExpressions.Variable")

--- a/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
@@ -173,3 +173,27 @@ extension PredicateExpressions.NilCoalesce : Sendable where LHS : Sendable, RHS 
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension PredicateExpressions.ForcedUnwrap : Sendable where Inner : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct NilLiteral<Wrapped> : StandardPredicateExpression, Codable, Sendable {
+        public typealias Output = Optional<Wrapped>
+        
+        public init() {}
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            nil
+        }
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        }
+        
+        public init(from decoder: Decoder) throws {}
+    }
+    
+    public static func build_NilLiteral<Wrapped>() -> NilLiteral<Wrapped> {
+        NilLiteral()
+    }
+}

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -337,6 +337,12 @@ extension PredicateExpressions.SequenceStartsWith : ConvertibleExpression where 
     }
 }
 
+extension PredicateExpressions.NilLiteral : ConvertibleExpression {
+    fileprivate func convert(state: inout NSPredicateConversionState) throws -> ExpressionOrPredicate {
+        .expression(NSExpression(forConstantValue: nil))
+    }
+}
+
 private protocol OverwritingInitializable {
     init(existing: Self)
 }

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -433,6 +433,20 @@ final class NSPredicateConversionTests: XCTestCase {
         converted = NSPredicate(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), -1) > 1"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+        
+        predicate = Predicate<ObjCObject> {
+            // $0.j == nil
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.j
+                ),
+                rhs: PredicateExpressions.build_NilLiteral()
+            )
+        }
+        converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "j == nil"))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
     }
     
     func testUUID() {

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -372,6 +372,19 @@ final class PredicateTests: XCTestCase {
         XCTAssert(try predicate2.evaluate(Wrapper<Int>(wrapped: 19)))
         XCTAssertThrowsError(try predicate2.evaluate(Wrapper<Int>(wrapped: nil)))
         
+        struct _NonCodableType : Equatable {}
+        let predicate3 = Predicate<Wrapper<_NonCodableType>> {
+            // $0.wrapped == nil
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.wrapped
+                ),
+                rhs: PredicateExpressions.build_NilLiteral()
+            )
+        }
+        XCTAssertFalse(try predicate3.evaluate(Wrapper(wrapped: _NonCodableType())))
+        XCTAssertTrue(try predicate3.evaluate(Wrapper(wrapped: nil)))
     }
     
     #if false // TODO: Re-enable with Variadic Generics


### PR DESCRIPTION
Adds support for `nil` literals that are unconditionally `Sendable & Codable` in predicates even when the wrapped value type is not `Codable` or `Sendable`.

Resolves rdar://111180725