### PR TITLE
Move `#Predicate` macro to FoundationPreview

### DIFF
--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,8 +1,7 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-import CompilerPluginSupport
 
 let package = Package(
     name: "FoundationPreview",
@@ -81,40 +80,4 @@ package.targets.append(contentsOf: [
         "FoundationInternationalization"
     ]),
 ])
-#endif
-
-#if !os(Linux) && !os(Windows)
-// FoundationMacros
-package.dependencies.append(
-    .package(
-        url: "https://github.com/apple/swift-syntax.git",
-        from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-08-15-a")
-)
-package.targets.append(contentsOf: [
-    .macro(
-        name: "FoundationMacros",
-        dependencies: [
-            .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "SwiftOperators", package: "swift-syntax"),
-            .product(name: "SwiftParser", package: "swift-syntax"),
-            .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-        ],
-        swiftSettings: [
-            .enableExperimentalFeature("AccessLevelOnImport")
-        ]
-    ),
-    .testTarget(
-        name: "FoundationMacrosTests",
-        dependencies: [
-            "FoundationMacros",
-            "TestSupport"
-        ]
-    )
-])
-
-if let index = package.targets.firstIndex(where: { $0.name == "FoundationEssentials" }) {
-    package.targets[index].dependencies.append("FoundationMacros")
-}
 #endif

--- a/Sources/FoundationMacros/FoundationMacros.swift
+++ b/Sources/FoundationMacros/FoundationMacros.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !FOUNDATION_FRAMEWORK
+
+import SwiftSyntaxMacros
+import SwiftCompilerPlugin
+
+@main
+struct FoundationMacros: CompilerPlugin {
+  var providingMacros: [Macro.Type] = [PredicateMacro.self]
+}
+
+#endif

