### PR TITLE
Implement unlocalized range(of:) for AttributedString

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -257,13 +257,12 @@ extension AttributedStringProtocol {
 
         return self._utf8Index(at: startOffset) ..< self._utf8Index(at: endOffset) // O(log(n))
     }
-    
-#if FOUNDATION_FRAMEWORK
+
     public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = [], locale: Locale? = nil) -> Range<AttributedString.Index>? {
         if locale == nil {
             return _range(of: stringToFind, options: options)
         }
-
+#if FOUNDATION_FRAMEWORK
         // TODO: Implement localized AttributedStringProtocol.range(of:) for FoundationPreview
         // Since we have secret access to the String property, go ahead and use the full implementation given by Foundation rather than the limited reimplementation we needed for CharacterView.
         // FIXME: There is no longer a `String` property. This is going to be terribly slow.
@@ -281,12 +280,10 @@ extension AttributedStringProtocol {
         let end = bstring.utf8.index(bounds.lowerBound, offsetBy: utf8End)
 
         return AttributedString.Index(start) ..< AttributedString.Index(end)
-    }
 #else
-    public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = []) -> Range<AttributedString.Index>? {
-        _range(of: stringToFind, options: options)
-
-    }
+        // TODO: Implement localized AttributedStringProtocol.range(of:) for FoundationPreview
+        return _range(of: stringToFind, options: options)
 #endif // FOUNDATION_FRAMEWORK
+    }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -235,13 +235,36 @@ extension AttributedStringProtocol {
         let clamped = Swift.min(Swift.max(result, bounds.lowerBound), bounds.upperBound)
         return AttributedString.Index(clamped)
     }
+
+    internal func _utf8Index(at utf8Offset: Int) -> AttributedString.Index {
+        let startOffset = self.startIndex._value.utf8Offset
+        return AttributedString.Index(self.__guts.utf8Index(at: startOffset + utf8Offset))
+    }
 }
 
-#if FOUNDATION_FRAMEWORK
-// TODO: Implement AttributedStringProtocol.range(of:) for FoundationPreview
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedStringProtocol {
+    internal func _range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = []) -> Range<AttributedString.Index>? {
+
+        // TODO: Implement this on BigString to avoid O(n) iteration
+        let substring = Substring(characters)
+        guard let range = try? substring._range(of: Substring(stringToFind), options: options) else {
+            return nil
+        }
+
+        let startOffset = substring.utf8.distance(from: substring.startIndex, to: range.lowerBound) // O(1)
+        let endOffset = substring.utf8.distance(from: substring.startIndex, to: range.upperBound) // O(1)
+
+        return self._utf8Index(at: startOffset) ..< self._utf8Index(at: endOffset) // O(log(n))
+    }
+    
+#if FOUNDATION_FRAMEWORK
     public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = [], locale: Locale? = nil) -> Range<AttributedString.Index>? {
+        if locale == nil {
+            return _range(of: stringToFind, options: options)
+        }
+
+        // TODO: Implement localized AttributedStringProtocol.range(of:) for FoundationPreview
         // Since we have secret access to the String property, go ahead and use the full implementation given by Foundation rather than the limited reimplementation we needed for CharacterView.
         // FIXME: There is no longer a `String` property. This is going to be terribly slow.
         let bstring = self.__guts.string
@@ -259,6 +282,11 @@ extension AttributedStringProtocol {
 
         return AttributedString.Index(start) ..< AttributedString.Index(end)
     }
+#else
+    public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = []) -> Range<AttributedString.Index>? {
+        _range(of: stringToFind, options: options)
+
+    }
+#endif // FOUNDATION_FRAMEWORK
 }
 
-#endif // FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -14,6 +14,10 @@
 import TestSupport
 #endif
 
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif // FOUNDATION_FRAMEWORK
+
 #if FOUNDATION_FRAMEWORK
 @testable @_spi(AttributedString) import Foundation
 // For testing default attribute scope conversion
@@ -2126,8 +2130,6 @@ E {
         XCTAssertEqual(abc_lit, abc)
     }
 
-#if FOUNDATION_FRAMEWORK
-    // TODO: Implement AttributedStringProtocol.range(of:) in FoundationPreview
     func testSearch() {
         let testString = AttributedString("abcdefghi")
         XCTAssertNil(testString.range(of: "baba"))
@@ -2218,8 +2220,6 @@ E {
         XCTAssertNil(testString.range(of: "bcd", options: [.anchored]))
         XCTAssertNil(testString.range(of: "abc", options: [.anchored, .backwards]))
     }
-    
-#endif // FOUNDATION_FRAMEWORK
 
     func testIndexConversion() {
         let attrStr = AttributedString("ABCDE")


### PR DESCRIPTION
`String` has a natively-implemented `_range(of:options:)`. This PR implements `AttributedString`'s `range(of:options:)` with that when localization support is not needed.

Ideally we should implement this on `BigString` to avoid iterating through `Characters`, which is tracked as a future TODO.
    
This function takes a `Locale` argument, which isn't available in FoundationEssentials. We could move this to FoundationInternalization where `Locale` is defined, but some clients use it with `locale: nil` and do not need localized results. To make the best of this let's add a non-localized version for FoundationEssentials.