### PR TITLE
(112778892) Unlocalized decimal separators

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -402,6 +402,9 @@ internal final class _Locale: Sendable, Hashable {
 
     // This only includes a subset of preferences that are representable by
     // CLDR keywords: https://www.unicode.org/reports/tr35/#Key_Type_Definitions
+    //
+    // Intentionally ignore `prefs.country`: Locale identifier should already contain
+    // that information. Do not override it.
     internal var identifierCapturingPreferences: String {
         lock.withLock { state in
             if let result = state.identifierCapturingPreferences {
@@ -422,10 +425,6 @@ internal final class _Locale: Sendable, Hashable {
             let calendarID = _lockedCalendarIdentifier(&state)
             if let weekdayNumber = prefs.firstWeekday?[calendarID], let weekday = Locale.Weekday(Int32(weekdayNumber)) {
                 components.firstDayOfWeek = weekday
-            }
-
-            if let country = prefs.country {
-                components.region = .init(country)
             }
 
             if let measurementSystem = prefs.measurementSystem {

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -354,8 +354,8 @@ final class LocaleTests : XCTestCase {
         // We treat it as US system as long as `metricUnits` is false
         expectIdentifier("en_US", preferences: .init(metricUnits: false, measurementUnits: .centimeters), expectedFullIdentifier: "en_US@measure=ussystem")
 
-        expectIdentifier("en_US", preferences: .init(country: "GB"), expectedFullIdentifier: "en_US@rg=gbzzzz")
-        // Preference's region code is the same as the language code; no need for the specific keyword
+        // 112778892: Country pref is intentionally ignored
+        expectIdentifier("en_US", preferences: .init(country: "GB"), expectedFullIdentifier: "en_US")
         expectIdentifier("en_US", preferences: .init(country: "US"), expectedFullIdentifier: "en_US")
 
         expectIdentifier("en_US", preferences: .init(firstWeekday: [.gregorian : 3]), expectedFullIdentifier: "en_US@fw=tue")


### PR DESCRIPTION
We regressed this behavior in 110211953; Now `IntegerFormatStyle` (and all other number format styles) and `Date.FormatStyle` ignores user's region settings if it uses the current locale.

The regression was caused by us changing to use `locale.identifierCapturingPreferences` for the identifier, which includes "Country" code from global preferences as the extra "rg" keyword. I misunderstood what that represents -- It has nothing to do with the Region setting in System Preferences. We should ignore it internally.

I'm very inclined to remove the reference to that key altogether, but let's keep it for compatibility reason for now.