--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -1,0 +1,1159 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import SwiftDiagnostics
+@_implementationOnly import SwiftSyntaxBuilder
+#else
+package import SwiftDiagnostics
+package import SwiftSyntaxBuilder
+#endif
+
+// A list of all functions supported by Predicate itself, any other functions called will be diagnosed as an error
+// This allows for checking the function name, the number of arguments, and the argument labels, but the types of the arguments will need to be validated by the post-expansion type checking pass
+// The trailingClosure parameter indicates whether the final argument is a closure and therefore supports dropping the final argument label in favor of a trailing closure
+private let knownSupportedFunctions: Set<FunctionStructure> = [
+    FunctionStructure("contains", arguments: [.unlabeled]),
+    FunctionStructure("contains", arguments: [.closure(labeled: "where")]),
+    FunctionStructure("allSatisfy", arguments: [.closure(labeled: nil)]),
+    FunctionStructure("flatMap", arguments: [.closure(labeled: nil)]),
+    FunctionStructure("filter", arguments: [.closure(labeled: nil)]),
+    FunctionStructure("subscript", arguments: [.unlabeled]),
+    FunctionStructure("subscript", arguments: [.unlabeled, "default"]),
+    FunctionStructure("starts", arguments: ["with"]),
+    FunctionStructure("min", arguments: []),
+    FunctionStructure("max", arguments: []),
+    FunctionStructure("localizedStandardContains", arguments: [.unlabeled]),
+    FunctionStructure("localizedCompare", arguments: [.unlabeled]),
+    FunctionStructure("caseInsensitiveCompare", arguments: [.unlabeled])
+]
+
+private let supportedFunctionSuggestions: [FunctionStructure : FunctionStructure] = [
+    FunctionStructure("hasPrefix", arguments: [.unlabeled]) : FunctionStructure("starts", arguments: ["with"]),
+    FunctionStructure("localizedCaseInsensitiveContains", arguments: [.unlabeled]) : FunctionStructure("localizedStandardContains", arguments: [.unlabeled]),
+    FunctionStructure("localizedCaseInsensitiveCompare", arguments: [.unlabeled]) : FunctionStructure("localizedCompare", arguments: [.unlabeled]),
+    FunctionStructure("localizedStandardCompare", arguments: [.unlabeled]) : FunctionStructure("localizedCompare", arguments: [.unlabeled])
+]
+
+#if FOUNDATION_FRAMEWORK
+private let moduleName = "Foundation"
+#else
+private let moduleName = "FoundationEssentials"
+#endif
+
+private struct FunctionStructure: Hashable {
+    struct Argument : Hashable, ExpressibleByStringLiteral {
+        let label: String?
+        let isClosure: Bool
+        
+        init(stringLiteral: String) {
+            label = stringLiteral
+            isClosure = false
+        }
+        
+        init(label: String?, closure: Bool) {
+            self.label = label
+            self.isClosure = closure
+        }
+        
+        static func closure(labeled label: String?) -> Self {
+            Self(label: label, closure: true)
+        }
+        
+        static var unlabeled: Self {
+            Self(label: nil, closure: false)
+        }
+        
+        static func ==(lhs: Self, rhs: Self) -> Bool {
+            lhs.label == rhs.label
+        }
+    }
+    let name: String
+    let arguments: [Argument]
+    let hasTrailingClosure: Bool
+    
+    var supportsTrailingClosure: Bool {
+        hasTrailingClosure || (arguments.last?.isClosure ?? false)
+    }
+    
+    var signature: String {
+        let args = arguments.map { ($0.label ?? "_") + ":" }.joined()
+        return "\(name)(\(args))"
+    }
+    
+    init(_ name: String, arguments: [Argument], trailingClosure: Bool = false) {
+        self.name = name
+        self.arguments = arguments
+        self.hasTrailingClosure = trailingClosure
+    }
+    
+    func matches(_ other: FunctionStructure) -> Bool {
+        guard self.name == other.name else { return false }
+        
+        switch (self.hasTrailingClosure, other.hasTrailingClosure) {
+        case (true, true), (false, false):
+            return self.arguments == other.arguments
+        case (true, false):
+            guard let otherLast = other.arguments.last else { return false }
+            return self.arguments == other.arguments.dropLast() && otherLast.isClosure
+        case (false, true):
+            guard let last = self.arguments.last else { return false }
+            return self.arguments.dropLast() == other.arguments && last.isClosure
+        }
+    }
+    
+    func fixItChanges(transformingFrom source: FunctionCallExprSyntax) -> [FixIt.Change]? {
+        let sourceHasTrailingClosure = source.trailingClosure != nil
+        if sourceHasTrailingClosure {
+            guard supportsTrailingClosure else { return nil }
+        }
+        let sourceArgumentTotalCount = source.argumentList.count + (sourceHasTrailingClosure ? 1 : 0)
+        let argumentTotalCount = self.arguments.count + (hasTrailingClosure ? 1 : 0)
+        guard argumentTotalCount == sourceArgumentTotalCount,
+              let calledExpr = source.calledExpression.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+        var newFunctionCall = source
+        newFunctionCall.calledExpression = ExprSyntax(calledExpr.with(\.name, .identifier(name)))
+        newFunctionCall.argumentList = TupleExprElementListSyntax(zip(source.argumentList, arguments).map {
+            if let newLabel = $1.label {
+                return $0.with(\.label, .identifier(newLabel)).with(\.colon, .colonToken()).with(\.expression, $0.expression.with(\.leadingTrivia, [.spaces(1)]))
+            } else {
+                return $0.with(\.label, nil).with(\.colon, nil).with(\.trailingTrivia, []).with(\.expression, $0.expression.with(\.leadingTrivia, []))
+            }
+        })
+        newFunctionCall.leadingTrivia = []
+        newFunctionCall.trailingTrivia = []
+        if self.hasTrailingClosure && source.trailingClosure == nil, let newTrailingClosure = source.argumentList.last?.expression.as(ClosureExprSyntax.self) {
+            newFunctionCall.trailingClosure = newTrailingClosure
+        }
+        return [.replace(oldNode: Syntax(source), newNode: Syntax(newFunctionCall))]
+    }
+}
+
+private func _knownMatchingFunction(_ structure: FunctionStructure) -> FunctionStructure? {
+    knownSupportedFunctions.first {
+        $0.matches(structure)
+    }
+}
+
+private func _suggestionForUnknownFunction(_ structure: FunctionStructure) -> FunctionStructure? {
+    guard let key = supportedFunctionSuggestions.keys.first(where: { $0.matches(structure) }) else {
+        return nil
+    }
+    return supportedFunctionSuggestions[key]
+}
+
+private class ShorthandArgumentIdentifierDetector: SyntaxVisitor {
+    var found = false
+
+    override func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
+        // Look for identifiers such as $0, $1, etc.
+        if case let .dollarIdentifier(identifier) = node.identifier.tokenKind, identifier.dropFirst().allSatisfy(\.isNumber) {
+            found = true
+            return .skipChildren
+        } else {
+            return .visitChildren
+        }
+    }
+}
+
+extension SyntaxProtocol {
+    var containsShorthandArgumentIdentifiers: Bool {
+        let visitor = ShorthandArgumentIdentifierDetector(viewMode: .all)
+        visitor.walk(self)
+        return visitor.found
+    }
+}
+
+private protocol PredicateSyntaxRewriter : SyntaxRewriter {
+    var success: Bool { get }
+    var diagnostics: [Diagnostic] { get }
+}
+
+extension PredicateSyntaxRewriter {
+    var success: Bool { true }
+    var diagnostics: [Diagnostic] { [] }
+}
+
+extension SyntaxProtocol {
+    fileprivate func rewrite(with rewriter: some PredicateSyntaxRewriter) throws -> Syntax {
+        let translated = rewriter.rewrite(Syntax(self))
+        guard rewriter.success else {
+            throw DiagnosticsError(diagnostics: rewriter.diagnostics)
+        }
+        return translated
+    }
+}
+
+private class OptionalChainRewriter: SyntaxRewriter, PredicateSyntaxRewriter {
+    var withinValidChainingTreeStart = true
+    var withinChainingTree = false
+    var optionalInput: ExprSyntax? = nil
+    
+    private func _prePossibleTopOfTree() -> Bool {
+        if !withinChainingTree && withinValidChainingTreeStart {
+            withinChainingTree = true
+            return true
+        }
+        return false
+    }
+    
+    private func _postTopOfTree(_ node: ExprSyntax) -> ExprSyntax {
+        assert(withinChainingTree)
+        withinChainingTree = false
+        if let input = optionalInput {
+            optionalInput = nil
+            let visited = self.visit(input)
+            let closure = ClosureExprSyntax(statements: [CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(node))])
+            let functionMember = MemberAccessExprSyntax(base: visited, name: "flatMap")
+            let functionCall = FunctionCallExprSyntax(calledExpression: functionMember, argumentList: [], trailingClosure: closure)
+            return ExprSyntax(functionCall)
+        }
+        return node
+    }
+    
+    override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
+        guard withinChainingTree else {
+            // If we're not already in a chaining tree, just keep progressing with our current rewriter
+            return super.visit(node)
+        }
+        
+        // We're in the middle of a potential tree, so rewrite the closure with a fresh state
+        // This ensures potential chaining in the closure isn't rewritten outside of the closure
+        guard let rewritten = (try? node.rewrite(with: OptionalChainRewriter()))?.as(ExprSyntax.self) else {
+            // If rewriting the closure failed, just leave the closure as-is
+            return ExprSyntax(node)
+        }
+        return rewritten
+    }
+    
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        let priorValidTreeStart = withinValidChainingTreeStart
+        defer { withinValidChainingTreeStart = priorValidTreeStart }
+        
+        if node.argumentList.containsShorthandArgumentIdentifiers {
+            withinValidChainingTreeStart = false
+        }
+        
+        let topOfTree = _prePossibleTopOfTree()
+        let visited = super.visit(node)
+        if topOfTree {
+            return _postTopOfTree(visited)
+        } else {
+            return visited
+        }
+    }
+    
+    override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
+        let topOfTree = _prePossibleTopOfTree()
+        let visited = super.visit(node)
+        if topOfTree {
+            return _postTopOfTree(visited)
+        } else {
+            return visited
+        }
+    }
+    
+    override func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
+        guard withinChainingTree else {
+            return super.visit(node)
+        }
+        // Capture the optional input, and replace it in the output expression with a "$0"
+        optionalInput = node.expression
+        return .init(IdentifierExprSyntax(identifier: .dollarIdentifier("$0")))
+    }
+}
+
+extension CodeBlockItemListSyntax.Element.Item {
+    fileprivate var _expression: ExprSyntax? {
+        switch self {
+        case .expr(let expr): return expr
+        case .stmt(let stmt): return stmt.as(ExpressionStmtSyntax.self)?.expression
+        default: return nil
+        }
+    }
+}
+
+extension ConditionElementListSyntax {
+    fileprivate var optionalBindings: [OptionalBindingConditionSyntax]? {
+        var result = [OptionalBindingConditionSyntax]()
+        for element in self {
+            switch element.condition {
+            case let .optionalBinding(binding):
+                result.append(binding)
+            default:
+                return nil
+            }
+        }
+        return result
+    }
+}
+
+extension ClosureParameterListSyntax {
+    fileprivate var withVariableWrappedTypes: Self {
+        return Self(self.map {
+            if let type = $0.type {
+                $0.with(\.type, "PredicateExpressions.Variable<\(type)>")
+            } else {
+                $0
+            }
+        })
+    }
+}
+
+extension KeyPathExprSyntax {
+    private enum KeyPathDirectExpressionRewritingError : Error {
+        case unknownKeypathComponentType
+    }
+    
+    fileprivate func asDirectExpression<E: ExprSyntaxProtocol>(on base: E) -> ExprSyntax? {
+        try? self.components.reduce(ExprSyntax(base)) {
+            switch $1.component {
+            case .property(let prop):
+                ExprSyntax(MemberAccessExprSyntax(_base: $0, prop: prop))
+            case .optional(let opt):
+                if opt.questionOrExclamationMark.tokenKind == .exclamationMark {
+                    ExprSyntax(ForcedValueExprSyntax(expression: $0))
+                } else {
+                    ExprSyntax(OptionalChainingExprSyntax(expression: $0))
+                }
+            case .subscript(let sub):
+                ExprSyntax(SubscriptExprSyntax(calledExpression: $0, argumentList: sub.argumentList))
+            default:
+                throw KeyPathDirectExpressionRewritingError.unknownKeypathComponentType
+            }
+        }
+    }
+}
+
+extension PrefixOperatorExprSyntax {
+    // Work around the TokenSyntax? -> TokenSyntax source breaking change
+    var _operatorToken: TokenSyntax? {
+        self.operatorToken
+    }
+}
+
+extension DoStmtSyntax {
+    // Work around the CatchClauseListSyntax? -> CatchClauseListSyntax source breaking change
+    var _catchClauses: CatchClauseListSyntax? {
+        self.catchClauses
+    }
+}
+
+#if !FOUNDATION_FRAMEWORK
+extension KeyPathPropertyComponentSyntax {
+    init(_identifier id: TokenSyntax) {
+        self.init(declName: DeclReferenceExprSyntax(baseName: id))
+    }
+}
+
+extension ClosureSignatureSyntax.Input {
+    var _parameterClause: ClosureParameterClauseSyntax? {
+        if case let .parameterClause(paramClause) = self {
+            return paramClause
+        }
+        return nil
+    }
+    
+    init(_parameterClause parameterClause: ClosureParameterClauseSyntax) {
+        self = .parameterClause(parameterClause)
+    }
+}
+
+extension MemberAccessExprSyntax {
+    init(_base base: some ExprSyntaxProtocol, prop: KeyPathPropertyComponentSyntax) {
+        self.init(base: base, declName: prop.declName)
+    }
+}
+#endif
+
+private class PredicateQueryRewriter: SyntaxRewriter, PredicateSyntaxRewriter {
+    private let indentWidth: Trivia = .spaces(4)
+    private var indentLevel = 0
+    private var indent: Trivia {
+        Trivia(pieces: Array(repeating: .spaces(4), count: indentLevel))
+    }
+    var validOptionalChainingTree = true
+    var diagnostics: [Diagnostic] = []
+    var success: Bool { diagnostics.isEmpty }
+    
+    private func diagnose(node: SyntaxProtocol, message: PredicateExpansionDiagnostic, fixIts: [FixIt] = []) {
+        diagnostics.append(.init(node: Syntax(node), message: message, fixIts: fixIts))
+    }
+    
+    private func makeArgument(label: String?, _ expression: ExprSyntax, shouldVisit: Bool = true, shouldIndent: Bool = true) -> TupleExprElementSyntax {
+        if shouldIndent {
+            indentLevel += 1
+        }
+        defer {
+            if shouldIndent {
+                indentLevel -= 1
+            }
+        }
+        
+        let labelSyntax = label.map {
+            TokenSyntax(.identifier($0), presence: .present)
+        }?.with(\.leadingTrivia, indent)
+        
+        let colonSyntax = label.map { _ in
+            TokenSyntax(.colon, presence: .present)
+        }
+        
+        var argument = shouldVisit ? visit(expression) : expression
+        
+        if shouldVisit && argument == expression {
+            argument = "PredicateExpressions.build_Arg(\(expression.with(\.leadingTrivia, []).with(\.trailingTrivia, [])))"
+        }
+        
+        argument = argument.with(\.leadingTrivia, label == nil ? indent : .space)
+        return .init(label: labelSyntax,
+                     colon: colonSyntax,
+                     expression: argument,
+                     trailingComma: nil)
+    }
+    
+    override func visit(_ node: PrefixOperatorExprSyntax) -> ExprSyntax {
+        guard let opToken = node._operatorToken else {
+            diagnose(node: node, message: "This unknown operator is not supported in this predicate")
+            return ExprSyntax(node)
+        }
+
+        switch opToken.text {
+        case "!":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Negation(
+                \(makeArgument(label: nil, node.postfixExpression))
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "-":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_UnaryMinus(
+                \(makeArgument(label: nil, node.postfixExpression))
+                \(raw: indent))
+                """
+            
+            return syntax
+        default:
+            diagnose(node: opToken, message: "The '\(opToken.text)' operator is not supported in this predicate")
+            return ExprSyntax(node)
+        }
+    }
+    
+    override func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
+        let lhsOp =  node.leftOperand
+        let rhsOp = node.rightOperand
+        let opExpr = node.operatorOperand
+        
+        guard let opSyntax = opExpr.as(BinaryOperatorExprSyntax.self) else {
+            diagnose(node: opExpr, message: "The '\(opExpr.description)' operator is not supported in this predicate")
+            return ExprSyntax(node)
+        }
+        
+        let (lhsLabel, rhsLabel) = switch opSyntax.operatorToken.text {
+        case "...", "..<": ("lower", "upper")
+        default: ("lhs", "rhs")
+        }
+        
+        let lhsArgument = makeArgument(label: lhsLabel, lhsOp).with(\.trailingTrivia, [])
+        let rhsArgument = makeArgument(label: rhsLabel, rhsOp).with(\.trailingTrivia, [])
+        
+        switch (opSyntax.operatorToken.text) {
+        case "==":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Equal(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "!=":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_NotEqual(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "<":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Comparison(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .lessThan
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "<=":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Comparison(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .lessThanOrEqual
+                \(raw: indent))
+                """
+            
+            return syntax
+        case ">":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Comparison(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .greaterThan
+                \(raw: indent))
+                """
+            
+            return syntax
+        case ">=":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Comparison(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .greaterThanOrEqual
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "||":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Disjunction(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "&&":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Conjunction(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "+":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Arithmetic(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .add
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "-":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Arithmetic(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .subtract
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "*":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Arithmetic(
+                \(lhsArgument),
+                \(rhsArgument),
+                \(raw: indent + indentWidth)op: .multiply
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "/":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Division(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "%":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Remainder(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        case "??":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_NilCoalesce(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+            
+        case "...":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_ClosedRange(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+            
+        case "..<":
+            let syntax: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Range(
+                \(lhsArgument),
+                \(rhsArgument)
+                \(raw: indent))
+                """
+            
+            return syntax
+        default:
+            diagnose(node: opSyntax, message: "The '\(opSyntax.operatorToken.text)' operator is not supported in this predicate")
+            return ExprSyntax(node)
+        }
+    }
+    
+    // We only hit this if our OptionalChainingRewriter was unable to rewrite them out of the expression tree
+    override func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
+        diagnose(node: node.questionMark, message: "Optional chaining is not supported here in this predicate. Use the flatMap(_:) function explicitly instead.")
+        return .init(node)
+    }
+    
+    override func visit(_ node: ForcedValueExprSyntax) -> ExprSyntax {
+        return """
+                \(raw: indent)PredicateExpressions.build_ForcedUnwrap(
+                \(makeArgument(label: nil, node.expression))
+                \(raw: indent))
+                """
+    }
+    
+    override func visit(_ node: NilLiteralExprSyntax) -> ExprSyntax {
+        "PredicateExpressions.build_NilLiteral()"
+    }
+    
+    override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
+        guard let base = node.base else {
+            diagnose(node: node, message: "Member access without an explicit base is not allowed in this predicate")
+            return .init(node)
+        }
+        
+        let newPropertyComponent = KeyPathPropertyComponentSyntax(_identifier: node.name)
+        let keyPath = KeyPathExprSyntax(components: [.init(period: TokenSyntax.periodToken(), component: .property(newPropertyComponent))])
+        return """
+                \(raw: indent)PredicateExpressions.build_KeyPath(
+                \(makeArgument(label: "root", base)),
+                \(makeArgument(label: "keyPath", .init(keyPath), shouldVisit: false).with(\.trailingTrivia, []))
+                \(raw: indent))
+                """
+    }
+    
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self)
+        let base = memberAccess?.base
+        let funcName = memberAccess?.name.with(\.leadingTrivia, []).with(\.trailingTrivia, []).text ?? node.calledExpression.as(IdentifierExprSyntax.self)!.identifier.text
+        return _processFunction(
+            base: base,
+            functionName: funcName,
+            argumentList: node.argumentList,
+            trailingClosure: node.trailingClosure,
+            diagnosticPoint: .init(memberAccess?.name) ?? .init(node),
+            functionCallExpr: node)
+        ?? .init(node)
+    }
+    
+    override func visit(_ node: SubscriptExprSyntax) -> ExprSyntax {
+        return _processFunction(
+            base: node.calledExpression,
+            functionName: "subscript",
+            argumentList: node.argumentList,
+            trailingClosure: node.trailingClosure,
+            diagnosticPoint: .init(node.leftBracket))
+        ?? .init(node)
+    }
+    
+    private func _processFunction(base: ExprSyntax?, functionName: String, argumentList: TupleExprElementListSyntax, trailingClosure: ClosureExprSyntax?, diagnosticPoint: Syntax, functionCallExpr: FunctionCallExprSyntax? = nil) -> ExprSyntax? {
+        // The provided base is nil when calling global functions functions
+        guard let base else {
+            diagnose(node: diagnosticPoint, message: "Global functions are not supported in this predicate")
+            return nil
+        }
+        
+        // Check this function against our known list to provide rich diagnostics for functions we know we don't support
+        let name = TokenSyntax(.identifier(functionName), presence: .present).with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+        let args = argumentList.map {
+            FunctionStructure.Argument(label: $0.label?.text, closure: $0.expression.is(ClosureExprSyntax.self) || $0.expression.is(KeyPathExprSyntax.self))
+        }
+        let structure = FunctionStructure(name.text, arguments: args, trailingClosure: trailingClosure != nil)
+        guard let knownFunc = _knownMatchingFunction(structure) else {
+            let diagnostic = PredicateExpansionDiagnostic("The \(structure.signature) function is not supported in this predicate")
+            var fixIts = [FixIt]()
+            if let functionCallExpr,
+               let suggestion = _suggestionForUnknownFunction(structure),
+               let changes = suggestion.fixItChanges(transformingFrom: functionCallExpr) {
+                fixIts.append(FixIt(message: PredicateExpansionDiagnostic("Use \(suggestion.signature)", severity: .note), changes: changes))
+            }
+            diagnose(node: diagnosticPoint, message: diagnostic, fixIts: fixIts)
+            return nil
+        }
+        
+        var arguments: [TupleExprElementSyntax] = []
+        func addArgument(_ argument: ExprSyntax, label: String?, withComma: Bool) {
+            arguments.append(
+                makeArgument(label: label, argument)
+                    .with(\.trailingComma, withComma ? TokenSyntax(.comma, presence: .present) : nil)
+                    .with(\.trailingTrivia, withComma ? .newline : [])
+            )
+        }
+        
+        // Function arguments can contain dollar sign identifiers that can't be nested inside of a new closure
+        // Prevent this function call from being placed inside of a flatMap due to optionalChaining
+        let oldValidOptionalChainingTree = validOptionalChainingTree
+        validOptionalChainingTree = false
+        addArgument(base, label: nil, withComma: !argumentList.isEmpty)
+        validOptionalChainingTree = oldValidOptionalChainingTree
+        
+        for (sourceArg, knownArgStructure) in zip(argumentList, knownFunc.arguments) {
+            var expression = sourceArg.expression
+            if knownArgStructure.isClosure, let kpExpr = sourceArg.expression.as(KeyPathExprSyntax.self) {
+                guard !kpExpr.containsShorthandArgumentIdentifiers,
+                      let memberAccess = kpExpr.asDirectExpression(on: IdentifierExprSyntax(identifier: .dollarIdentifier("$0"))),
+                      let preparedMemberAccess = try? memberAccess.rewrite(with: OptionalChainRewriter()) else {
+                    diagnose(node: kpExpr, message: "This key path is not supported here in this predicate. Use an explicit closure instead.")
+                    return nil
+                }
+                expression = ExprSyntax(ClosureExprSyntax(statements: [CodeBlockItemSyntax(item: .expr(preparedMemberAccess.as(ExprSyntax.self)!))]))
+            }
+            addArgument(expression, label: sourceArg.label?.text, withComma: sourceArg.trailingComma != nil)
+        }
+        
+        if let closure = trailingClosure {
+            // Don't indent, because closures already get indented
+            let closureArg = makeArgument(label: nil, ExprSyntax(closure), shouldIndent: false)
+            return """
+             \(raw: indent)PredicateExpressions.build_\(name.with(\.leadingTrivia, []).with(\.trailingTrivia, []))(
+             \(TupleExprElementListSyntax(arguments))
+             \(raw: indent))\(raw: Trivia.space)\(closureArg.with(\.leadingTrivia, []).with(\.trailingTrivia, []))
+             """
+        } else {
+            return """
+             \(raw: indent)PredicateExpressions.build_\(name.with(\.leadingTrivia, []).with(\.trailingTrivia, []))(
+             \(TupleExprElementListSyntax(arguments))
+             \(raw: indent))
+             """
+        }
+    }
+    
+    override func visit(_ node: TupleExprSyntax) -> ExprSyntax {
+        guard node.elementList.count == 1, let element = node.elementList.first else {
+            diagnose(node: node, message: "Tuples are not supported in this predicate")
+            return ExprSyntax(node)
+        }
+        
+        // Support expressions like "(input as? Bool) == true" where parantheses used for grouping are treated like a single element tuple expression
+        return visit(element.expression)
+    }
+    
+    // Processes a code block and guarantees that the returned code block only contains one item
+    func _processCodeBlock(_ statements: CodeBlockItemListSyntax, in node: Syntax, removeReturn: Bool = false) -> CodeBlockItemListSyntax? {
+        guard statements.count == 1 else {
+            diagnose(node: statements.isEmpty ? node : statements[statements.index(after: statements.startIndex)], message: "Predicate body may only contain one expression")
+            return nil
+        }
+        
+        indentLevel += 1
+        var body = visit(statements)
+        if success && body == statements {
+            let wrapped: ExprSyntax =
+                """
+                \(raw: indent)PredicateExpressions.build_Arg(
+                \(raw: indent + indentWidth)\(body.with(\.leadingTrivia, []).with(\.trailingTrivia, []))
+                \(raw: indent))
+                """
+            body = [.init(item: .expr(wrapped))]
+        }
+        indentLevel -= 1
+        
+        if removeReturn, let first = body.first, case .stmt(let statement) = first.item, let returnStmt = statement.as(ReturnStmtSyntax.self), let returnExpr = returnStmt.expression {
+            body = [.init(item: .expr(returnExpr.with(\.leadingTrivia, returnStmt.leadingTrivia)))]
+        }
+        return body
+    }
+    
+    override func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
+        guard let body = _processCodeBlock(node.statements, in: .init(node)) else {
+            return node
+        }
+        return node.with(\.statements, body)
+    }
+    
+    override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
+        guard let body = _processCodeBlock(node.statements, in: .init(node)) else {
+            return .init(node)
+        }
+        
+        var resultingSignature = node.signature
+        if let signature = node.signature {
+            var visited = signature
+            visited.output = nil
+            if let paramClause = signature.input?._parameterClause {
+                let newParamClause = paramClause.with(\.parameterList, paramClause.parameterList.withVariableWrappedTypes)
+                visited.input = .init(_parameterClause: newParamClause)
+            }
+            resultingSignature = visited
+        }
+        
+        return ExprSyntax(
+            node
+            .with(\.statements, body)
+            .with(\.leftBrace, node.leftBrace.with(\.trailingTrivia, node.signature == nil ? .newline : .space))
+            .with(\.signature, resultingSignature?.with(\.trailingTrivia, .newline))
+            .with(\.rightBrace, node.rightBrace.with(\.leadingTrivia, .newline + indent))
+        )
+    }
+    
+    override func visit(_ node: TernaryExprSyntax) -> ExprSyntax {
+        let condition = node.conditionExpression
+        let firstChoice = node.firstChoice
+        let secondChoice = node.secondChoice
+        
+        return """
+         \(raw: indent)PredicateExpressions.build_Conditional(
+         \(makeArgument(label: nil, condition).with(\.trailingTrivia, [])),
+         \(makeArgument(label: nil, firstChoice).with(\.trailingTrivia, [])),
+         \(makeArgument(label: nil, secondChoice).with(\.trailingTrivia, []))
+         \(raw: indent))
+         """
+    }
+    
+    override func visit(_ node: IsExprSyntax) -> ExprSyntax {
+        return """
+         \(raw: indent)PredicateExpressions.TypeCheck<_, \(node.typeName)>(
+         \(makeArgument(label: nil, node.expression).with(\.trailingTrivia, []))
+         \(raw: indent))
+         """
+    }
+    
+    override func visit(_ node: AsExprSyntax) -> ExprSyntax {
+        let castType: String
+        switch node.questionOrExclamationMark?.tokenKind {
+        case .none: fallthrough
+        case .some(.exclamationMark):
+            castType = "Force"
+        case .some(.postfixQuestionMark):
+            castType = "Conditional"
+        default:
+            fatalError("Unexpected question/exclamation mark token kind")
+        }
+        
+        return """
+         \(raw: indent)PredicateExpressions.\(raw: castType)Cast<_, \(node.typeName)>(
+         \(makeArgument(label: nil, node.expression).with(\.trailingTrivia, []))
+         \(raw: indent))
+         """
+    }
+    
+    override func visit(_ node: ReturnStmtSyntax) -> StmtSyntax {
+        guard let expression = node.expression else {
+            // No expansion needed when returning Void
+            return StmtSyntax(node)
+        }
+        
+        let visited = visit(expression)
+        guard visited == expression else {
+            // No expansion needed when returning transformed expression
+            return StmtSyntax(node.with(\.expression, visited.with(\.leadingTrivia, [])).with(\.leadingTrivia, indent))
+        }
+        
+        // Wrap constant return expressions in a build_Arg call
+        let wrapped: ExprSyntax =
+            """
+            PredicateExpressions.build_Arg(
+            \(visited.with(\.leadingTrivia, indent + indentWidth))
+            \(raw: indent))
+            """
+        return StmtSyntax(node.with(\.expression, wrapped).with(\.leadingTrivia, indent))
+    }
+    
+    override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
+        self.diagnose(node: node, message: "Switch expressions are not supported in this predicate")
+        return .init(node)
+    }
+    
+    private func _rewriteConditionsAsExpression<C: BidirectionalCollection<ConditionElementListSyntax.Element>>(_ collection: C, in expr: IfExprSyntax) -> ExprSyntax? {
+        guard let last = collection.last else {
+            self.diagnose(node: expr, message: "This list of conditionals is unsupported in this predicate")
+            return nil
+        }
+        guard case .expression(let lastExpr) = last.condition else {
+            let type: String
+            switch last.condition {
+            case .availability(_):
+                type = "Availability conditions"
+            case .matchingPattern(_):
+                type = "Matching pattern conditions"
+            case .optionalBinding(_):
+                self.diagnose(node: last, message: "Mixing optional bindings with other conditions is not supported in this predicate")
+                return nil
+            default:
+                type = "These types of conditions"
+            }
+            self.diagnose(node: last, message: "\(type) are not supported in this predicate")
+            return nil
+        }
+        let rest = collection.dropLast()
+        if rest.isEmpty {
+            return lastExpr
+        } else {
+            guard let restRewritten = _rewriteConditionsAsExpression(rest, in: expr) else {
+                return nil
+            }
+            return .init(InfixOperatorExprSyntax(leftOperand: restRewritten, operatorOperand: BinaryOperatorExprSyntax(operatorToken: .binaryOperator("&&")), rightOperand: lastExpr))
+        }
+    }
+    
+    private func _rewriteIfAsFlatMap(bindings: [OptionalBindingConditionSyntax], body: ExprSyntax, else: ExprSyntax) -> ExprSyntax? {
+        indentLevel += bindings.count
+        
+        var prior: ExprSyntax = body
+        for binding in bindings.reversed() {
+            guard let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+                self.diagnose(node: binding.pattern, message: "This optional binding condition is not supported in this predicate")
+                return nil
+            }
+            let initializer = binding.initializer?.value ?? ExprSyntax(IdentifierExprSyntax(identifier: identifier))
+            
+            prior = """
+             \(raw: indent)PredicateExpressions.build_flatMap(
+             \(makeArgument(label: nil, initializer).with(\.trailingTrivia, []))
+             \(raw: indent)) { \(identifier.with(\.trailingTrivia, []).with(\.leadingTrivia, [])) in
+             \(makeArgument(label: nil, prior, shouldVisit: false).with(\.trailingTrivia, []))
+             \(raw: indent)}
+             """
+            indentLevel -= 1
+        }
+        
+        return """
+         \(raw: indent)PredicateExpressions.build_NilCoalesce(
+         \(makeArgument(label: "lhs", prior, shouldVisit: false)),
+         \(makeArgument(label: "rhs", `else`, shouldVisit: false))
+         \(raw: indent))
+         """
+    }
+    
+    private func _processIfBody(_ node: IfExprSyntax) -> ExprSyntax? {
+        guard let visitedBody = _processCodeBlock(node.body.statements, in: .init(node.body), removeReturn: true) else {
+            return nil
+        }
+        
+        guard let bodyExpression = visitedBody.first?.item._expression else {
+            self.diagnose(node: node.body, message: "This if expression body is not supported in this predicate")
+            return nil
+        }
+        
+        return bodyExpression
+    }
+    
+    private func _processElseBody(_ node: IfExprSyntax) -> ExprSyntax? {
+        guard let elseBody = node.elseBody else {
+            self.diagnose(node: node, message: "If expressions without an else expression are not supported in this predicate")
+            return nil
+        }
+
+        let elseExpression: ExprSyntax
+        switch elseBody {
+        case .codeBlock(let codeBlock):
+            guard let visitedElseBody = _processCodeBlock(codeBlock.statements, in: .init(codeBlock), removeReturn: true) else {
+                return nil
+            }
+            guard let expr = visitedElseBody.first?.item._expression else {
+                self.diagnose(node: node.body, message: "This if expression else body is not supported in this predicate")
+                return nil
+            }
+            elseExpression = expr
+        case .ifExpr(let ifExpr):
+            elseExpression = visit(ifExpr)
+#if FOUNDATION_FRAMEWORK
+        @unknown default:
+            self.diagnose(node: elseBody, message: "This if expression else body is not supported in this predicate")
+            return nil
+#endif
+        }
+        
+        return elseExpression
+    }
+    
+    override func visit(_ node: IfExprSyntax) -> ExprSyntax {
+        if let bindings = node.conditions.optionalBindings {
+            indentLevel += bindings.count
+            guard let bodyExpression = _processIfBody(node) else {
+                return .init(node)
+            }
+            indentLevel -= bindings.count
+            guard let elseExpression = _processElseBody(node) else {
+                return .init(node)
+            }
+            return _rewriteIfAsFlatMap(bindings: bindings, body: bodyExpression, else: elseExpression) ?? .init(node)
+        }
+        
+        guard let ifExpression = _rewriteConditionsAsExpression(node.conditions, in: node),
+              let bodyExpression = _processIfBody(node),
+              let elseExpression = _processElseBody(node) else {
+            return .init(node)
+        }
+
+        return """
+         \(raw: indent)PredicateExpressions.build_Conditional(
+         \(makeArgument(label: nil, ifExpression).with(\.trailingTrivia, [])),
+         \(makeArgument(label: nil, bodyExpression, shouldVisit: false).with(\.trailingTrivia, [])),
+         \(makeArgument(label: nil, elseExpression, shouldVisit: false).with(\.trailingTrivia, []))
+         \(raw: indent))
+         """
+    }
+    
+    override func visit(_ node: WhileStmtSyntax) -> StmtSyntax {
+        self.diagnose(node: node, message: "While loops are not supported in this predicate")
+        return .init(node)
+    }
+    
+    override func visit(_ node: ForInStmtSyntax) -> StmtSyntax {
+        self.diagnose(node: node, message: "For-in loops are not supported in this predicate")
+        return .init(node)
+    }
+    
+    override func visit(_ node: DoStmtSyntax) -> StmtSyntax {
+        self.diagnose(node: node, message: "Do statements are not supported in this predicate")
+        return .init(node)
+    }
+    
+    override func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
+        self.diagnose(node: node, message: "Catch clauses are not supported in this predicate")
+        return node
+    }
+    
+    override func visit(_ node: RepeatWhileStmtSyntax) -> StmtSyntax {
+        self.diagnose(node: node, message: "Repeat-while loops are not supported in this predicate")
+        return .init(node)
+    }
+    
+    override func visit(_ node: CodeBlockItemSyntax) -> CodeBlockItemSyntax {
+        // At this point, we know we're the only item in the code block because predicates only support single-expression code blocks
+        
+        // Diagnose any declarations
+        if case .decl(_) = node.item {
+            diagnose(node: node.item, message: "Declarations are not supported in this predicate")
+            return node
+        }
+        
+        if case let .stmt(statement) = node.item {
+            // Unwrap a do statement with valid expression bodies
+            if let doStatement = statement.as(DoStmtSyntax.self) {
+                if let catchClause = doStatement._catchClauses?.first {
+                    diagnose(node: catchClause, message: "Catch clauses are not supported in this predicate")
+                    return node
+                }
+                indentLevel -= 1
+                let visitedBody = self.visit(doStatement.body)
+                indentLevel += 1
+                guard success else {
+                    return node
+                }
+                guard let innerExpr = visitedBody.statements.first else {
+                    diagnose(node: doStatement, message: "Do statement is not supported here in this predicate")
+                    return node
+                }
+                return innerExpr
+            }
+        }
+        
+        return super.visit(node)
+    }
+}
+
+private struct PredicateExpansionDiagnostic: DiagnosticMessage, FixItMessage, ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
+    let message: String
+    let severity: DiagnosticSeverity
+    let diagnosticID: MessageID = .init(domain: "FoundationMacros", id: "PredicateDiagnostic")
+    var fixItID: MessageID { diagnosticID }
+    
+    init(_ message: String, severity: DiagnosticSeverity = .error) {
+        self.message = message
+        self.severity = severity
+    }
+    
+    init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
+public struct PredicateMacro: ExpressionMacro, Sendable {
+    public static var formatMode: FormatMode { .disabled }
+    
+    public static func expansion(of node: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext) throws -> ExprSyntax {
+        guard let closure = node.trailingClosure else {
+            let fixIts: [FixIt]
+            if let argument = node.argumentList.first?.expression.as(ClosureExprSyntax.self) {
+                let newNode = node.with(\.leftParen, nil)
+                    .with(\.rightParen, nil)
+                    .with(\.argumentList, [])
+                    .with(\.trailingClosure, argument.with(\.leadingTrivia, [.spaces(1)]).with(\.trailingTrivia, []))
+                fixIts = [
+                    FixIt(message: PredicateExpansionDiagnostic("Use a trailing closure instead of a function parameter", severity: .note), changes: [
+                        .replace(oldNode: Syntax(node), newNode: Syntax(newNode))
+                    ])
+                ]
+            } else {
+                fixIts = []
+            }
+            throw DiagnosticsError(diagnostics: [.init(
+                node: Syntax(node),
+                message: PredicateExpansionDiagnostic("#Predicate macro expansion requires a trailing closure"),
+                fixIts: fixIts
+            )])
+        }
+        
+        let translatedClosure = try closure.rewrite(with: OptionalChainRewriter()).rewrite(with: PredicateQueryRewriter()).with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+        if let genericArgs = node.genericArguments {
+            return "\(raw: moduleName).Predicate\(genericArgs.with(\.leadingTrivia, []).with(\.trailingTrivia, []))(\(translatedClosure))"
+        } else {
+            // When the macro is specified without generic args (ex. "#Predicate { ... }") initialize a Predicate without generic args so they can be inferred from context
+            return "\(raw: moduleName).Predicate(\(translatedClosure))"
+        }
+    }
+}

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -53,6 +53,21 @@ final class PredicateTests: XCTestCase {
         try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
+#if !FOUNDATION_FRAMEWORK
+    func testBasicMacro() throws {
+#if os(Linux) || os(Windows)
+        throw XCTSkip("Macros are not supported on this platform")
+#else
+        let compareTo = 2
+        let predicate: Predicate = #Predicate<Object> {
+             $0.a == compareTo
+        }
+        try XCTAssertFalse(predicate.evaluate(Object(a: 1, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+        try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
+#endif
+    }
+#endif
+    
     func testVariadic() throws {
         let predicate = Predicate<Object, Int> {
             // $0.a == $1 + 1

--- a/Tests/FoundationMacrosTests/MacroTestUtilities.swift
+++ b/Tests/FoundationMacrosTests/MacroTestUtilities.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import FoundationMacros
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftParser
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntaxMacroExpansion
+
+#if FOUNDATION_FRAMEWORK
+let foundationModuleName = "Foundation"
+#else
+let foundationModuleName = "FoundationEssentials"
+#endif
+
+struct DiagnosticTest : ExpressibleByStringLiteral, Hashable, CustomStringConvertible {
+    struct FixItTest : Hashable {
+        let message: String
+        let result: String
+        
+        init(_ message: String, result: String) {
+            self.message = message
+            self.result = result
+        }
+        
+        func matches(_ fixIt: FixIt) -> Bool {
+            fixIt.message.message == message && fixIt.changes.first?._result == result
+        }
+    }
+    
+    let message: String
+    let fixIts: [FixItTest]
+    var description: String { message }
+    
+    init(stringLiteral value: StringLiteralType) {
+        message = value
+        fixIts = []
+    }
+    
+    init(_ message: String, fixIts: [FixItTest] = []) {
+        self.message = message
+        self.fixIts = fixIts
+    }
+    
+    func matches(_ diagnostic: Diagnostic) -> Bool {
+        func hasProducedFixIt(_ fixIt: FixItTest) -> Bool {
+            diagnostic.fixIts.contains { produced in
+                fixIt.matches(produced)
+            }
+        }
+        func hasExpectedFixIt(_ fixIt: FixIt) -> Bool {
+            fixIts.contains { expected in
+                expected.matches(fixIt)
+            }
+        }
+        
+        return diagnostic.debugDescription == message &&
+                diagnostic.fixIts.allSatisfy(hasExpectedFixIt) &&
+                fixIts.allSatisfy(hasProducedFixIt)
+    }
+}
+
+extension FixIt.Change {
+    fileprivate var _result: String {
+        switch self {
+        case let .replace(_, newNode):
+            return newNode.description
+        default:
+            return "<trivia change>"
+        }
+    }
+}
+
+extension Diagnostic {
+    fileprivate var _assertionDescription: String {
+        if fixIts.isEmpty {
+            return debugDescription
+        } else {
+            var result = "Message: \(debugDescription)\nFix-Its:\n"
+            for fixIt in fixIts {
+                result += "\t\(fixIt.message.message)\n\t\(fixIt.changes.first!._result.replacingOccurrences(of: "\n", with: "\n\t"))"
+            }
+            return result
+        }
+    }
+}
+
+extension DiagnosticTest {
+    fileprivate var _assertionDescription: String {
+        if fixIts.isEmpty {
+            return message
+        } else {
+            var result = "Message: \(message)\nFix-Its:\n"
+            for fixIt in fixIts {
+                result += "\t\(fixIt.message)\n\t\(fixIt.result.replacingOccurrences(of: "\n", with: "\n\t"))"
+            }
+            return result
+        }
+    }
+}
+
+func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String = "TestModule", testFileName: String = "test.swift", _ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #file, line: UInt = #line) {
+    let context = BasicMacroExpansionContext()
+    let origSourceFile = Parser.parse(source: source)
+    let expandedSourceFile: Syntax
+    do {
+        expandedSourceFile = try OperatorTable.standardOperators.foldAll(origSourceFile).expand(macros: macros, in: context)
+    } catch {
+        XCTFail("Operator folding on input source failed with error \(error)")
+        return
+    }
+    let expansionResult = expandedSourceFile.description
+    if !context.diagnostics.contains(where: { $0.diagMessage.severity == .error }) {
+        XCTAssertEqual(expansionResult, result, file: file, line: line)
+    }
+    for diagnostic in context.diagnostics {
+        if !diagnostics.contains(where: { $0.matches(diagnostic) }) {
+            XCTFail("Produced extra diagnostic:\n\(diagnostic._assertionDescription)", file: file, line: line)
+        }
+    }
+    for diagnostic in diagnostics {
+        if !context.diagnostics.contains(where: { diagnostic.matches($0) }) {
+            XCTFail("Failed to produce diagnostic:\n\(diagnostic._assertionDescription)", file: file, line: line)
+        }
+    }
+}
+
+func AssertPredicateExpansion(_ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #file, line: UInt = #line) {
+    AssertMacroExpansion(macros: ["Predicate": PredicateMacro.self], source, result, diagnostics: diagnostics, file: file, line: line)
+}

--- a/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
@@ -1,0 +1,216 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+final class PredicateMacroBasicTests: XCTestCase {
+    func testSimple() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                return true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                return PredicateExpressions.build_Arg(
+                    true
+                )
+            })
+            """
+        )
+    }
+    
+    func testImplicitReturn() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Arg(
+                    true
+                )
+            })
+            """
+        )
+    }
+    
+    func testInferredGenerics() {
+        AssertPredicateExpansion(
+            """
+            #Predicate { input in
+                true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate({ input in
+                PredicateExpressions.build_Arg(
+                    true
+                )
+            })
+            """
+        )
+    }
+    
+    func testShorthandArgumentNames() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> {
+                $0
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({
+                PredicateExpressions.build_Arg(
+                    $0
+                )
+            })
+            """
+        )
+    }
+    
+    func testExplicitClosureArgumentTypes() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Int, String> { (a: Int, b: String) -> Bool in
+                true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Int, String>({ (a: PredicateExpressions.Variable<Int>, b: PredicateExpressions.Variable<String>) in
+                PredicateExpressions.build_Arg(
+                    true
+                )
+            })
+            """
+        )
+    }
+    
+    func testDiagnoseMissingTrailingClosure() {
+        AssertPredicateExpansion(
+            """
+            #Predicate
+            """,
+            diagnostics: ["1:1: #Predicate macro expansion requires a trailing closure"]
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object>
+            """,
+            diagnostics: ["1:1: #Predicate macro expansion requires a trailing closure"]
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object>(myClosure)
+            """,
+            diagnostics: ["1:1: #Predicate macro expansion requires a trailing closure"]
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object>({
+                return true
+            })
+            """,
+            diagnostics: [
+                DiagnosticTest(
+                    "1:1: #Predicate macro expansion requires a trailing closure",
+                    fixIts: [
+                        DiagnosticTest.FixItTest(
+                            "Use a trailing closure instead of a function parameter",
+                            result: """
+                                    #Predicate<Object> {
+                                        return true
+                                    }
+                                    """
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+    
+    func testKeyPath() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> {
+                $0.foo
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \\.foo
+                )
+            })
+            """
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input.foo
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg(input),
+                    keyPath: \\.foo
+                )
+            })
+            """
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> {
+                $0.foo.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.foo
+                    ),
+                    keyPath: \\.bar
+                )
+            })
+            """
+        )
+    }
+    
+    func testComments() {
+#if !FOUNDATION_FRAMEWORK
+        func expansionPreservesSurroundings() -> Bool { true }
+#endif
+        
+        AssertPredicateExpansion(
+            """
+            // comment
+            #Predicate<Object> { input in // comment
+                return true // comment
+            } // comment
+            """,
+            """
+            \(expansionPreservesSurroundings() ? "// comment\n" : "")\(foundationModuleName).Predicate<Object>({ input in
+                return PredicateExpressions.build_Arg(
+                    true // comment
+                )
+            })\(expansionPreservesSurroundings() ? " // comment" : "")
+            """
+        )
+    }
+}

