### PR TITLE
Predicate incorrectly asserts on some keypaths

### DIFF
--- a/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
+++ b/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
@@ -16,10 +16,11 @@ extension UInt32 {
     private static var COMPONENT_HEADER_KIND_MASK: UInt32 { 0x7F00_0000 }
     private static var COMPONENT_HEADER_PAYLOAD_MASK: UInt32 { 0x00FF_FFFF }
     
+    private static var STORED_COMPONENT_HEADER_PAYLOAD_MASK: UInt32 { 0x007F_FFFF }
+    fileprivate static var STORED_COMPONENT_PROPERTY_OFFSET_OUT_OF_LINE: UInt32 { 0x007F_FFFF }
+    
     private static var COMPUTED_COMPONENT_PAYLOAD_ARGUMENTS_MASK: UInt32 { 0x0008_0000 }
     private static var COMPUTED_COMPONENT_PAYLOAD_SETTABLE_MASK: UInt32 { 0x0040_0000 }
-    
-    fileprivate static var PROPERTY_OFFSET_TOO_LARGE: UInt32 { 0x00FF_FFFF }
     
     fileprivate var _keyPathHeader_bufferSize: Int {
         Int(self & Self.KEYPATH_HEADER_BUFFER_SIZE_MASK)
@@ -31,6 +32,10 @@ extension UInt32 {
     
     fileprivate var _keyPathComponentHeader_payload: UInt32 {
         self & Self.COMPONENT_HEADER_PAYLOAD_MASK
+    }
+    
+    fileprivate var _keyPathComponentHeader_storedPayload: UInt32 {
+        self & Self.STORED_COMPONENT_HEADER_PAYLOAD_MASK
     }
     
     fileprivate var _keyPathComponentHeader_computedHasArguments: Bool {
@@ -56,7 +61,7 @@ extension AnyKeyPath {
             fallthrough
         case 3: // class stored property
             // Stored property components are either just the payload, or the payload plus 32 bits if the payload is the sentinel value
-            let size = (firstComponentHeader._keyPathComponentHeader_payload == .PROPERTY_OFFSET_TOO_LARGE) ? MemoryLayout<UInt64>.size : MemoryLayout<UInt32>.size
+            let size = (firstComponentHeader._keyPathComponentHeader_storedPayload == .STORED_COMPONENT_PROPERTY_OFFSET_OUT_OF_LINE) ? MemoryLayout<UInt64>.size : MemoryLayout<UInt32>.size
             if header._keyPathHeader_bufferSize > size {
                 fatalError("Predicate does not support keypaths with multiple components")
             }

--- a/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
+++ b/Sources/FoundationEssentials/Predicate/KeyPath+Inspection.swift
@@ -40,7 +40,7 @@ extension UInt32 {
     }
 }
 
-private func _keyPathOffset<T>(_ root: T, _ keyPath: AnyKeyPath) -> Int? {
+private func _keyPathOffset<T>(_ root: T.Type, _ keyPath: AnyKeyPath) -> Int? {
     MemoryLayout<T>.offset(of: keyPath as! PartialKeyPath<T>)
 }
 
@@ -58,7 +58,10 @@ extension AnyKeyPath {
             fallthrough
         case 3: // class stored property
             // Key paths to stored properties are only single-component if MemoryLayout.offset(of:) returns an offset
-            if _keyPathOffset(Self.rootType, self) == nil {
+            func project<T>(_: T.Type) -> Bool {
+                _keyPathOffset(T.self, self) == nil
+            }
+            if _openExistential(Self.rootType, do: project) {
                 fatalError("Predicate does not support keypaths with multiple components")
             }
         case 2: // computed

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -680,6 +680,38 @@ final class PredicateTests: XCTestCase {
         XCTAssertTrue(try _build(true).evaluate(1))
         XCTAssertFalse(try _build(false).evaluate(1))
     }
+    
+    func testResilientKeyPaths() {
+        // Local, non-resilient type
+        struct Foo {
+            let a: String   // Non-resilient
+            let b: Date     // Resilient (in Foundation)
+            let c: String   // Non-resilient
+        }
+        
+        let now = Date.now
+        let _ = Predicate<Foo> {
+            PredicateExpressions.build_Conjunction(
+                lhs: PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.a
+                    ),
+                    rhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.c
+                    )
+                ),
+                rhs: PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.b
+                    ),
+                    rhs: PredicateExpressions.build_Arg(now)
+                )
+            )
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
In our key path inspection logic, I unfortunately got a few values wrong when inspecting the memory contents of keypaths. This leads to the inspection logic detecting stored property keypaths which use out-of-line storage (i.e. those with a very large offset in a large struct or those whose offset needs to be calculated at runtime due to properties of resilient types) as multiple components when they are only one component. This PR updates the mask values to ensure the appropriate logic, and the unit test (which accesses keypaths before, at, and after the resilient Date type property) ensures that predicate initialization with these keypaths no longer crashes.