### PR TITLE
Support Predicate construction with existential expression

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -15,7 +15,13 @@ public struct Predicate<each Input> : Sendable {
     public let expression : any StandardPredicateExpression<Bool>
     public let variable: (repeat PredicateExpressions.Variable<each Input>)
 
-    public init<E: StandardPredicateExpression<Bool>>(_ builder: (repeat PredicateExpressions.Variable<each Input>) -> E) {
+    @usableFromInline // Preserve ABI for older initializer
+    internal init<E: StandardPredicateExpression<Bool>>(_ builder: (repeat PredicateExpressions.Variable<each Input>) -> E) {
+        self.variable = (repeat PredicateExpressions.Variable<each Input>())
+        self.expression = builder(repeat each variable.element)
+    }
+    
+    public init(_ builder: (repeat PredicateExpressions.Variable<each Input>) -> any StandardPredicateExpression<Bool>) {
         self.variable = (repeat PredicateExpressions.Variable<each Input>())
         self.expression = builder(repeat each variable.element)
     }

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -659,6 +659,27 @@ final class PredicateTests: XCTestCase {
     }
     
     #endif
+    
+    func testBuildDynamically() throws {
+        func _build(_ equal: Bool) -> Predicate<Int> {
+            Predicate<Int> {
+                if equal {
+                    PredicateExpressions.Equal(
+                        lhs: $0,
+                        rhs: PredicateExpressions.Value(1)
+                    )
+                } else {
+                    PredicateExpressions.NotEqual(
+                        lhs: $0,
+                        rhs: PredicateExpressions.Value(1)
+                    )
+                }
+            }
+        }
+        
+        XCTAssertTrue(try _build(true).evaluate(1))
+        XCTAssertFalse(try _build(false).evaluate(1))
+    }
 }
 
 #endif


### PR DESCRIPTION
Developers may wish to construct predicates dynamically with arbitrary operators determined at runtime (for example, when making a predicate editor UI). The predicate builder closure should return an existential rather than a concrete type to allow for this dynamic construction. We annotate the old initializer as `@usableFromInline` to temporarily preserve the ABI of the old initializer until all call-sites have migrated to the source-compatible new initializer.

Resolves rdar://112423538