### PR TITLE
Support parameter packs with #Predicate macro

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -30,7 +30,7 @@ public struct Predicate<each Input> : Sendable {
 #if !os(Linux) && !os(Windows)
 @freestanding(expression)
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-public macro Predicate<Input>(_ body: (Input) -> Bool) -> Predicate<Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
+public macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
 #endif
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)


### PR DESCRIPTION
This adds parameter pack support to the macro declaration for `#Predicate`

Resolves rdar://111690754