### PR TITLE
`Substring._rangeOf` fast path is incorrect

### DIFF
--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -667,43 +667,11 @@ extension Substring {
         let result: Range<Index>?
         if options.contains(.literal) {
             result = unicodeScalars._range(of: strToFind.unicodeScalars, toHalfWidth: toHalfWidth, diacriticsInsensitive: diacriticsInsensitive, caseFold: caseFold, anchored: anchored, backwards: backwards)
-        } else if !toHalfWidth && !diacriticsInsensitive && !caseFold {
-            // Fast path: iterate through UTF8 view when we don't need to transform string content
-            guard let utf8Result = utf8._range(of: strToFind.utf8, anchored: anchored, backwards: backwards) else {
-                 return nil
-            }
-
-            // Adjust the index to that of the original slice since we called `makeContiguousUTF8` before
-            guard let lower = String.Index(utf8Result.lowerBound, within: self), let upper = String.Index(utf8Result.upperBound, within: self) else {
-                return nil
-            }
-            result = lower..<upper
-
-        } else if _isASCII && strToFind._isASCII {
-            // Fast path: Iterate utf8 without having to decode as unicode scalars. In this case only case folding matters.
-
-            guard let utf8Result = utf8._range(of: strToFind.utf8, toHalfWidth: false, diacriticsInsensitive: false, caseFold: caseFold, anchored: anchored, backwards: backwards) else {
-                return nil
-            }
-
-            // Adjust the index to that of the original slice since we called `makeContiguousUTF8` before
-            guard let lower = String.Index(utf8Result.lowerBound, within: self), let upper = String.Index(utf8Result.upperBound, within: self) else {
-                return nil
-            }
-            result = lower..<upper
-
         } else {
             result = _range(of: strToFind, toHalfWidth: toHalfWidth, diacriticsInsensitive: diacriticsInsensitive, caseFold: caseFold, anchored: anchored, backwards: backwards)
         }
 
         return result
-    }
-
-    var _isASCII: Bool {
-        var mutated = self
-        return mutated.withUTF8 {
-            _allASCII($0)
-        }
     }
 
     func _components(separatedBy separator: Substring, options: String.CompareOptions = []) throws -> [String] {

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -240,6 +240,21 @@ final class StringTests : XCTestCase {
         }
     }
 
+    func testRangeOfString_lineSeparator() {
+        func test(_ tested: String, _ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+            return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
+        }
+        test("\r\n \r", "\r", anchored: false, backwards: false, 2..<3)
+        test("\r\n \r", "\r", anchored: true, backwards: false, nil)
+        test("\r\n \r", "\r", anchored: false, backwards: true, 2..<3)
+        test("\r\n \r", "\r", anchored: true, backwards: true, 2..<3)
+
+        test("\r \r\n \r", "\r", anchored: false, backwards: false, 0..<1)
+        test("\r \r\n \r", "\r", anchored: true, backwards: false, 0..<1)
+        test("\r \r\n \r", "\r", anchored: false, backwards: true, 4..<5)
+        test("\r \r\n \r", "\r", anchored: true, backwards: true, 4..<5)
+    }
+
     func testTryFromUTF16() {
         func test(_ utf16Buffer: [UInt16], expected: String?, file: StaticString = #file, line: UInt = #line) {
             let result = utf16Buffer.withUnsafeBufferPointer {


### PR DESCRIPTION
We had a fast path implemented incorrectly: We search the UTF8 code unit whenever possible, and convert the found UTF8 index back to String index. If the conversion fails, i.e. when the found UTF8 index does not fall on a character boundary, we simply bail and return nil. The correct implementation should be advancing the slice from the point of failure and keeping searching.

But we don't really need this fast path here as we already have another one that skips string transformation inside the helper function. Let's just remove this.