### PR TITLE
Cleanup old Predicate compiler workarounds

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/ExpressionArchiving.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/ExpressionArchiving.swift
@@ -151,7 +151,7 @@ enum PredicateExpressionCodingKeys : CodingKey {
 fileprivate extension PredicateCodableConfiguration {
     mutating func allowInputs<each Input>(_ input: repeat (each Input).Type) {
         var inputTypes = [Any.Type]()
-        _ = (repeat inputTypes.append((each Input).self))
+        repeat inputTypes.append((each Input).self)
         for (index, type) in inputTypes.enumerated() {
             allowType(type, identifier: "Foundation.Predicate.Input.\(index)")
         }
@@ -166,7 +166,7 @@ extension KeyedEncodingContainer where Key == PredicateExpressionCodingKeys {
         let structure = try ExpressionStructure(Type(expression), with: predicateConfiguration)
         var state = PredicateArchivingState(configuration: predicateConfiguration)
         var variableContainer = self.nestedUnkeyedContainer(forKey: .variable)
-        _ = (repeat try variableContainer.encode(each variable))
+        repeat try variableContainer.encode(each variable)
         try _ThreadLocal.withValue(&state, for: .predicateArchivingState) {
             try self.encode(structure, forKey: .structure)
             try self.encode(expression, forKey: .expression)
@@ -192,9 +192,8 @@ extension KeyedDecodingContainer where Key == PredicateExpressionCodingKeys {
         var container = try self.nestedUnkeyedContainer(forKey: .variable)
         return try _ThreadLocal.withValue(&state, for: .predicateArchivingState) {
             let variable = (repeat try container.decode(PredicateExpressions.Variable<each Input>.self))
-            // Box as an Any to work around compiler bug with closures that return values with pack expansions (rdar://111219086)
-            return (try decode(exprType), variable) as Any
-        } as! (expression: any PredicateExpression<Bool>, variable: (repeat PredicateExpressions.Variable<each Input>))
+            return (try decode(exprType), variable)
+        }
     }
 }
 

--- a/Sources/FoundationEssentials/Predicate/Archiving/Predicate+Codable.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/Predicate+Codable.swift
@@ -28,10 +28,9 @@ extension Predicate : CodableWithConfiguration {
     public typealias EncodingConfiguration = PredicateCodableConfiguration
     public typealias DecodingConfiguration = PredicateCodableConfiguration
     
-    @inline(never) // Avoid a compiler crash when inlining this function
     public func encode(to encoder: Encoder, configuration: EncodingConfiguration) throws {
         var container = encoder.unkeyedContainer()
-        try container.encodePredicateExpression(expression, variable: repeat each variable.element, predicateConfiguration: configuration)
+        try container.encodePredicateExpression(expression, variable: repeat each variable, predicateConfiguration: configuration)
     }
     
     public init(from decoder: Decoder, configuration: DecodingConfiguration) throws {

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -14,21 +14,15 @@
 public struct Predicate<each Input> : Sendable {
     public let expression : any StandardPredicateExpression<Bool>
     public let variable: (repeat PredicateExpressions.Variable<each Input>)
-
-    @usableFromInline // Preserve ABI for older initializer
-    internal init<E: StandardPredicateExpression<Bool>>(_ builder: (repeat PredicateExpressions.Variable<each Input>) -> E) {
-        self.variable = (repeat PredicateExpressions.Variable<each Input>())
-        self.expression = builder(repeat each variable.element)
-    }
     
     public init(_ builder: (repeat PredicateExpressions.Variable<each Input>) -> any StandardPredicateExpression<Bool>) {
         self.variable = (repeat PredicateExpressions.Variable<each Input>())
-        self.expression = builder(repeat each variable.element)
+        self.expression = builder(repeat each variable)
     }
     
     public func evaluate(_ input: repeat each Input) throws -> Bool {
         try expression.evaluate(
-            .init(repeat (each variable.element, each input))
+            .init(repeat (each variable, each input))
         )
     }
 }

--- a/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
@@ -18,7 +18,7 @@ public struct PredicateBindings {
     
     public init<each T>(_ value: repeat (PredicateExpressions.Variable<each T>, each T)) {
         storage = []
-        _ = (repeat storage.append(((each value).0.key, (each value).1)))
+        repeat storage.append(((each value).0.key, (each value).1))
     }
     
     public subscript<T>(_ variable: PredicateExpressions.Variable<T>) -> T? {


### PR DESCRIPTION
When implementing Predicate, we had to employ a few workarounds to compiler bugs we encountered. Now that these bugs have been resolved, we can go ahead and clean up the workarounds to keep the implementation tidy