### PR TITLE
Enable the `#Predicate` macro on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -109,8 +109,8 @@ package.targets.append(contentsOf: [
 ])
 #endif
 
-#if !os(Linux) && !os(Windows)
-// Using macros at build-time is only supported on Darwin platforms
+#if !os(Windows)
+// Using macros at build-time is not yet supported on Windows
 if let index = package.targets.firstIndex(where: { $0.name == "FoundationEssentials" }) {
     package.targets[index].dependencies.append("FoundationMacros")
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Later this year, the porting effort will continue. It will bring high quality Sw
 
 ## Building and Testing
 
-Building the Foundation package requires the under-development [Swift 5.9 toolchain](https://www.swift.org/download/#swift-59-development) on or later than May 3rd 2023 (607f4eb), on macOS and Linux. 
+Building the Foundation package requires the under-development [Swift 5.9 toolchain](https://www.swift.org/download/#swift-59-development) on or later than September 1st, 2023 (46a3b41), on macOS and Linux. 
 ### macOS
 
 macOS Ventura 13.3.1 is the minimum supported version.

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -33,7 +33,7 @@ public struct Predicate<each Input> : Sendable {
     }
 }
 
-#if !os(Linux) && !os(Windows)
+#if compiler(>=5.9) && !os(Windows)
 @freestanding(expression)
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -55,7 +55,7 @@ final class PredicateTests: XCTestCase {
     
 #if !FOUNDATION_FRAMEWORK
     func testBasicMacro() throws {
-#if os(Linux) || os(Windows)
+#if compiler(<5.9) || os(Windows)
         throw XCTSkip("Macros are not supported on this platform")
 #else
         let compareTo = 2


### PR DESCRIPTION
With support for macros enabled on Linux, we can now enable the `#Predicate` macro on Linux. Using macros on Linux (and Darwin in Swift packages) requires a 5.9 toolchain so this patch replaces the `os(Linux)` checks with `compiler(>=5.9)` checks. This also bumps the minimum recommended 5.9 snapshot to the September 1st snapshot which added support for macros on Linux.