### PR TITLE
(113054230) Remove a Locale test and update imports in performance tests

### DIFF
--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringPerformanceTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringPerformanceTests.swift
@@ -12,9 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 // TODO: Support AttributedString performance tests in FoundationPreview
-#if canImport(TestSupport)
-import TestSupport
-#endif
+//       (see https://github.com/apple/swift-foundation/issues/254)
+
+import Foundation
+import XCTest
 
 /// Performance tests for `AttributedString` and its associated objects
 final class TestAttributedStringPerformance: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/CalendarPerformanceTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarPerformanceTests.swift
@@ -10,11 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(TestSupport)
-import TestSupport
-#endif
-
 #if FOUNDATION_FRAMEWORK
+import Foundation
+import XCTest
+
 final class TestCalendarPerformance: XCTestCase {
 
     var metrics: [XCTMetric] {

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -31,14 +31,6 @@ import TestSupport
 #endif
 
 final class LocaleTests : XCTestCase {
-    
-#if FOUNDATION_FRAMEWORK
-    func test_xcode_override_french() {
-        let task = AuxRunner.launchedTaskRunningClientNamed("TestLocaleAppleLanguagesOverride", withArguments: ["-AppleLanguages", "(fr)"], environment: [:], standardOutput: nil, standardError: nil, options: .init(0))
-        task?.waitUntilExit()
-        XCTAssertEqual(task?.terminationStatus(), 0)
-    }
-#endif
 
     func test_equality() {
         let autoupdating = Locale.autoupdatingCurrent


### PR DESCRIPTION
Remove test_xcode_override_french() from Locale's test. This was added to test a behaviour in a part of the Foundation framework that's not open-source and isn't needed in FoundationEssentials.

Also, update the imports for performance tests. They were importing TestSupport, which was then importing Foundation as `@testable`. In performance tests, we run against a release build of the framework, so that import couldn't succeed. Since performance tests are currently not run in FoundationEssentials (see issue #254) for now we simply import Foundation and XCTest in lieu of TestSupport.