### PR TITLE
Refactor TimeZone to allow for ICU-free specialized implementation of GMT

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1710,7 +1710,7 @@ internal final class _Calendar: Equatable, @unchecked Sendable {
     }
 
     private func _locked_nextDaylightSavingTimeTransition(startingAt: Date, limit: Date) -> Date? {
-        _TimeZone.nextDaylightSavingTimeTransition(forLocked: ucalendar, startingAt: startingAt, limit: limit)
+        _TimeZoneICU.nextDaylightSavingTimeTransition(forLocked: ucalendar, startingAt: startingAt, limit: limit)
     }
 
     private func _locked_timeZoneTransitionInterval(at date: Date) -> DateInterval? {

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Autoupdating.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Autoupdating.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+/// A time zone which always reflects what the currently set time zone is. Aka `local` in Objective-C.
+internal final class _TimeZoneAutoupdating : _TimeZoneBase, Sendable {
+    override var identifier: String {
+        TimeZoneCache.cache.current.identifier
+    }
+    
+    override func secondsFromGMT(for date: Date = Date()) -> Int {
+        TimeZoneCache.cache.current.secondsFromGMT(for: date)
+    }
+    
+    override func abbreviation(for date: Date = Date()) -> String? {
+        TimeZoneCache.cache.current.abbreviation(for: date)
+    }
+    
+    override func isDaylightSavingTime(for date: Date = Date()) -> Bool {
+        TimeZoneCache.cache.current.isDaylightSavingTime(for: date)
+    }
+    
+    override func daylightSavingTimeOffset(for date: Date = Date()) -> TimeInterval {
+        TimeZoneCache.cache.current.daylightSavingTimeOffset(for: date)
+    }
+    
+    override func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+        TimeZoneCache.cache.current.nextDaylightSavingTimeTransition(after: date)
+    }
+        
+    override func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
+        TimeZoneCache.cache.current.localizedName(for: style, locale: locale)
+    }
+    
+    override var isAutoupdating: Bool {
+        true
+    }
+    
+    override var debugDescription: String {
+        "autoupdating \(identifier)"
+    }
+    
+    override func hash(into hasher: inout Hasher) {
+        hasher.combine(1)
+    }    
+}

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Base.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Base.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+/// Abstract base class for time zones.
+internal class _TimeZoneBase : @unchecked Sendable, CustomDebugStringConvertible {
+    var identifier: String { fatalError("Abstract implementation must be overridden") }
+    func secondsFromGMT(for date: Date = Date()) -> Int { fatalError("Abstract implementation must be overridden") }
+    func abbreviation(for date: Date = Date()) -> String? { fatalError("Abstract implementation must be overridden") }
+    func isDaylightSavingTime(for date: Date = Date()) -> Bool { fatalError("Abstract implementation must be overridden") }
+    func daylightSavingTimeOffset(for date: Date = Date()) -> TimeInterval { fatalError("Abstract implementation must be overridden") }
+    func nextDaylightSavingTimeTransition(after date: Date) -> Date? { fatalError("Abstract implementation must be overridden") }
+    func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? { fatalError("Abstract implementation must be overridden") }
+    
+    // Used by legacy ObjC clients only
+    var data: Data? {
+        nil
+    }
+    
+    var isAutoupdating: Bool {
+        false
+    }
+    
+    var debugDescription: String {
+        identifier
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+    }
+    
+#if FOUNDATION_FRAMEWORK
+    func bridgeToNSTimeZone() -> NSTimeZone {
+        _NSSwiftTimeZone(timeZone: TimeZone(inner: self))
+    }
+#endif
+}

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+@_implementationOnly import _ForSwiftFoundation
+import CoreFoundation
+@_implementationOnly import os
+
+/// Wraps an `NSTimeZone` with a more Swift-like `TimeZone` API.
+/// This is only used in the case where we have a custom Objective-C subclass of `NSTimeZone`.
+internal final class _TimeZoneBridged: _TimeZoneBase, @unchecked Sendable {
+    let _timeZone: NSTimeZone
+
+    // MARK: -
+    // MARK: Bridging
+
+    internal init(adoptingReference reference: NSTimeZone) {
+        _timeZone = reference
+    }
+
+    override func hash(into hasher: inout Hasher) {
+        hasher.combine(_timeZone)
+    }
+
+    func isEqual(to other: Any) -> Bool {
+        if let other = other as? _TimeZoneBridged {
+            return _timeZone == other._timeZone
+        } else {
+            return false
+        }
+    }
+
+    // MARK: -
+    //
+
+    override var identifier: String {
+        _timeZone.name
+    }
+
+    override var data: Data {
+        _timeZone.data
+    }
+
+    override func secondsFromGMT(for date: Date) -> Int {
+        _timeZone.secondsFromGMT(for: date)
+    }
+
+    override func abbreviation(for date: Date) -> String? {
+        _timeZone.abbreviation(for: date)
+    }
+
+    override func isDaylightSavingTime(for date: Date) -> Bool {
+        _timeZone.isDaylightSavingTime(for: date)
+    }
+
+    override func daylightSavingTimeOffset(for date: Date) -> TimeInterval {
+        _timeZone.daylightSavingTimeOffset(for: date)
+    }
+
+    override func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+        _timeZone.nextDaylightSavingTimeTransition(after: date)
+    }
+
+    override func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
+        _timeZone.localizedName(style, locale: locale)
+    }
+    
+    override func bridgeToNSTimeZone() -> NSTimeZone {
+        _timeZone.copy() as! NSTimeZone
+    }
+}
+
+#endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Cache.swift
@@ -33,14 +33,16 @@ struct TimeZoneCache : Sendable {
         // a.k.a. `systemTimeZone`
         private var currentTimeZone: TimeZone!
 
+        private var autoupdatingCurrentTimeZone: _TimeZoneAutoupdating!
+        
         // If this is not set, the behavior is to fall back to the current time zone
         private var defaultTimeZone: TimeZone?
 
         // This cache is not cleared, but only holds validly named time zones.
-        private var fixedTimeZones: [String: TimeZone] = [:]
+        private var fixedTimeZones: [String: _TimeZoneICU] = [:]
 
         // This cache holds offset-specified time zones, but only a subset of the universe of possible values. See the implementation below for the policy.
-        private var offsetTimeZones: [Int: TimeZone] = [:]
+        private var offsetTimeZones: [Int: _TimeZoneGMT] = [:]
 
         private var noteCount = -1
         private var identifiers: [String]?
@@ -88,7 +90,7 @@ struct TimeZoneCache : Sendable {
             if let tzenv = getenv("TZFILE") {
                 if let name = String(validatingUTF8: tzenv) {
                     if let result = fixed(name) {
-                        return result
+                        return TimeZone(inner: result)
                     }
                 }
             }
@@ -99,19 +101,19 @@ struct TimeZoneCache : Sendable {
                     // Use cached function here to avoid recursive lock
                     if let name2 = timeZoneAbbreviations()[name] {
                         if let result = fixed(name2) {
-                            return result
+                            return TimeZone(inner: result)
                         }
                     }
 
                     // Try with just the name
                     if let result = fixed(name) {
-                        return result
+                        return TimeZone(inner: result)
                     }
                 }
             }
 
 #if os(Windows)
-            let hFile = _TimeZone.TZDEFAULT.withCString(encodedAs: UTF16.self) {
+            let hFile = TimeZone.TZDEFAULT.withCString(encodedAs: UTF16.self) {
                 CreateFileW($0, GENERIC_READ, DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE), nil, DWORD(OPEN_EXISTING), 0, nil)
             }
             defer { CloseHandle(hFile) }
@@ -120,7 +122,7 @@ struct TimeZoneCache : Sendable {
                 _ = GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwSize, DWORD(VOLUME_NAME_DOS))
                 return String(decodingCString: $0.baseAddress!, as: UTF16.self)
             }
