### PR TITLE
Allow nullable result for localizedString(forIdentifier:)

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
@@ -481,7 +481,7 @@ internal class _NSSwiftLocale: _NSLocaleBridge {
         }
 
         switch key {
-        case .identifier: return self.localizedString(forLocaleIdentifier: value)
+        case .identifier: return self._nullableLocalizedString(forLocaleIdentifier: value)
         case .languageCode: return self.localizedString(forLanguageCode: value)
         case .countryCode: return self.localizedString(forCountryCode: value)
         case .scriptCode: return self.localizedString(forScriptCode: value)
@@ -601,9 +601,14 @@ internal class _NSSwiftLocale: _NSLocaleBridge {
     }
 
     override func localizedString(forLocaleIdentifier localeIdentifier: String) -> String {
-        locale.localizedString(forIdentifier: localeIdentifier) ?? ""
+        _nullableLocalizedString(forLocaleIdentifier: localeIdentifier) ?? ""
     }
-
+    
+    /// Some CFLocale APIs require the result to remain `nullable`. They can call this directly, where the `localizedString(forLocaleIdentifier:)` entry point can remain (correctly) non-nullable.
+    private func _nullableLocalizedString(forLocaleIdentifier localeIdentifier: String) -> String? {
+        locale.localizedString(forIdentifier: localeIdentifier)
+    }
+    
     override func localizedString(forLanguageCode languageCode: String) -> String? {
         locale.localizedString(forLanguageCode: languageCode)
     }


### PR DESCRIPTION
Some CFLocale API require the result of `localizedString(forIdentifier:)` to remain `nullable`, even though the `NSLocale` entry point is non-nullable. Provide a mechanism to preserve compatibility.

Resolves rdar://110834805