### PR TITLE
Empty string is returned instead of null for failure on CFLocaleCreateLocaleIdentifierFromWindowsLocaleCode

### DIFF
--- a/Sources/FoundationInternationalization/Locale/Locale.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale.swift
@@ -1119,7 +1119,10 @@ public struct Locale : Hashable, Equatable, Sendable {
 
     /// Returns the `Locale` identifier from a given Windows locale code, or nil if it could not be converted.
     public static func identifier(fromWindowsLocaleCode code: Int) -> String? {
-        _Locale.identifierFromWindowsLocaleCode(UInt32(code))
+        guard let unsigned = UInt32(exactly: code) else {
+            return nil
+        }
+        return _Locale.identifierFromWindowsLocaleCode(unsigned)
     }
 
     /// Returns the Windows locale code from a given identifier, or nil if it could not be converted.

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -441,12 +441,12 @@ internal final class _Locale: Sendable, Hashable {
         }
     }
 
-    internal static func identifierFromWindowsLocaleCode(_ code: UInt32) -> String {
+    internal static func identifierFromWindowsLocaleCode(_ code: UInt32) -> String? {
         let result = _withFixedCharBuffer(size: MAX_ICU_NAME_SIZE) { buffer, size, status in
             return uloc_getLocaleForLCID(code, buffer, size, &status)
         }
 
-        return result ?? ""
+        return result
     }
 
     internal static func windowsLocaleCode(from identifier: String) -> Int? {

--- a/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Wrappers.swift
@@ -124,7 +124,10 @@ extension NSLocale {
 
     @objc(_localeIdentifierFromWindowsLocaleCode:)
     class func _localeIdentifier(fromWindowsLocaleCode: UInt32) -> String? {
-        Locale.identifier(fromWindowsLocaleCode: Int(fromWindowsLocaleCode))
+        guard let code = Int(exactly: fromWindowsLocaleCode) else {
+            return nil
+        }
+        return Locale.identifier(fromWindowsLocaleCode: code)
     }
 
     @objc(_windowsLocaleCodeFromLocaleIdentifier:)

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -369,6 +369,12 @@ final class LocaleTests : XCTestCase {
         expectIdentifier("en_US", preferences: .init(minDaysInFirstWeek: [.gregorian: 7]), expectedFullIdentifier: "en_US")
         expectIdentifier("en_US", preferences: .init(dateFormats: [.abbreviated: "custom style"]), expectedFullIdentifier: "en_US")
     }
+    
+    func test_badWindowsLocaleID() {
+        // Negative values are invalid
+        let result = Locale.identifier(fromWindowsLocaleCode: -1)
+        XCTAssertNil(result)
+    }
 }
 
 final class LocalePropertiesTests : XCTestCase {


### PR DESCRIPTION
In previous releases, `CFLocaleCreateLocaleIdentifierFromWindowsLocaleCode` would return `NULL` for a bad locale code. This restores that behavior instead of returning an empty string.

rdar://113874839