### PR TITLE
Only use week if weekOfYear is missing

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1381,9 +1381,9 @@ internal final class _Calendar: Equatable, @unchecked Sendable {
             if let amount = components.month { _ = _locked_add(UCAL_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.day { _ = _locked_add(UCAL_DAY_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekOfYear { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
+            // `week` is for backward compatibility only, and is only used if weekOfYear is missing
+            if let amount = components.week, components.weekOfYear == nil { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekOfMonth { _ = _locked_add(UCAL_WEEK_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
-            // `week` is for backward compatibility only
-            if let amount = components.week { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekday { _ = _locked_add(UCAL_DAY_OF_WEEK, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekdayOrdinal { _ = _locked_add(UCAL_DAY_OF_WEEK_IN_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.hour { _ = _locked_add(UCAL_HOUR_OF_DAY, amount: amount, wrap: wrappingComponents, status: &status) }


### PR DESCRIPTION
Fixes a regression introduced when rewriting Calendar in Swift -- `CFCalendar` entry points expect this code to only use *one* of week of year or (deprecated) week.

Resolves rdar://111791782