### PR TITLE
(110650486) Predicate support for max/min functions

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -375,6 +375,8 @@ extension PredicateCodableConfiguration {
         configuration.allowPartialType(PredicateExpressions.SequenceContainsWhere<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<Bool>>.self, identifier: "PredicateExpressions.SequenceContainsWhere")
         configuration.allowPartialType(PredicateExpressions.SequenceContainsWhere<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<Bool>>.self, identifier: "PredicateExpressions.SequenceAllSatisfy")
         configuration.allowPartialType(PredicateExpressions.SequenceStartsWith<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<[Int]>>.self, identifier: "PredicateExpressions.SequenceStartsWith")
+        configuration.allowPartialType(PredicateExpressions.SequenceMaximum<PredicateExpressions.Value<[Int]>>.self, identifier: "PredicateExpressions.SequenceMaximum")
+        configuration.allowPartialType(PredicateExpressions.SequenceMinimum<PredicateExpressions.Value<[Int]>>.self, identifier: "PredicateExpressions.SequenceMinimum")
         configuration.allowPartialType(PredicateExpressions.ConditionalCast<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.ConditionalCast")
         configuration.allowPartialType(PredicateExpressions.ForceCast<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.ForceCast")
         configuration.allowPartialType(PredicateExpressions.TypeCheck<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.TypeCheck")

--- a/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct SequenceMaximum<
+        Elements : PredicateExpression
+    > : PredicateExpression where
+        Elements.Output : Sequence,
+        Elements.Output.Element : Comparable
+    {
+        public typealias Output = Optional<Elements.Output.Element>
+        
+        public let elements: Elements
+        
+        public init(elements: Elements) {
+            self.elements = elements
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try elements.evaluate(bindings).max()
+        }
+    }
+    
+    public static func build_max<Elements>(_ elements: Elements) -> SequenceMaximum<Elements> {
+        SequenceMaximum(elements: elements)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMaximum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMaximum : Codable where Elements : Codable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMaximum : Sendable where Elements : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct SequenceMinimum<
+        Elements : PredicateExpression
+    > : PredicateExpression where
+        Elements.Output : Sequence,
+        Elements.Output.Element : Comparable
+    {
+        public typealias Output = Optional<Elements.Output.Element>
+        
+        public let elements: Elements
+        
+        public init(elements: Elements) {
+            self.elements = elements
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try elements.evaluate(bindings).min()
+        }
+    }
+    
+    public static func build_min<Elements>(_ elements: Elements) -> SequenceMinimum<Elements> {
+        SequenceMinimum(elements: elements)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMinimum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMinimum : Codable where Elements : Codable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.SequenceMinimum : Sendable where Elements : Sendable {}

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -543,6 +543,29 @@ final class NSPredicateConversionTests: XCTestCase {
         XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, NOT ($_local_1 == 2)).@count == 0"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
     }
+    
+    func testMaxMin() {
+        let predicate = Predicate<ObjCObject> {
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_max(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.g
+                    )
+                ),
+                rhs: PredicateExpressions.build_min(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.g
+                    )
+                )
+            )
+        }
+        
+        let converted = NSPredicate(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "g.@max.#self == g.@min.#self"))
+        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+    }
 }
 
 #endif

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -584,6 +584,38 @@ final class PredicateTests: XCTestCase {
         try assertPredicate(.true, value: "Hello", expected: true)
         try assertPredicate(.false, value: "Hello", expected: false)
     }
+    
+    func testMaxMin() throws {
+        var predicate = Predicate<Object> {
+            // $0.g.max() == 2
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_max(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.g
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(2)
+            )
+        }
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 2])))
+        
+        predicate = Predicate<Object> {
+            // $0.g.min() == 2
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_min(
+                    PredicateExpressions.build_KeyPath(
+                        root: $0,
+                        keyPath: \.g
+                    )
+                ),
+                rhs: PredicateExpressions.build_Arg(2)
+            )
+        }
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3])))
+    }
 }
 
 #endif


### PR DESCRIPTION
This adds support for using `Sequence`'s `.min()` and `.max()` functions in predicates