### PR TITLE
Conditionalize Darwin imports with canImport instead of os

### DIFF
--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS)
+#if canImport(Darwin)
 import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Glibc
-#elseif os(Windows)
+#elseif canImport(ucrt)
 import ucrt
 #endif
 


### PR DESCRIPTION
We should ensure that our platform-specific imports are conditionalized with `canImport` rather than `os`. In this case, the file failed to build for watchOS because the `Darwin` import was excluded unintentionally.