--- a/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
@@ -1,0 +1,592 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+final class PredicateMacroFunctionCallTests: XCTestCase {
+    func testSubscript() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input[1]
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.build_Arg(1)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input[1, default: "Hello"]
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_subscript(
+                    PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.build_Arg(1),
+                    default: PredicateExpressions.build_Arg("Hello")
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input, input2, input3 in
+                input.dictionary[input2 + 1, default: input3 == input2] == false
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input, input2, input3 in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_subscript(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.dictionary
+                        ),
+                        PredicateExpressions.build_Arithmetic(
+                            lhs: PredicateExpressions.build_Arg(input2),
+                            rhs: PredicateExpressions.build_Arg(1),
+                            op: .add
+                        ),
+                        default: PredicateExpressions.build_Equal(
+                            lhs: PredicateExpressions.build_Arg(input3),
+                            rhs: PredicateExpressions.build_Arg(input2)
+                        )
+                    ),
+                    rhs: PredicateExpressions.build_Arg(false)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input[index: 1]
+            }
+            """,
+            diagnostics: ["2:10: The subscript(index:) function is not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input[1, index: 2, 3, other: 4]
+            }
+            """,
+            diagnostics: ["2:10: The subscript(_:index:_:other:) function is not supported in this predicate"]
+        )
+    }
+    
+    func testContains() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA.contains(inputB)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_contains(
+                    PredicateExpressions.build_Arg(inputA),
+                    PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { input in
+                input.contains("foo")
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ input in
+                PredicateExpressions.build_contains(
+                    PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.build_Arg("foo")
+                )
+            })
+            """
+        )
+    }
+    
+    func testContainsWhere() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.contains(where: {
+                    $0
+                })
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_contains(
+                    PredicateExpressions.build_Arg(inputA),
+                    where: {
+                        PredicateExpressions.build_Arg(
+                            $0
+                        )
+                    }
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.contains {
+                    $0
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_contains(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_Arg(
+                        $0
+                    )
+                }
+            })
+            """
+        )
+    }
+    
+    func testAllSatisfy() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.allSatisfy({
+                    $0
+                })
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_allSatisfy(
+                    PredicateExpressions.build_Arg(inputA),
+                    {
+                        PredicateExpressions.build_Arg(
+                            $0
+                        )
+                    }
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.allSatisfy {
+                    $0
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_allSatisfy(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_Arg(
+                        $0
+                    )
+                }
+            })
+            """
+        )
+    }
+    
+    func testFilter() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.filter({
+                    $0
+                })
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_filter(
+                    PredicateExpressions.build_Arg(inputA),
+                    {
+                        PredicateExpressions.build_Arg(
+                            $0
+                        )
+                    }
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.filter {
+                    $0
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_filter(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_Arg(
+                        $0
+                    )
+                }
+            })
+            """
+        )
+        
+        // Ensure that keypath literals are correctly translated into closure arguments
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.filter(\\Element.foo.bar)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_filter(
+                    PredicateExpressions.build_Arg(inputA),
+                    {
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg($0),
+                                keyPath: \\.foo
+                            ),
+                            keyPath: \\.bar
+                        )
+                    }
+                )
+            })
+            """
+        )
+        
+        // Ensure keypath literal to closure transformation only occurs when argument is a closure type
+        // Note: starts(with:) explicitly does not take a closure as its argument
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.starts(with: \\Element.foo.bar)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_starts(
+                    PredicateExpressions.build_Arg(inputA),
+                    with: PredicateExpressions.build_Arg(\\Element.foo.bar)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<[Object]> { inputA in
+                inputA.filter(\\.foo!.bar).isEmpty
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<[Object]>({ inputA in
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_filter(
+                        PredicateExpressions.build_Arg(inputA),
+                        {
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_ForcedUnwrap(
+                                    PredicateExpressions.build_KeyPath(
+                                        root: PredicateExpressions.build_Arg($0),
+                                        keyPath: \\.foo
+                                    )
+                                ),
+                                keyPath: \\.bar
+                            )
+                        }
+                    ),
+                    keyPath: \\.isEmpty
+                )
+            })
+            """
+        )
+        
+        // Key paths with anonymous closure arguments cannot be rewritten into nested closures automatically
+        AssertPredicateExpansion(
+            """
+            #Predicate<[Object]> { inputA in
+                inputA.filter(\\.foo[$0]).isEmpty
+            }
+            """,
+            diagnostics: ["2:19: This key path is not supported here in this predicate. Use an explicit closure instead."]
+        )
+    }
+    
+    func testStartsWith() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.starts(with: "foo")
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_starts(
+                    PredicateExpressions.build_Arg(inputA),
+                    with: PredicateExpressions.build_Arg("foo")
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.hasPrefix("foo")
+            }
+            """,
+            diagnostics: [
+                DiagnosticTest(
+                    "2:12: The hasPrefix(_:) function is not supported in this predicate",
+                    fixIts: [
+                        DiagnosticTest.FixItTest(
+                            "Use starts(with:)",
+                            result: """
+                                    inputA.starts(with: "foo")
+                                    """
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+    
+    func testMin() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<[Int]> { inputA in
+                inputA.min() == 0
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<[Int]>({ inputA in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_min(
+                        PredicateExpressions.build_Arg(inputA)
+                    ),
+                    rhs: PredicateExpressions.build_Arg(0)
+                )
+            })
+            """
+        )
+    }
+    
+    func testMax() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<[Int]> { inputA in
+                inputA.max() == 0
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<[Int]>({ inputA in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_max(
+                        PredicateExpressions.build_Arg(inputA)
+                    ),
+                    rhs: PredicateExpressions.build_Arg(0)
+                )
+            })
+            """
+        )
+    }
+    
+    func testLocalizedStandardContains() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.localizedStandardContains("foo")
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ inputA in
+                PredicateExpressions.build_localizedStandardContains(
+                    PredicateExpressions.build_Arg(inputA),
+                    PredicateExpressions.build_Arg("foo")
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.localizedCaseInsensitiveContains("foo")
+            }
+            """,
+            diagnostics: [
+                DiagnosticTest(
+                    "2:12: The localizedCaseInsensitiveContains(_:) function is not supported in this predicate",
+                    fixIts: [
+                        DiagnosticTest.FixItTest(
+                            "Use localizedStandardContains(_:)",
+                            result: "inputA.localizedStandardContains(\"foo\")"
+                        )
+                    ])
+            ]
+        )
+    }
+    
+    func testLocalizedStandardCompare() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.localizedCompare("foo")
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ inputA in
+                PredicateExpressions.build_localizedCompare(
+                    PredicateExpressions.build_Arg(inputA),
+                    PredicateExpressions.build_Arg("foo")
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.localizedCaseInsensitiveCompare("foo")
+            }
+            """,
+            diagnostics: [
+                DiagnosticTest(
+                    "2:12: The localizedCaseInsensitiveCompare(_:) function is not supported in this predicate",
+                    fixIts: [
+                        DiagnosticTest.FixItTest(
+                            "Use localizedCompare(_:)",
+                            result: "inputA.localizedCompare(\"foo\")"
+                        )
+                    ])
+            ]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.localizedStandardCompare("foo")
+            }
+            """,
+            diagnostics: [
+                DiagnosticTest(
+                    "2:12: The localizedStandardCompare(_:) function is not supported in this predicate",
+                    fixIts: [
+                        DiagnosticTest.FixItTest(
+                            "Use localizedCompare(_:)",
+                            result: "inputA.localizedCompare(\"foo\")"
+                        )
+                    ])
+            ]
+        )
+    }
+    
+    func testCaseInsensitiveCompare() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { inputA in
+                inputA.caseInsensitiveCompare("foo")
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ inputA in
+                PredicateExpressions.build_caseInsensitiveCompare(
+                    PredicateExpressions.build_Arg(inputA),
+                    PredicateExpressions.build_Arg("foo")
+                )
+            })
+            """
+        )
+    }
+    
+    func testDiagnoseUnsupportedFunction() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+               globalFunction(inputA)
+            }
+            """,
+            diagnostics: ["2:4: Global functions are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+               inputA.unsupportedFunction(inputB)
+            }
+            """,
+            diagnostics: ["2:11: The unsupportedFunction(_:) function is not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+               inputA.unsupportedFunction(label: inputB)
+            }
+            """,
+            diagnostics: ["2:11: The unsupportedFunction(label:) function is not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+               inputA.unsupportedFunction { $0 }
+            }
+            """,
+            diagnostics: ["2:11: The unsupportedFunction() function is not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+               inputA.unsupportedFunction(inputB) { $0 }
+            }
+            """,
+            diagnostics: ["2:11: The unsupportedFunction(_:) function is not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+               inputA.unsupportedFunction(label: inputB) { $0 }
+            }
+            """,
+            diagnostics: ["2:11: The unsupportedFunction(label:) function is not supported in this predicate"]
+        )
+    }
+}

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageOperatorTests.swift
@@ -1,0 +1,681 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+final class PredicateMacroLanguageOperatorTests: XCTestCase {
+    func testEqual() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA == inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testEqualExplicitReturn() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                return inputA == inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                return PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testNotEqual() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA != inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_NotEqual(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testComparison() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA < inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .lessThan
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA <= inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .lessThanOrEqual
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA > inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .greaterThan
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA >= inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .greaterThanOrEqual
+                )
+            })
+            """
+        )
+    }
+    
+    func testConjunction() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA && inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Conjunction(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testDisjunction() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA || inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Disjunction(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testArithmetic() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA + inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Arithmetic(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .add
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA - inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Arithmetic(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .subtract
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA * inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Arithmetic(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB),
+                    op: .multiply
+                )
+            })
+            """
+        )
+    }
+    
+    func testDivision() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA / inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Division(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testRemainder() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA % inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Remainder(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testNegation() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                !inputA
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Negation(
+                    PredicateExpressions.build_Arg(inputA)
+                )
+            })
+            """
+        )
+    }
+    
+    func testUnaryMinus() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                -inputA
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_UnaryMinus(
+                    PredicateExpressions.build_Arg(inputA)
+                )
+            })
+            """
+        )
+    }
+    
+    func testNilCoalesce() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA ?? inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_Arg(inputA),
+                    rhs: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testRanges() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA ..< inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_Range(
+                    lower: PredicateExpressions.build_Arg(inputA),
+                    upper: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA ... inputB
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ inputA, inputB in
+                PredicateExpressions.build_ClosedRange(
+                    lower: PredicateExpressions.build_Arg(inputA),
+                    upper: PredicateExpressions.build_Arg(inputB)
+                )
+            })
+            """
+        )
+    }
+    
+    func testOptionalChaining() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA?.foo
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.foo
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA.flatMap {
+                    $0.foo
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.foo
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.foo?.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(inputA),
+                        keyPath: \\.foo
+                    )
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.bar
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA?.foo?.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_Arg(inputA)
+                    ) {
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg($0),
+                            keyPath: \\.foo
+                        )
+                    }
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.bar
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.foo?.contains(0)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(inputA),
+                        keyPath: \\.foo
+                    )
+                ) {
+                    PredicateExpressions.build_contains(
+                        PredicateExpressions.build_Arg($0),
+                        PredicateExpressions.build_Arg(0)
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> {
+                $0.foo?.contains($1)
+            }
+            """,
+            diagnostics: ["2:11: Optional chaining is not supported here in this predicate. Use the flatMap(_:) function explicitly instead."]
+        )
+        
+        // Ensure that operators that become nested in a flatMap due to optional chaining are folded correctly
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> {
+                $0?.contains {
+                    $0 == "Test"
+                } ?? true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({
+                PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_Arg($0)
+                    ) {
+                        PredicateExpressions.build_contains(
+                            PredicateExpressions.build_Arg($0)
+                        ) {
+                            PredicateExpressions.build_Equal(
+                                lhs: PredicateExpressions.build_Arg($0),
+                                rhs: PredicateExpressions.build_Arg("Test")
+                            )
+                        }
+                    },
+                    rhs: PredicateExpressions.build_Arg(true)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<[Object?]> { objects in
+                objects.allSatisfy {
+                    $0?.bar == 2
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<[Object?]>({ objects in
+                PredicateExpressions.build_allSatisfy(
+                    PredicateExpressions.build_Arg(objects)
+                ) {
+                    PredicateExpressions.build_Equal(
+                        lhs: PredicateExpressions.build_flatMap(
+                            PredicateExpressions.build_Arg($0)
+                        ) {
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg($0),
+                                keyPath: \\.bar
+                            )
+                        },
+                        rhs: PredicateExpressions.build_Arg(2)
+                    )
+                }
+            })
+            """
+        )
+    }
+    
+    func testForceUnwrap() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA!.foo
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_ForcedUnwrap(
+                        PredicateExpressions.build_Arg(inputA)
+                    ),
+                    keyPath: \\.foo
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.foo!.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_ForcedUnwrap(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(inputA),
+                            keyPath: \\.foo
+                        )
+                    ),
+                    keyPath: \\.bar
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA!.foo!.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_ForcedUnwrap(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_ForcedUnwrap(
+                                PredicateExpressions.build_Arg(inputA)
+                            ),
+                            keyPath: \\.foo
+                        )
+                    ),
+                    keyPath: \\.bar
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { inputA in
+                inputA.foo!.contains(0)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ inputA in
+                PredicateExpressions.build_contains(
+                    PredicateExpressions.build_ForcedUnwrap(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(inputA),
+                            keyPath: \\.foo
+                        )
+                    ),
+                    PredicateExpressions.build_Arg(0)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA!.foo?.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_ForcedUnwrap(
+                            PredicateExpressions.build_Arg(inputA)
+                        ),
+                        keyPath: \\.foo
+                    )
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \\.bar
+                    )
+                }
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { inputA in
+                inputA?.foo!.bar
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ inputA in
+                PredicateExpressions.build_flatMap(
+                    PredicateExpressions.build_Arg(inputA)
+                ) {
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_ForcedUnwrap(
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg($0),
+                                keyPath: \\.foo
+                            )
+                        ),
+                        keyPath: \\.bar
+                    )
+                }
+            })
+            """
+        )
+    }
+    
+    func testDiagnoseUnknownOperator() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { inputA, inputB in
+                inputA & inputB
+            }
+            """,
+            diagnostics: ["2:12: The '&' operator is not supported in this predicate"]
+        )
+    }
+}

