### PR TITLE
Address FoundationMacros warnings from SwiftSyntax

### DIFF
--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -621,7 +621,7 @@ final class PredicateTests: XCTestCase {
             }
         }
         
-        var foo = Foo()
+        let foo = Foo()
         let predicate = Predicate<[String : Int]> {
             PredicateExpressions.build_Equal(
                 lhs: PredicateExpressions.build_subscript(

--- a/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroBasicTests.swift
@@ -193,10 +193,6 @@ final class PredicateMacroBasicTests: XCTestCase {
     }
     
     func testComments() {
-#if !FOUNDATION_FRAMEWORK
-        func expansionPreservesSurroundings() -> Bool { true }
-#endif
-        
         AssertPredicateExpansion(
             """
             // comment
@@ -205,11 +201,12 @@ final class PredicateMacroBasicTests: XCTestCase {
             } // comment
             """,
             """
-            \(expansionPreservesSurroundings() ? "// comment\n" : "")\(foundationModuleName).Predicate<Object>({ input in
+            // comment
+            \(foundationModuleName).Predicate<Object>({ input in
                 return PredicateExpressions.build_Arg(
                     true // comment
                 )
-            })\(expansionPreservesSurroundings() ? " // comment" : "")
+            }) // comment
             """
         )
     }


### PR DESCRIPTION
SwiftSyntax has recently introduced a handful of deprecations as part of the 509.0.0 snapshots that we should address in FoundationMacros. This PR addresses the current warnings (as well as an isolated warning in `PredicateTests`). I'll update this as any additional changes are made in SwiftSyntax and plan to merge this as the 509.0.0 tag wraps up. Leaving this as a draft until that happens.