### PR TITLE
JSONEncoder: Fixed escaping of certain strings

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1167,6 +1167,27 @@ final class JSONEncoderTests : XCTestCase {
             XCTAssertThrowsError(try JSONDecoder().decode(String.self, from: data))
         }
     }
+    
+    func test_nullByte() throws {
+        let string = "abc\u{0000}def"
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        let data = try encoder.encode([string])
+        let decoded = try decoder.decode([String].self, from: data)
+        XCTAssertEqual([string], decoded)
+        
+        let data2 = try encoder.encode([string:string])
+        let decoded2 = try decoder.decode([String:String].self, from: data2)
+        XCTAssertEqual([string:string], decoded2)
+        
+        struct Container: Codable {
+            let s: String
+        }
+        let data3 = try encoder.encode(Container(s: string))
+        let decoded3 = try decoder.decode(Container.self, from: data3)
+        XCTAssertEqual(decoded3.s, string)
+    }
 
     func test_superfluouslyEscapedCharacters() {
         let json = "[\"\\h\\e\\l\\l\\o\"]"


### PR DESCRIPTION
Two bugs for one here. The "direct array" encoding optimization was bypassing the proper means of serializing strings, such that they were not getting filtered through the character escaping checks.

Also, the code performing those checks were assuming a null-terminated C string, which is not correct in the case of an embedded null character.

And yes, roughly the same code is duplicated (and therefore needs fixing) in two places. Heed the comment regarding this:

```
// Ideally we'd entirely de-duplicate this code with serializeString()'s, but at the moment there's a noticeable performance regression when doing so.
```

Would be happy to find a technique to de-duplicate that without the performance penalty!