### PR TITLE
Predicate support for localized/case-insensitive string comparisons

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -383,6 +383,12 @@ extension PredicateCodableConfiguration {
         configuration.allowPartialType(PredicateExpressions.UnaryMinus<PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.UnaryMinus")
         configuration.allowPartialType(PredicateExpressions.NilLiteral<Int>.self, identifier: "PredicateExpressions.NilLiteral")
         
+        #if FOUNDATION_FRAMEWORK
+        configuration.allowPartialType(PredicateExpressions.StringCaseInsensitiveCompare<PredicateExpressions.Value<String>, PredicateExpressions.Value<String>>.self, identifier: "PredicateExpressions.StringCaseInsensitiveCompare")
+        configuration.allowPartialType(PredicateExpressions.StringLocalizedCompare<PredicateExpressions.Value<String>, PredicateExpressions.Value<String>>.self, identifier: "PredicateExpressions.StringLocalizedCompare")
+        configuration.allowPartialType(PredicateExpressions.StringLocalizedStandardContains<PredicateExpressions.Value<String>, PredicateExpressions.Value<String>>.self, identifier: "PredicateExpressions.StringLocalizedStandardContains")
+        #endif
+        
         configuration.allowPartialType(PredicateExpressions.KeyPath<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.KeyPath")
         configuration.allowPartialType(PredicateExpressions.Variable<Int>.self, identifier: "PredicateExpressions.Variable")
         configuration.allowPartialType(PredicateExpressions.Value<Int>.self, identifier: "PredicateExpressions.Value")

--- a/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct StringCaseInsensitiveCompare<
+        Root : PredicateExpression,
+        Other : PredicateExpression
+    > : PredicateExpression where
+        Root.Output : StringProtocol,
+        Other.Output : StringProtocol
+    {
+        public typealias Output = ComparisonResult
+        
+        public let root: Root
+        public let other: Other
+        
+        public init(root: Root, other: Other) {
+            self.root = root
+            self.other = other
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try root.evaluate(bindings).caseInsensitiveCompare(try other.evaluate(bindings))
+        }
+    }
+    
+    public static func build_caseInsensitiveCompare<Root, Other>(_ root: Root, _ other: Other) -> StringCaseInsensitiveCompare<Root, Other> {
+        StringCaseInsensitiveCompare(root: root, other: other)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringCaseInsensitiveCompare : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringCaseInsensitiveCompare : Codable where Root : Codable, Other : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(root)
+        try container.encode(other)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        root = try container.decode(Root.self)
+        other = try container.decode(Other.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringCaseInsensitiveCompare : Sendable where Root : Sendable, Other : Sendable {}
+
+#endif

--- a/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
+++ b/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct StringLocalizedStandardContains<
+        Root : PredicateExpression,
+        Other : PredicateExpression
+    > : PredicateExpression where
+        Root.Output : StringProtocol,
+        Other.Output : StringProtocol
+    {
+        public typealias Output = Bool
+        
+        public let root: Root
+        public let other: Other
+        
+        public init(root: Root, other: Other) {
+            self.root = root
+            self.other = other
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try root.evaluate(bindings).localizedStandardContains(try other.evaluate(bindings))
+        }
+    }
+    
+    public static func build_localizedStandardContains<Root, Other>(_ root: Root, _ other: Other) -> StringLocalizedStandardContains<Root, Other> {
+        StringLocalizedStandardContains(root: root, other: other)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedStandardContains : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedStandardContains : Codable where Root : Codable, Other : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(root)
+        try container.encode(other)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        root = try container.decode(Root.self)
+        other = try container.decode(Other.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedStandardContains : Sendable where Root : Sendable, Other : Sendable {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions {
+    public struct StringLocalizedCompare<
+        Root : PredicateExpression,
+        Other : PredicateExpression
+    > : PredicateExpression where
+        Root.Output : StringProtocol,
+        Other.Output : StringProtocol
+    {
+        public typealias Output = ComparisonResult
+        
+        public let root: Root
+        public let other: Other
+        
+        public init(root: Root, other: Other) {
+            self.root = root
+            self.other = other
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try root.evaluate(bindings).localizedCompare(other.evaluate(bindings))
+        }
+    }
+    
+    public static func build_localizedCompare<Root, Other>(_ root: Root, _ other: Other) -> StringLocalizedCompare<Root, Other> {
+        StringLocalizedCompare(root: root, other: other)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedCompare : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedCompare : Codable where Root : Codable, Other : Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(root)
+        try container.encode(other)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        root = try container.decode(Root.self)
+        other = try container.decode(Other.self)
+    }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension PredicateExpressions.StringLocalizedCompare : Sendable where Root : Sendable, Other : Sendable {}
+
+#endif

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -636,6 +636,29 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
         XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "", c: 0.0, d: 0, e: "c", f: true, g: [2, 3])))
     }
+    
+    #if FOUNDATION_FRAMEWORK
+    
+    func testCaseInsensitiveCompare() throws {
+        let equal = ComparisonResult.orderedSame
+        let predicate = Predicate<Object> {
+            // $0.b.caseInsensitiveCompare("ABC") == equal
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_caseInsensitiveCompare(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.b
+                    ),
+                    PredicateExpressions.build_Arg("ABC")
+                ),
+                rhs: PredicateExpressions.build_Arg(equal)
+            )
+        }
+        XCTAssertTrue(try predicate.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertFalse(try predicate.evaluate(Object(a: 3, b: "def", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+    }
+    
+    #endif
 }
 
 #endif

--- a/Tests/FoundationInternationalizationTests/PredicateInternationalizationTests.swift
+++ b/Tests/FoundationInternationalizationTests/PredicateInternationalizationTests.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+// Predicate does not back-deploy to older Darwin versions
+#if FOUNDATION_FRAMEWORK || os(Linux) || os(Windows)
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+final class PredicateInternationalizationTests: XCTestCase {
+    
+    struct Object {
+        var string: String = ""
+    }
+    
+    #if FOUNDATION_FRAMEWORK
+    
+    func testLocalizedCompare() throws {
+        let predicate = Predicate<String, String, ComparisonResult> {
+            // $0.localizedCompare($1) == $2
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_localizedCompare(
+                    PredicateExpressions.build_Arg($0),
+                    PredicateExpressions.build_Arg($1)
+                ),
+                rhs: PredicateExpressions.build_Arg($2)
+            )
+        }
+        let tests: [(String, String, ComparisonResult)] = [
+            ("ABC", "ABC", .orderedSame),
+            ("ABC", "abc", .orderedDescending),
+            ("abc", "ABC", .orderedAscending),
+            ("ABC", "ÁḄÇ", .orderedAscending)
+        ]
+        
+        for test in tests {
+            XCTAssertTrue(try predicate.evaluate(test.0, test.1, test.2), "Comparison failed for inputs '\(test.0)', '\(test.1)' - expected \(test.2.rawValue)")
+        }
+    }
+    
+    func testLocalizedStandardContains() throws {
+        let predicate = Predicate<Object> {
+            // $0.string.localizedStandardContains("ABC")
+            PredicateExpressions.build_localizedStandardContains(
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.string
+                ),
+                PredicateExpressions.build_Arg("ABC")
+            )
+        }
+        XCTAssertTrue(try predicate.evaluate(Object(string: "ABCDEF")))
+        XCTAssertTrue(try predicate.evaluate(Object(string: "abcdef")))
+        XCTAssertTrue(try predicate.evaluate(Object(string: "ÁḄÇDEF")))
+    }
+    
+    #endif
+    
+}
+
+#endif


### PR DESCRIPTION
This adds support for the `localizedStandardContains`/`localizedCompare`/`caseInsensitiveCompare` functions in `Predicate`. These operators are all within `FOUNDATION_FRAMEWORK` blocks currently since we haven't ported the respective `String` APIs over to this repo yet. We also use `localizedCompare` instead of `localizedStandardCompare` here since the `Standard` comparison uses options such as forced ordering, width insensitive, etc. that destinations of these `Predicate`s do not yet support.

Resolves rdar://110083385