### PR TITLE
Consider both language and region when deciding whether to override day period with conversational style

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -125,7 +125,7 @@ extension Date.FormatStyle {
 
             var preferredHour: Symbol.SymbolType.HourOption?
 
-            if locale.region == .taiwan {
+            if locale.language.languageCode == .chinese && locale.region == .taiwan {
                 switch hour {
                 case .defaultDigitsWithAbbreviatedAMPM:
                     preferredHour = .conversationalDefaultDigitsWithAbbreviatedAMPM

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -559,6 +559,23 @@ final class DateFormatStyleTests : XCTestCase {
             verifyWithFormat(afternoon, expected: "15時")
             verifyWithFormat(evening, expected: "21時")
         }
+
+        // Tests for when region matches the special case but language doesn't
+        do {
+            locale = Locale(identifier: "en_TW")
+            format = .init(timeZone: .gmt).hour(.twoDigits(amPM: .wide)).minute().second()
+#if FOUNDATION_FRAMEWORK
+    let separator = "\u{202f}"
+#else
+    let separator = " "
+#endif
+            verifyWithFormat(middleOfNight, expected: "03:50:00\(separator)AM")
+            verifyWithFormat(earlyMorning, expected: "06:50:00\(separator)AM")
+            verifyWithFormat(morning, expected: "09:50:00\(separator)AM")
+            verifyWithFormat(noon, expected: "12:50:00\(separator)PM")
+            verifyWithFormat(afternoon, expected: "03:50:00\(separator)PM")
+            verifyWithFormat(evening, expected: "09:50:00\(separator)PM")
+        }
     }
 }
 

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -241,6 +241,22 @@ final class ICUPatternGeneratorTests: XCTestCase {
             test(symbols: .init(year: .defaultDigits, month: .defaultDigits, day: .defaultDigits),
                  expectedPattern: "d/M/y")
         }
+
+        do {
+            // We do not override locales if language isn't Chinese
+            // So there should be no "B" in the pattern
+            locale = Locale(identifier: "en_TW")
+            calendar = Calendar(identifier: .gregorian)
+#if FOUNDATION_FRAMEWORK
+    let separator = "\u{202f}"
+#else
+    let separator = " "
+#endif
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits),
+                 expectedPattern: "h:mm\(separator)a")
+            test(symbols: .init(hour: .defaultDigitsWithAbbreviatedAMPM, minute: .defaultDigits, second: .defaultDigits),
+                 expectedPattern: "h:mm:ss\(separator)a")
+        }
     }
 
 }


### PR DESCRIPTION
We added an override to use the conversational day period option for Taiwan in #168. We should constrain it to when the language is Chinese.
