### PR TITLE
Ensure predicate dictionary subscript default value evaluation is lazy

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
@@ -84,8 +84,10 @@ extension PredicateExpressions {
         }
         
         public func evaluate(_ bindings: PredicateBindings) throws -> Output {
-            let defaultValue = try `default`.evaluate(bindings)
-            return try wrapped.evaluate(bindings)[try key.evaluate(bindings), default: defaultValue]
+            guard let value =  try wrapped.evaluate(bindings)[try key.evaluate(bindings)] else {
+                return try `default`.evaluate(bindings)
+            }
+            return value
         }
     }
     


### PR DESCRIPTION
The stdlib `Dictionary` API uses an `autoclosure` to compute the default value, which means that the default value is computed lazily. However, the `Predicate` in-memory evaluation path previously eagerly fetched the default value. We should match the stdlib behavior here so that in-memory evaluation behaves the same as standard swift code.

Resolves #241 