-            if let rangeOfZoneInfo = path.range(of: "\(_TimeZone.TZDIR)\\") {
+            if let rangeOfZoneInfo = path.range(of: "\(TimeZone.TZDIR)\\") {
                 let name = path[rangeOfZoneInfo.upperBound...]
                 if let result = fixed(String(name)) {
                     return result
@@ -131,7 +133,7 @@ struct TimeZoneCache : Sendable {
             defer { buffer.deallocate() }
             buffer.initialize(repeating: 0)
 
-            let ret = readlink(_TimeZone.TZDEFAULT, buffer.baseAddress!, Int(PATH_MAX))
+            let ret = readlink(TimeZone.TZDEFAULT, buffer.baseAddress!, Int(PATH_MAX))
             if ret >= 0 {
                 // Null-terminate the value
                 buffer[ret] = 0
@@ -139,12 +141,12 @@ struct TimeZoneCache : Sendable {
 #if targetEnvironment(simulator) && (os(iOS) || os(tvOS) || os(watchOS))
                     let lookFor = "zoneinfo/"
 #else
-                    let lookFor = _TimeZone.TZDIR + "/"
+                    let lookFor = TimeZone.TZDIR + "/"
 #endif
                     if let rangeOfZoneInfo = file._range(of: lookFor) {
                         let name = file[rangeOfZoneInfo.upperBound...]
                         if let result = fixed(String(name)) {
-                            return result
+                            return TimeZone(inner: result)
                         }
                     }
                 }
@@ -152,7 +154,7 @@ struct TimeZoneCache : Sendable {
 #endif
 
             // Last option as a default is the GMT value (again, using the cached version directly to avoid recursive lock)
-            return offsetFixed(0)!
+            return TimeZone(inner: offsetFixed(0)!)
         }
 
         mutating func current() -> TimeZone {
@@ -184,41 +186,51 @@ struct TimeZoneCache : Sendable {
             return old
         }
 
-        mutating func fixed(_ identifier: String) -> TimeZone? {
-            if let cached = fixedTimeZones[identifier] {
+        mutating func fixed(_ identifier: String) -> _TimeZoneBase? {
+            // Check for GMT/UTC
+            if identifier == "GMT" {
+                return offsetFixed(0)
+            } else if let cached = fixedTimeZones[identifier] {
                 return cached
             } else {
-                if let innerTz = _TimeZone(identifier: identifier) {
-                    let tz = TimeZone(fixed: innerTz)
-                    fixedTimeZones[identifier] = tz
-                    return tz
+                if let innerTz = _TimeZoneICU(identifier: identifier) {
+                    fixedTimeZones[identifier] = innerTz
+                    return innerTz
                 } else {
                     return nil
                 }
             }
         }
-
-        mutating func offsetFixed(_ offset: Int) -> TimeZone? {
+        
+        mutating func offsetFixed(_ offset: Int) -> _TimeZoneBase? {
             if let cached = offsetTimeZones[offset] {
                 return cached
             } else {
                 // In order to avoid bloating a cache with weird time zones, only cache values that are 30min offsets (including 1hr offsets).
                 let doCache = abs(offset) % 1800 == 0
-                if let innerTz = _TimeZone(secondsFromGMT: offset) {
-                    let tz = TimeZone(fixed: innerTz)
+                if let innerTz = _TimeZoneGMTICU(secondsFromGMT: offset) {
                     if doCache {
-                        offsetTimeZones[offset] = tz
+                        offsetTimeZones[offset] = innerTz
                     }
-                    return tz
+                    return innerTz
                 } else {
                     return nil
                 }
             }
         }
+        
+        mutating func autoupdatingCurrent() -> _TimeZoneAutoupdating {
+            if let cached = autoupdatingCurrentTimeZone {
+                return cached
+            } else {
+                autoupdatingCurrentTimeZone = _TimeZoneAutoupdating()
+                return autoupdatingCurrentTimeZone
+            }
+        }
 
         mutating func knownTimeZoneIdentifiers() -> [String] {
             if identifiers == nil {
-                identifiers = _TimeZone.timeZoneNamesFromICU()
+                identifiers = _TimeZoneICU.timeZoneNamesFromICU()
             }
             return identifiers!
         }
@@ -299,7 +311,9 @@ struct TimeZoneCache : Sendable {
             if let autoupdating = bridgedAutoupdatingCurrentTimeZone {
                 return autoupdating
             } else {
-                let result = _NSSwiftTimeZone(timeZone: TimeZone.autoupdatingCurrent)
+                // Do not call TimeZone.autoupdatingCurrent, as it will recursively lock.
+                let tz = TimeZone(inner: autoupdatingCurrent())
+                let result = _NSSwiftTimeZone(timeZone: tz)
                 bridgedAutoupdatingCurrentTimeZone = result
                 return result
             }
@@ -319,14 +333,13 @@ struct TimeZoneCache : Sendable {
                 return cached
             } else if let swiftCached = fixedTimeZones[identifier] {
                 // If we don't have a bridged instance yet, check to see if we have a Swift one and re-use that
-                let bridged = _NSSwiftTimeZone(timeZone: swiftCached)
+                let bridged = _NSSwiftTimeZone(timeZone: TimeZone(inner: swiftCached))
                 bridgedFixedTimeZones[identifier] = bridged
                 return bridged
-            } else if let innerTz = _TimeZone(identifier: identifier) {
+            } else if let innerTz = _TimeZoneICU(identifier: identifier) {
                 // In this case, the identifier is unique and we need to cache it (in two places)
-                let tz = TimeZone(fixed: innerTz)
-                fixedTimeZones[identifier] = tz
-                let bridgedTz = _NSSwiftTimeZone(timeZone: tz)
+                fixedTimeZones[identifier] = innerTz
+                let bridgedTz = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTz))
                 bridgedFixedTimeZones[identifier] = bridgedTz
                 return bridgedTz
             } else {
@@ -339,18 +352,17 @@ struct TimeZoneCache : Sendable {
                 return cached
             } else if let swiftCached = offsetTimeZones[offset] {
                 // If we don't have a bridged instance yet, check to see if we have a Swift one and re-use that
-                let bridged = _NSSwiftTimeZone(timeZone: swiftCached)
+                let bridged = _NSSwiftTimeZone(timeZone: TimeZone(inner: swiftCached))
                 bridgedOffsetTimeZones[offset] = bridged
                 return bridged
-            } else if let innerTz = _TimeZone(secondsFromGMT: offset) {
+            } else if let innerTz = _TimeZoneGMTICU(secondsFromGMT: offset) {
                 // In order to avoid bloating a cache with weird time zones, only cache values that are 30min offsets (including 1hr offsets).
                 let doCache = abs(offset) % 1800 == 0
 
                 // In this case, the offset is unique and we need to cache it (in two places)
-                let tz = TimeZone(fixed: innerTz)
-                let bridgedTz = _NSSwiftTimeZone(timeZone: tz)
+                let bridgedTz = _NSSwiftTimeZone(timeZone: TimeZone(inner: innerTz))
                 if doCache {
-                    offsetTimeZones[offset] = tz
+                    offsetTimeZones[offset] = innerTz
                     bridgedOffsetTimeZones[offset] = bridgedTz
                 }
                 return bridgedTz
@@ -397,12 +409,16 @@ struct TimeZoneCache : Sendable {
 #endif // FOUNDATION_FRAMEWORK
     }
 
-    func fixed(_ identifier: String) -> TimeZone? {
+    func fixed(_ identifier: String) -> _TimeZoneBase? {
         lock.withLock { $0.fixed(identifier) }
     }
 
-    func offsetFixed(_ seconds: Int) -> TimeZone? {
+    func offsetFixed(_ seconds: Int) -> _TimeZoneBase? {
         lock.withLock { $0.offsetFixed(seconds) }
+    }
+    
+    func autoupdatingCurrent() -> _TimeZoneBase {
+        lock.withLock { $0.autoupdatingCurrent() }
     }
 
     func knownTimeZoneIdentifiers() -> [String] {

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMT.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMT.swift
@@ -1,0 +1,262 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+internal class _TimeZoneGMT : _TimeZoneBase {
+    let offset: Int
+    let name: String
+    
+    init?(secondsFromGMT: Int) {
+        guard let name = TimeZone.nameForSecondsFromGMT(secondsFromGMT) else {
+            return nil
+        }
+
+        self.name = name
+        offset = secondsFromGMT
+    }
+
+    override var identifier: String {
+        self.name
+    }
+    
+    override func secondsFromGMT(for date: Date) -> Int {
+        offset
+    }
+    
+    override func abbreviation(for date: Date) -> String? {
+        guard !(offset < -18 * 3600 || 18 * 3600 < offset) else {
+            return nil
+        }
+        
+        // Move up by half a minute so that rounding down via division gets us the right answer
+        var remainder = abs(offset) + 30
+        
+        let hours = remainder / 3600
+        remainder = remainder % 3600
+        let minutes = remainder / 60
+        
+        if hours == 0 && minutes == 0 {
+            return "GMT"
+        }
+
+        // This format discards "seconds" values
+        
+        var result = "GMT"
+        if offset < 0 {
+            result += "-"
+        } else {
+            result += "+"
+        }
+        
+        if hours >= 10 {
+            // Tens
+            result.unicodeScalars.append(Unicode.Scalar((hours / 10) + 48)!)
+        }
+        
+        // Ones
+        result.unicodeScalars.append(Unicode.Scalar((hours % 10) + 48)!)
+        guard minutes > 0 else {
+            return result
+        }
+
+        // ':'
+        result.unicodeScalars.append(Unicode.Scalar(58)!)
+
+        if minutes >= 10 {
+            // Tens
+            result.unicodeScalars.append(Unicode.Scalar((minutes / 10) + 48)!)
+        } else if minutes > 0 {
+            // 0 for Tens
+            result.unicodeScalars.append(Unicode.Scalar(48)!)
+        }
+        
+        // Ones
+        result.unicodeScalars.append(Unicode.Scalar((minutes % 10) + 48)!)
+
+        return result
+    }
+    
+    override func isDaylightSavingTime(for date: Date) -> Bool {
+        false
+    }
+    
+    override func daylightSavingTimeOffset(for date: Date) -> TimeInterval {
+        0.0
+    }
+    
+    override func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+        nil
+    }
+    
+    override func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
+        // Subclass _TimeZoneGMTICU has localization support, if required.
+        nil
+    }
+
+    override var debugDescription: String {
+        "gmt offset \(offset)"
+    }    
+}
+
+extension TimeZone {
+    /// A time zone name, not the same as the abbreviated name above. e.g., that one includes a `:`.
+    internal static func nameForSecondsFromGMT(_ seconds: Int) -> String? {
+        guard !(seconds < -18 * 3600 || 18 * 3600 < seconds) else {
+            return nil
+        }
+
+        // Move up by half a minute so that rounding down via division gets us the right answer
+        let at = abs(seconds) + 30
+        let hour = at / 3600
+        let second = at % 3600
+        let minute = second / 60
+
+        if hour == 0 && minute == 0 {
+            return "GMT"
+        } else {
+            let formattedHour = hour < 10 ? "0\(hour)" : "\(hour)"
+            let formattedMinute = minute < 10 ? "0\(minute)" : "\(minute)"
+            let negative = seconds < 0
+            return "GMT\(negative ? "-" : "+")\(formattedHour)\(formattedMinute)"
+        }
+    }
+
+    // Returns seconds offset (positive or negative or zero) from GMT on success, nil on failure
+    internal static func tryParseGMTName(_ name: String) -> Int? {
+        // GMT, GMT{+|-}H, GMT{+|-}HH, GMT{+|-}HHMM, GMT{+|-}{H|HH}{:|.}MM
+        // UTC, UTC{+|-}H, UTC{+|-}HH, UTC{+|-}HHMM, UTC{+|-}{H|HH}{:|.}MM
+        //   where "00" <= HH <= "18", "00" <= MM <= "59", and if HH==18, then MM must == 00
+
+        let len = name.count
+        guard len >= 3 && len <= 9 else {
+            return nil
+        }
+
+        let isGMT = name.starts(with: "GMT")
+        let isUTC = name.starts(with: "UTC")
+
+        guard isGMT || isUTC else {
+            return nil
+        }
+
+        if len == 3 {
+            // GMT or UTC, exactly
+            return 0
+        }
+
+        guard len >= 5 else {
+            return nil
+        }
+
+        var idx = name.index(name.startIndex, offsetBy: 3)
+        let plusOrMinus = name[idx]
+        let positive = plusOrMinus == "+"
+        let negative = plusOrMinus == "-"
+        guard positive || negative else {
+            return nil
+        }
+
+        let zero: UInt8 = 0x30
+        let five: UInt8 = 0x35
+        let nine: UInt8 = 0x39
+
+        idx = name.index(after: idx)
+        let oneHourDigit = name[idx].asciiValue ?? 0
+        guard oneHourDigit >= zero && oneHourDigit <= nine else {
+            return nil
+        }
+
+        let hourOne = Int(oneHourDigit - zero)
+
+        if len == 5 {
+            // GMT{+|-}H
+            if negative {
+                return -hourOne * 3600
+            } else {
+                return hourOne * 3600
+            }
+        }
+
+        idx = name.index(after: idx)
+        let twoHourDigitOrPunct = name[idx].asciiValue ?? 0
+        let colon: UInt8 = 0x3a
+        let period: UInt8 = 0x2e
+
+        let secondHourIsTwoHourDigit = (twoHourDigitOrPunct >= zero && twoHourDigitOrPunct <= nine)
+        let secondHourIsPunct = twoHourDigitOrPunct == colon || twoHourDigitOrPunct == period
+        guard secondHourIsTwoHourDigit || secondHourIsPunct else {
+            return nil
+        }
+
+        let hours: Int
+        if secondHourIsTwoHourDigit {
+            hours = 10 * hourOne + Int(twoHourDigitOrPunct - zero)
+        } else { // secondHourIsPunct
+            // The above advance of idx 'consumed' the punctuation
+            hours = hourOne
+        }
+
+        if 18 < hours {
+            return nil
+        }
+
+        if secondHourIsTwoHourDigit && len == 6 {
+            // GMT{+|-}HH
+            if negative {
+                return -hours * 3600
+            } else {
+                return hours * 3600
+            }
+        }
+
+        if len < 8 {
+            return nil
+        }
+
+        idx = name.index(after: idx)
+        let firstMinuteDigitOrPunct = name[idx].asciiValue ?? 0
+        let firstMinuteIsDigit = (firstMinuteDigitOrPunct >= zero && firstMinuteDigitOrPunct <= five)
+        let firstMinuteIsPunct = firstMinuteDigitOrPunct == colon || firstMinuteDigitOrPunct == period
+        guard (firstMinuteIsDigit && len == 8) || (firstMinuteIsPunct && len == 9) else {
+            return nil
+        }
+
+        if firstMinuteIsPunct {
+            // Skip the punctuation
+            idx = name.index(after: idx)
+        }
+
+        let firstMinute = name[idx].asciiValue ?? 0
+
+        // Next character must also be a digit, no single-minutes allowed
+        idx = name.index(after: idx)
+        let secondMinute = name[idx].asciiValue ?? 0
+        guard secondMinute >= zero && secondMinute <= nine else {
+            return nil
+        }
+
+        let minutes = Int(10 * (firstMinute - zero) + (secondMinute - zero))
+        if hours == 18 && minutes != 0 {
+            // 18 hours requires 0 minutes
+            return nil
+        }
+
+        if negative {
+            return -(hours * 3600 + minutes * 60)
+        } else {
+            return hours * 3600 + minutes * 60
+        }
+    }
+}

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import FoundationICU
+#else
+package import FoundationICU
+#endif
+
+internal final class _TimeZoneGMTICU : _TimeZoneGMT {
+    override func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
+        // The GMT localized name is always the 'generic' one, as there is no variation for daylight vs standard time. Short or not depends on the style.
+        let isShort = switch style {
+        case .shortStandard, .shortDaylightSaving, .shortGeneric: true
+        default: false
+        }
+        
+        // TODO: Consider using ICU C++ API instead of a date formatter here
+        let timeZoneIdentifier = Array(name.utf16)
+        let result: String? = timeZoneIdentifier.withUnsafeBufferPointer {
+            var status = U_ZERO_ERROR
+            guard let df = udat_open(UDAT_NONE, UDAT_NONE, locale?.identifier ?? "", $0.baseAddress, Int32($0.count), nil, 0, &status) else {
+                return nil
+            }
+
+            guard status.isSuccess else {
+                return nil
+            }
+
+            defer { udat_close(df) }
+
+            let pattern = "vvvv"
+            let patternUTF16 = Array(pattern.utf16)
+            return patternUTF16.withUnsafeBufferPointer {
+                udat_applyPattern(df, UBool.false, $0.baseAddress, Int32(isShort ? 1 : $0.count))
+
+                return _withResizingUCharBuffer { buffer, size, status in
+                    udat_format(df, ucal_getNow(), buffer, size, nil, &status)
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
@@ -23,10 +23,10 @@ extension NSTimeZone {
     static func _timeZoneWith(name: String, data: Data?) -> _NSSwiftTimeZone? {
         if let data {
             // We don't cache data-based TimeZones
-            guard let tz = TimeZone(name: name, data: data) else {
+            guard let tz = TimeZone(name: name) else {
                 return nil
             }
-            return _NSSwiftTimeZone(timeZone: tz)
+            return _NSSwiftTimeZone(timeZone: tz, data: data)
         } else {
             return _timeZoneWith(name: name)
         }
@@ -126,9 +126,15 @@ extension NSTimeZone {
 @objc(_NSSwiftTimeZone)
 final class _NSSwiftTimeZone: _NSTimeZoneBridge {
     var timeZone: TimeZone
+    struct State {
+        var data: Data?
+    }
 
-    init(timeZone: TimeZone) {
+    let lock: LockedState<State>
+
+    init(timeZone: TimeZone, data: Data? = nil) {
         self.timeZone = timeZone
+        lock = LockedState(initialState: State(data: data))
         super.init()
     }
     
@@ -166,7 +172,16 @@ final class _NSSwiftTimeZone: _NSTimeZoneBridge {
     }
 
     override var data: Data {
-        timeZone.data
+        let name = timeZone.identifier
+        return lock.withLock {
+            if let data = $0.data {
+                return data
+            }
+            
+            let data = Self.dataFromTZFile(name)
+            $0.data = data
+            return data
+        }
     }
 
     override func secondsFromGMT(for aDate: Date) -> Int {
@@ -212,74 +227,62 @@ final class _NSSwiftTimeZone: _NSTimeZoneBridge {
     override func localizedName(_ style: TimeZone.NameStyle, locale: Locale?) -> String? {
         timeZone.localizedName(for: style, locale: locale)
     }
-}
-
-// MARK: -
-
-/// Wraps an `NSTimeZone` with a more Swift-like `TimeZone` API.
-/// This is only used in the case where we have a custom Objective-C subclass of `NSTimeZone`.
-internal final class _NSTimeZoneSwiftWrapper: @unchecked Sendable {
-    let _timeZone: NSTimeZone
-
-    // MARK: -
-    // MARK: Bridging
-
-    internal init(adoptingReference reference: NSTimeZone) {
-        _timeZone = reference
-    }
-
-    func bridgeToObjectiveC() -> NSTimeZone {
-        return _timeZone.copy() as! NSTimeZone
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(_timeZone)
-    }
-
-    func isEqual(to other: Any) -> Bool {
-        if let other = other as? _NSTimeZoneSwiftWrapper {
-            return _timeZone == other._timeZone
-        } else if let other = other as? _TimeZone {
-            return self.identifier == other.identifier && self.data == other.data
-        } else {
-            return false
+    
+    private static func dataFromTZFile(_ name: String) -> Data {
+        let path = TimeZone.TZDIR + "/" + name
+        guard !path.contains("..") else {
+            // No good reason for .. to be present anywhere in the path
+            return Data()
         }
+
+        #if os(Windows)
+        let fd: CInt = path.withCString(encodedAs: UTF16.self) {
+            var fd: CInt = -1
+            let errno: errno_t =
+                _wsopen_s(&fd, $0, _O_RDONLY | _O_BINARY, _SH_DENYNO, _S_IREAD | _S_IWRITE)
+            guard errno == 0 else { return -1 }
+            return fd
+        }
+        #else
+        let fd = open(path, O_RDONLY, 0666)
+        #endif
+
+        guard fd >= 0 else { return Data() }
+        defer { close(fd) }
+
+#if os(Windows)
+        var stat: _stat64 = _stat64()
+        let res = _fstat64(fd, &stat)
+#else
+        var stat: stat = stat()
+        let res = fstat(fd, &stat)
+#endif
+        guard res >= 0 else { return Data() }
+
+#if os(Windows)
+        guard (CInt(stat.st_mode) & _S_IFMT) == S_IFREG else { return Data() }
+        guard stat.st_size < Int64.max else { return Data() }
+#else
+        guard (stat.st_mode & S_IFMT) == S_IFREG else { return Data() }
+        guard stat.st_size < Int.max else { return Data() }
+#endif
+
+        let sz = Int(stat.st_size)
+
+        let bytes = UnsafeMutableRawBufferPointer.allocate(byteCount: sz, alignment: 0)
+        defer { bytes.deallocate() }
+
+#if os(Windows)
+        let ret = _read(fd, bytes.baseAddress!, CUnsignedInt(sz))
+#else
+        let ret = read(fd, bytes.baseAddress!, sz)
+#endif
+        guard ret >= sz else { return Data() }
+
+        return Data(bytes: bytes.baseAddress!, count: sz)
     }
 
-    // MARK: -
-    //
-
-    var identifier: String {
-        _timeZone.name
-    }
-
-    var data: Data {
-        _timeZone.data
-    }
-
-    func secondsFromGMT(for date: Date) -> Int {
-        _timeZone.secondsFromGMT(for: date)
-    }
-
-    func abbreviation(for date: Date) -> String? {
-        _timeZone.abbreviation(for: date)
-    }
-
-    func isDaylightSavingTime(for date: Date) -> Bool {
-        _timeZone.isDaylightSavingTime(for: date)
-    }
-
-    func daylightSavingTimeOffset(for date: Date) -> TimeInterval {
-        _timeZone.daylightSavingTimeOffset(for: date)
-    }
-
-    func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
-        _timeZone.nextDaylightSavingTimeTransition(after: date)
-    }
-
-    func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
-        _timeZone.localizedName(style, locale: locale)
-    }
 }
 
-#endif // FOUNDATION_FRAMEWORK
+#endif
+

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -50,7 +50,7 @@ final class TimeZoneTests : XCTestCase {
     func testPredefinedTimeZone() {
         XCTAssertEqual(TimeZone.gmt, TimeZone(identifier: "GMT"))
     }
-
+    
     func testLocalizedName_103036605() {
         func test(_ tzIdentifier: String, _ localeIdentifier: String, _ style: TimeZone.NameStyle, _ expected: String?, file: StaticString = #file, line: UInt = #line) {
             let tz = TimeZone(identifier: tzIdentifier)
@@ -123,6 +123,75 @@ final class TimeZoneTests : XCTestCase {
         testAbbreviation("GMT+8:00", 28800, "GMT+0800")
         testAbbreviation("GMT+0800", 28800, "GMT+0800")
         testAbbreviation("UTC", 0, "GMT")
+    }
+}
+
+final class TimeZoneGMTTests : XCTestCase {
+    var tz: TimeZone {
+        TimeZone(identifier: "GMT")!
+    }
+    
+    func testIdentifier() {
+        XCTAssertEqual(tz.identifier, "GMT")
+    }
+
+    func testSecondsFromGMT() {
+        XCTAssertEqual(tz.secondsFromGMT(), 0)
+    }
+
+    func testSecondsFromGMTForDate() {
+        XCTAssertEqual(tz.secondsFromGMT(for: Date.now), 0)
+        XCTAssertEqual(tz.secondsFromGMT(for: Date.distantFuture), 0)
+        XCTAssertEqual(tz.secondsFromGMT(for: Date.distantPast), 0)
+    }
+    
+    func testAbbreviationForDate() {
+        XCTAssertEqual(tz.abbreviation(for: Date.now), "GMT")
+        XCTAssertEqual(tz.abbreviation(for: Date.distantFuture), "GMT")
+        XCTAssertEqual(tz.abbreviation(for: Date.distantPast), "GMT")
+    }
+    
+    func testDaylightSavingTimeOffsetForDate() {
+        XCTAssertEqual(tz.daylightSavingTimeOffset(for: Date.now), 0)
+        XCTAssertEqual(tz.daylightSavingTimeOffset(for: Date.distantFuture), 0)
+        XCTAssertEqual(tz.daylightSavingTimeOffset(for: Date.distantPast), 0)
+    }
+    
+    func testNextDaylightSavingTimeTransitionAfterDate() {
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition(after: Date.now))
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition(after: Date.distantFuture))
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition(after: Date.distantPast))
+    }
+
+    func testNextDaylightSavingTimeTransition() {
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition)
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition)
+        XCTAssertNil(tz.nextDaylightSavingTimeTransition)
+    }
+
+    func testLocalizedName() {
+        XCTAssertEqual(tz.localizedName(for: .standard, locale: Locale(identifier: "en_US")), "Greenwich Mean Time")
+        XCTAssertEqual(tz.localizedName(for: .shortStandard, locale: Locale(identifier: "en_US")), "GMT")
+        XCTAssertEqual(tz.localizedName(for: .daylightSaving, locale: Locale(identifier: "en_US")), "Greenwich Mean Time")
+        XCTAssertEqual(tz.localizedName(for: .shortDaylightSaving, locale: Locale(identifier: "en_US")), "GMT")
+        XCTAssertEqual(tz.localizedName(for: .generic, locale: Locale(identifier: "en_US")), "Greenwich Mean Time")
+        XCTAssertEqual(tz.localizedName(for: .shortGeneric, locale: Locale(identifier: "en_US")), "GMT")
+        
+        // TODO: In non-framework, no FoundationInternationalization cases, return nil for all of tehse
+    }
+    
+    func testEqual() {
+        XCTAssertEqual(TimeZone(identifier: "UTC"), TimeZone(identifier: "UTC"))
+    }
+    
+    func test_abbreviated() {
+        // A sampling of expected values for abbreviated GMT names
+        let expected : [(Int, String)] = [(-64800, "GMT-18"), (-64769, "GMT-17:59"), (-64709, "GMT-17:58"),  (-61769, "GMT-17:09"), (-61229, "GMT-17"), (-36029, "GMT-10"), (-35969, "GMT-9:59"), (-35909, "GMT-9:58"), (-32489, "GMT-9:01"), (-32429, "GMT-9"), (-3629, "GMT-1"), (-1829, "GMT-0:30"), (-89, "GMT-0:01"), (-29, "GMT"), (-1, "GMT"), (0, "GMT"), (29, "GMT"), (30, "GMT+0:01"), (90, "GMT+0:02"), (1770, "GMT+0:30"), (3570, "GMT+1"), (3630, "GMT+1:01"), (34170, "GMT+9:30"), (35910, "GMT+9:59"), (35970, "GMT+10"), (36030, "GMT+10:01"), (64650, "GMT+17:58"), (64710, "GMT+17:59"), (64770, "GMT+18")]
+
+        for (offset, expect) in expected {
+            let tz = TimeZone(secondsFromGMT: offset)!
+            XCTAssertEqual(tz.abbreviation(), expect)
+        }
     }
 }
 


### PR DESCRIPTION
We would eventually like to have some core classes like `TimeZone`, `Locale`, and `Calendar` be available with reduced functionality when ICU is not present. For example, we can use GMT (+/- offsets), an English/US/POSIX locale, and Gregorian calendar, with appropriate re-implementations of a much smaller amount of ICU's logic.

The goal is to enable some simple date handling in Foundation for cases like logging ISO8601 timestamps.

This PR is the first step of that, by refactoring the guts of TimeZone to use an abstract base class. The "cache" class serves as a factory, and eventually we will be able to have that class pick the right concrete implementation to use depending on what build environment, platform, or runtime is present.