### PR TITLE
Fix JSONDecoder.unwrapString expectedType

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -784,7 +784,7 @@ extension JSONDecoderImpl: Decoder {
     }
 
     private func unwrapString(from value: JSONMap.Value, for codingPathNode: _JSONCodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> String {
-        try checkNotNull(value, expectedType: [String].self, for: codingPathNode, additionalKey)
+        try checkNotNull(value, expectedType: String.self, for: codingPathNode, additionalKey)
 
         guard case .string(let region, let isSimple) = value else {
             throw self.createTypeMismatchError(type: String.self, for: codingPathNode.path(with: additionalKey), value: value)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2132,6 +2132,17 @@ extension JSONEncoderTests {
         XCTAssertEqual("{\"this_is_camel_case\":\"test\"}", resultString)
     }
 
+    func testDecodingStringExpectedType() {
+        let input = #"{"thisIsCamelCase": null}"#.data(using: String._Encoding.utf8)!
+        do {
+            _ = try JSONDecoder().decode(DecodeMe3.self, from: input)
+        } catch DecodingError.valueNotFound(let expected, _) {
+            XCTAssertTrue(expected == String.self)
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+    }
+
     func testEncodingKeyStrategySnakeGenerated() {
         // Test that this works with a struct that has automatically generated keys
         let input = "{\"this_is_camel_case\":\"test\"}".data(using: String._Encoding.utf8)!


### PR DESCRIPTION
 `func unwrapString(from value: ...)` throws `DecodingError.valueNotFound` if the value is `null`, but it incorrectly reports that the expected type as `Array<String>` instead of `String`.
 
This PR fixes the bug, ensuring that the thrown error reports the expected type as `String` aligning the behaviour with Foundation on existing Darwin platforms.

```swift
DecodingError.valueNotFound(String.self, _)
```
