### PR TITLE
JSON5 parsing hex number with a trailing ‘E’ fails

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1124,14 +1124,16 @@ extension JSON5Scanner {
             preconditionFailure("Why was this function called, if there is no 0...9 or +/-")
         }
 
-        // Explicitly exclude a trailing 'e'. JSON5 and strtod both disallow it, but Decimal unfortunately accepts it so we need to prevent it in advance.
-        let lastIndex = jsonBytes.index(before: jsonBytes.endIndex)
-        let lastByte = jsonBytes[unchecked: lastIndex]
-        switch lastByte {
-        case UInt8(ascii: "e"), UInt8(ascii: "E"):
-            throw JSONError.unexpectedCharacter(context: "at end of number", ascii: lastByte, location: .sourceLocation(at: lastIndex, fullSource: fullSource))
-        default:
-            break
+        if (!isHex) {
+            // Explicitly exclude a trailing 'e'. JSON5 and strtod both disallow it, but Decimal unfortunately accepts it so we need to prevent it in advance.
+            let lastIndex = jsonBytes.index(before: jsonBytes.endIndex)
+            let lastByte = jsonBytes[unchecked: lastIndex]
+            switch lastByte {
+            case UInt8(ascii: "e"), UInt8(ascii: "E"):
+                throw JSONError.unexpectedCharacter(context: "at end of number", ascii: lastByte, location: .sourceLocation(at: lastIndex, fullSource: fullSource))
+            default:
+                break
+            }
         }
 
         return (firstDigitIndex, isHex, isSpecialValue)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1684,6 +1684,7 @@ final class JSONEncoderTests : XCTestCase {
             ("+1", +1),
             ("+10", +10),
             ("0x1F", 0x1F),
+            ("0x0000000E", 0xE),
             ("-0X1f", -0x1f),
             ("+0X1f", +0x1f),
             ("1.", 1),


### PR DESCRIPTION
Number prevalidation is looking for a trailing "E" character in a number because Decimal string parsing accepts one, but it's not valid JSON (strtod rejects it). However, this should not apply to hex numbers.

Resolves rdar://114714976