### PR TITLE
Locale.localeAsIfCurrentWithBundleLocalizations should respect user preferences

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Cache.swift
@@ -369,7 +369,8 @@ struct LocaleCache : Sendable {
             return nil
         }
 
-        let inner = _Locale(identifier: identifier)
+        let (prefs, _) = preferences()
+        let inner = _Locale(identifier: identifier, prefs: prefs)
         return Locale(.fixed(inner))
     }
 }

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -773,6 +773,14 @@ extension LocaleTests {
         // Starting an ID with script code is an acceptable special case
         verify("Hant", cldr: "hant", bcp47: "hant", icu: "hant")
     }
+
+    func test_asIfCurrentWithBundleLocalizations() {
+        let currentLanguage = Locale.current.language.languageCode!
+        var localizations = Set([ "zh", "fr", "en" ])
+        localizations.insert(currentLanguage.identifier) // We're not sure what the current locale is when test runs. Ensure that it's always in the list of available localizations
+        let fakeCurrent = Locale.localeAsIfCurrentWithBundleLocalizations(Array(localizations), allowsMixedLocalizations: false)
+        XCTAssertEqual(fakeCurrent?.language.languageCode, currentLanguage)
+    }
 }
 
 #endif // FOUNDATION_FRAMEWORK


### PR DESCRIPTION
An "as-if-current" locale should reflect user's preferences. We do that correctly if `allowsMixedLocalizations` is true, but we missed that if otherwise.