--- a/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroLanguageTokenTests.swift
@@ -1,0 +1,562 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+final class PredicateMacroLanguageTokenTests: XCTestCase {
+    func testConditional() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object, Object> { inputA, inputB, inputC in
+                inputA ? inputB : inputC
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object, Object>({ inputA, inputB, inputC in
+                PredicateExpressions.build_Conditional(
+                    PredicateExpressions.build_Arg(inputA),
+                    PredicateExpressions.build_Arg(inputB),
+                    PredicateExpressions.build_Arg(inputC)
+                )
+            })
+            """
+        )
+    }
+    
+    func testTypeCheck() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                input is Int
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.TypeCheck<_, Int>(
+                    PredicateExpressions.build_Arg(input)
+                )
+            })
+            """
+        )
+    }
+    
+    func testConditionalCast() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                (input as? Bool) == true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.ConditionalCast<_, Bool>(
+                        PredicateExpressions.build_Arg(input)
+                    ),
+                    rhs: PredicateExpressions.build_Arg(true)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                (input as Bool) == true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.ForceCast<_, Bool>(
+                        PredicateExpressions.build_Arg(input)
+                    ),
+                    rhs: PredicateExpressions.build_Arg(true)
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                (input as! Bool) == true
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.ForceCast<_, Bool>(
+                        PredicateExpressions.build_Arg(input)
+                    ),
+                    rhs: PredicateExpressions.build_Arg(true)
+                )
+            })
+            """
+        )
+    }
+    
+    func testIfExpressions() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                if input {
+                    return input
+                } else {
+                    return input.foo
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Conditional(
+                    PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.build_Arg(
+                        input
+                    ),
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(input),
+                        keyPath: \\.foo
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object, Object> { input, inputB in
+                if input.foo, input.abc && input.xyz {
+                    input.bar && input.baz
+                } else {
+                    inputB.foobar
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object, Object>({ input, inputB in
+                PredicateExpressions.build_Conditional(
+                    PredicateExpressions.build_Conjunction(
+                        lhs: PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.foo
+                        ),
+                        rhs: PredicateExpressions.build_Conjunction(
+                            lhs: PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg(input),
+                                keyPath: \\.abc
+                            ),
+                            rhs: PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg(input),
+                                keyPath: \\.xyz
+                            )
+                        )
+                    ),
+                    PredicateExpressions.build_Conjunction(
+                        lhs: PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.bar
+                        ),
+                        rhs: PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.baz
+                        )
+                    ),
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(inputB),
+                        keyPath: \\.foobar
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                if input.foo {
+                    if input.bar {
+                        input.baz
+                    } else {
+                        input.foobar
+                    }
+                } else {
+                    if input.bar {
+                        input.foobar
+                    } else {
+                        input.baz
+                    }
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_Conditional(
+                    PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg(input),
+                        keyPath: \\.foo
+                    ),
+                    PredicateExpressions.build_Conditional(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.bar
+                        ),
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.baz
+                        ),
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.foobar
+                        )
+                    ),
+                    PredicateExpressions.build_Conditional(
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.bar
+                        ),
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.foobar
+                        ),
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(input),
+                            keyPath: \\.baz
+                        )
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                if #available(macOS 9999, *) {
+                    input.foo
+                } else {
+                    input.bar
+                }
+            }
+            """,
+            diagnostics: ["2:8: Availability conditions are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { input in
+                if let nonOpt = input {
+                    nonOpt.foo
+                } else {
+                    true
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ input in
+                PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_Arg(input)
+                    ) { nonOpt in
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(nonOpt),
+                            keyPath: \\.foo
+                        )
+                    },
+                    rhs: PredicateExpressions.build_Arg(
+                        true
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { input in
+                if let nonOpt = input, let nonOpt2 = nonOpt.foo {
+                    nonOpt2
+                } else {
+                    true
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ input in
+                PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_Arg(input)
+                    ) { nonOpt in
+                        PredicateExpressions.build_flatMap(
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg(nonOpt),
+                                keyPath: \\.foo
+                            )
+                        ) { nonOpt2 in
+                            PredicateExpressions.build_Arg(
+                                nonOpt2
+                            )
+                        }
+                    },
+                    rhs: PredicateExpressions.build_Arg(
+                        true
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                if let nonOpt = input.foo?.bar {
+                    nonOpt.baz
+                } else {
+                    true
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                PredicateExpressions.build_NilCoalesce(
+                    lhs: PredicateExpressions.build_flatMap(
+                        PredicateExpressions.build_flatMap(
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg(input),
+                                keyPath: \\.foo
+                            )
+                        ) {
+                            PredicateExpressions.build_KeyPath(
+                                root: PredicateExpressions.build_Arg($0),
+                                keyPath: \\.bar
+                            )
+                        }
+                    ) { nonOpt in
+                        PredicateExpressions.build_KeyPath(
+                            root: PredicateExpressions.build_Arg(nonOpt),
+                            keyPath: \\.baz
+                        )
+                    },
+                    rhs: PredicateExpressions.build_Arg(
+                        true
+                    )
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { input in
+                if case .enumcase(let assocval) = input.foo {
+                    assocval
+                } else {
+                    true
+                }
+            }
+            """,
+            diagnostics: ["2:8: Matching pattern conditions are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { input in
+                if let nonOpt = input, nonOpt.foo == 2 {
+                    nonOpt.bar
+                } else {
+                    true
+                }
+            }
+            """,
+            diagnostics: ["2:8: Mixing optional bindings with other conditions is not supported in this predicate"]
+        )
+    }
+    
+    func testNilLiterals() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object?> { input in
+                input == nil
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object?>({ input in
+                PredicateExpressions.build_Equal(
+                    lhs: PredicateExpressions.build_Arg(input),
+                    rhs: PredicateExpressions.build_NilLiteral()
+                )
+            })
+            """
+        )
+    }
+    
+    func testDiagnoseDeclarations() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                let foo = input
+                return foo
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                var foo = input
+                return foo
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                struct Foo {}
+                return true
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                class Foo {}
+                return true
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                protocol Foo {}
+                return true
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                func bar() {}
+                return foo
+            }
+            """,
+            diagnostics: ["3:5: Predicate body may only contain one expression"]
+        )
+    }
+    
+    func testDiagnoseMiscellaneousStatements() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                for _ in 0 ..< 2 {
+                    return true
+                }
+            }
+            """,
+            diagnostics: ["2:5: For-in loops are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                while true {
+                    return true
+                }
+            }
+            """,
+            diagnostics: ["2:5: While loops are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                repeat {
+                    return true
+                } while true
+            }
+            """,
+            diagnostics: ["2:5: Repeat-while loops are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                do {
+                    let foo = "hello"
+                    return true
+                }
+            }
+            """,
+            diagnostics: ["4:9: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                do {
+                    return input
+                }
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<Object>({ input in
+                return PredicateExpressions.build_Arg(
+                    input
+                )
+            })
+            """
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                do {
+                    return true
+                } while true
+            }
+            """,
+            diagnostics: ["4:7: Predicate body may only contain one expression"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                switch input {
+                default: return true
+                }
+            }
+            """,
+            diagnostics: ["2:5: Switch expressions are not supported in this predicate"]
+        )
+        
+        AssertPredicateExpansion(
+            """
+            #Predicate<Object> { input in
+                do {
+                    return try input.foo
+                } catch {
+                    return false
+                }
+            }
+            """,
+            diagnostics: ["4:7: Catch clauses are not supported in this predicate"]
+        )
+    }
+}

--- a/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroUsageTests.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+import XCTest
+
+// MARK: - Stubs
+
+@inline(never)
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+fileprivate func _blackHole<T>(_ t: T) {}
+
+@inline(never)
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+fileprivate func _blackHoleExplicitInput(_ predicate: Predicate<Int>) {}
+
+// MARK: - Tests
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+final class PredicateMacroUsageTests: XCTestCase {
+    func testUsage() {
+        _blackHole(#Predicate<Bool> {
+            return $0
+        })
+        _blackHole(#Predicate<Bool> { input in
+            return true
+        })
+        _blackHole(#Predicate<Bool> { input in
+            return input
+        })
+        _blackHole(#Predicate<Bool> { input in
+            return input && input
+        })
+        _blackHoleExplicitInput(#Predicate { input in
+            return true
+        })
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds the `#Predicate` macro implementation and its unit tests to the open source swift-foundation repo. This will allow clients of swift-foundation to invoke the `#Predicate` macro to construct predicates using standard swift syntax.

A few notes:
- Adding a macro to a package manifest requires 5.9 tools. Since our current manifest only requires 5.8 tools, I created a copy of it (`Package@swift-5.8.swift`) for those using 5.8 tools that doesn't include the macro, and added the macro to the standard `Package.swift` after bumping its requirement to 5.9 tools
- Macros are currently only supported on Darwin platforms, so the package manifest does not add the macro on linux/windows. This isn't a robust solution (it doesn't work well with cross-compilation, etc.) but I expect it to be short lived as macro support on alternative platforms is currently in progress.
- The macro implementation does have some warnings that will be introduced into the project due to recent swift-syntax changes. After swift-syntax stabilizes the 5.9 release shortly, we'll quickly followup with another PR to address these warnings in the very near future.