### PR TITLE
Update `Predicate` Unit Tests to use the Macro

### DIFF
--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -56,115 +56,38 @@ final class NSPredicateConversionTests: XCTestCase {
     func testBasics() {
         let obj = ObjCObject()
         let compareTo = 2
-        var predicate = Predicate<ObjCObject> {
-            // $0.a == compareTo
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.a
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(compareTo)
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.a == compareTo
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "a == 2"))
         XCTAssertFalse(converted!.evaluate(with: obj))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.a + 2 == 4
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_Arithmetic(
-                        lhs: PredicateExpressions.build_Arg(
-                            PredicateExpressions.build_KeyPath(
-                                root: $0,
-                                keyPath: \.a
-                            )
-                        ),
-                        rhs: PredicateExpressions.build_Arg(2),
-                        op: .add
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(4)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.a + 2 == 4
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "a + 2 == 4"))
         XCTAssertFalse(converted!.evaluate(with: obj))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.b.count == 5
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_KeyPath(
-                            root: $0,
-                            keyPath: \.b
-                        ),
-                        keyPath: \.count
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(5)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.b.count == 5
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "b.length == 5"))
         XCTAssertTrue(converted!.evaluate(with: obj))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.g.count == 5
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_KeyPath(
-                            root: $0,
-                            keyPath: \.g
-                        ),
-                        keyPath: \.count
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(5)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.g.count == 5
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "g.@count == 5"))
         XCTAssertTrue(converted!.evaluate(with: obj))
         
-        predicate = Predicate<ObjCObject> { object in
-            /*object.g.filter {
+        predicate = #Predicate<ObjCObject> { object in
+            object.g.filter {
                 $0 == object.d
-            }.count > 0*/
-            
-            PredicateExpressions.build_Comparison(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_filter(
-                            PredicateExpressions.build_Arg(
-                                PredicateExpressions.build_KeyPath(
-                                    root: object,
-                                    keyPath: \.g
-                                )
-                            ),
-                            {
-                                PredicateExpressions.build_Equal(
-                                    lhs: PredicateExpressions.build_Arg($0),
-                                    rhs: PredicateExpressions.build_Arg(
-                                        PredicateExpressions.build_KeyPath(
-                                            root: object,
-                                            keyPath: \.d
-                                        )
-                                    )
-                                )
-                            }
-                        ),
-                        keyPath: \.count
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(0),
-                op: .greaterThan
-            )
+            }.count > 0
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == d).@count > 0"))
@@ -172,29 +95,15 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testEquality() {
-        var predicate = Predicate<ObjCObject> {
-            // $0.a == 0
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.a
-                ),
-                rhs: PredicateExpressions.build_Arg(0)
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.a == 0
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "a == 0"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.a != 0
-            PredicateExpressions.build_NotEqual(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.a
-                ),
-                rhs: PredicateExpressions.build_Arg(0)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.a != 0
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "a != 0"))
@@ -204,123 +113,55 @@ final class NSPredicateConversionTests: XCTestCase {
     func testRanges() {
         let now = Date.now
         let range = now ..< now
-        let intRange = 0 ..< 2
         let closedRange = now ... now
         let from = now...
         let through = ...now
         let upTo = ..<now
         
         // Closed Range Operator
-        var predicate = Predicate<ObjCObject> {
-            // ($0.i ... $0.i).contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_ClosedRange(
-                    lower: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.i
-                    ),
-                    upper: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.i
-                    )
-                ),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        var predicate = #Predicate<ObjCObject> {
+            ($0.i ... $0.i).contains($0.i)
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i BETWEEN {i, i}"))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
         
         // Non-closed Range Operator
-        predicate = Predicate<ObjCObject> {
-            // ($0.i ..< $0.i).contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Range(
-                    lower: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.i
-                    ),
-                    upper: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.i
-                    )
-                ),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            ($0.i ..< $0.i).contains($0.i)
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i >= i AND i < i"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
         // Various values
-        predicate = Predicate<ObjCObject> {
-            // range.contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Arg(range),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            range.contains($0.i)
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i >= %@ AND i < %@", now as NSDate, now as NSDate))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
-        predicate = Predicate<ObjCObject> {
-            // closedRange.contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Arg(closedRange),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            closedRange.contains($0.i)
         }
         converted = convert(predicate)
         let other = NSPredicate(format: "i BETWEEN %@", [now, now])
         XCTAssertEqual(converted, other)
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
-        predicate = Predicate<ObjCObject> {
-            // from.contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Arg(from),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            from.contains($0.i)
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i >= %@", now as NSDate))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
-        predicate = Predicate<ObjCObject> {
-            // through.contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Arg(through),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            through.contains($0.i)
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i <= %@", now as NSDate))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
-        predicate = Predicate<ObjCObject> {
-            // upTo.contains($0.i)
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_Arg(upTo),
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            upTo.contains($0.i)
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "i < %@", now as NSDate))
@@ -328,56 +169,24 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testNonObjC() {
-        let predicate = Predicate<ObjCObject> {
-            // $0.nonObjCKeypath == 2
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Arg(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.nonObjCKeypath
-                    )
-                ),
-                rhs: PredicateExpressions.build_Arg(2)
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.nonObjCKeypath == 2
         }
         XCTAssertNil(convert(predicate))
     }
     
     func testNonObjCConstantKeyPath() {
         let nonObjC = NonObjCStruct(a: 1, b: [1, 2, 3])
-        var predicate = Predicate<ObjCObject> {
-            // $0.a == nonObjC.a
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: $0,
-                    keyPath: \.a
-                ),
-                rhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg(nonObjC),
-                    keyPath: \.a
-                )
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.a == nonObjC.a
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "a == 1"))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
         
         
-        predicate = Predicate<ObjCObject> {
-            // $0.f == nonObjC.b.contains([1, 2])
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: $0,
-                    keyPath: \.f
-                ),
-                rhs: PredicateExpressions.build_contains(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg(nonObjC),
-                        keyPath: \.b
-                    ),
-                    PredicateExpressions.build_Arg([1, 2])
-                )
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.f == nonObjC.b.contains([1, 2])
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
@@ -386,35 +195,15 @@ final class NSPredicateConversionTests: XCTestCase {
     
     func testSubscripts() {
         let obj = ObjCObject()
-        var predicate = Predicate<ObjCObject> {
-            // $0.g[0] == 2
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_subscript(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.g
-                    ),
-                    PredicateExpressions.build_Arg(0)
-                ),
-                rhs: PredicateExpressions.build_Arg(2)
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.g[0] == 2
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "(SELF.g)[0] == 2"))
         XCTAssertFalse(converted!.evaluate(with: obj))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.h["A"] == 1
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_subscript(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.h
-                    ),
-                    PredicateExpressions.build_Arg("A")
-                ),
-                rhs: PredicateExpressions.build_Arg(1)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.h["A"] == 1
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "(SELF.h)['A'] == 1"))
@@ -423,30 +212,16 @@ final class NSPredicateConversionTests: XCTestCase {
     
     func testStringSearching() {
         let obj = ObjCObject()
-        var predicate = Predicate<ObjCObject> {
-            // $0.b.contains("foo")
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_KeyPath(
-                    root: $0,
-                    keyPath: \.b
-                ),
-                PredicateExpressions.build_Arg("foo")
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.b.contains("foo")
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "b CONTAINS 'foo'"))
         XCTAssertFalse(converted!.evaluate(with: obj))
         
         
-        predicate = Predicate<ObjCObject> {
-            // $0.b.contains("foo")
-            PredicateExpressions.build_starts(
-                PredicateExpressions.build_KeyPath(
-                    root: $0,
-                    keyPath: \.b
-                ),
-                with: PredicateExpressions.build_Arg("foo")
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.b.contains("foo")
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "b BEGINSWITH 'foo'"))
@@ -454,51 +229,36 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testExpressionEnforcement() {
-        var predicate = Predicate<ObjCObject> { _ in
-            PredicateExpressions.build_Arg(true)
+        var predicate = #Predicate<ObjCObject> { _ in
+            true
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "YES == YES"))
         XCTAssertTrue(converted!.evaluate(with: "Hello"))
         
-        predicate = Predicate<ObjCObject> { _ in
-            PredicateExpressions.build_Arg(false)
+        predicate = #Predicate<ObjCObject> { _ in
+            false
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "NO == YES"))
         XCTAssertFalse(converted!.evaluate(with: "Hello"))
         
-        predicate = Predicate<ObjCObject> { _ in
-            PredicateExpressions.build_Conjunction(
-                lhs: PredicateExpressions.build_Arg(true),
-                rhs: PredicateExpressions.build_Arg(false)
-            )
+        predicate = #Predicate<ObjCObject> { _ in
+            true && false
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "(YES == YES) && (NO == YES)"))
         XCTAssertFalse(converted!.evaluate(with: "Hello"))
         
-        predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_KeyPath(
-                root: PredicateExpressions.build_Arg($0),
-                keyPath: \.f
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.f
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "f == YES"))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_Conjunction(
-                    lhs: PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.f
-                    ),
-                    rhs: PredicateExpressions.build_Arg(true)
-                ),
-                rhs: PredicateExpressions.build_Arg(false)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.f && true && false
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES AND YES == YES, YES, NO) == NO"))
@@ -506,15 +266,8 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testConditional() {
-        let predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Conditional(
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.f
-                ),
-                PredicateExpressions.build_Arg(true),
-                PredicateExpressions.build_Arg(false)
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.f ? true : false
         }
         let converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES, YES, NO) == YES"))
@@ -522,57 +275,22 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testOptionals() {
-        var predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_KeyPath(
-                root: PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.j
-                    ),
-                    rhs: PredicateExpressions.build_Arg("")
-                ),
-                keyPath: \.isEmpty
-            )
+        var predicate = #Predicate<ObjCObject> {
+            ($0.j ?? "").isEmpty
         }
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(j != NULL, j, '').length == 0"))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            // ($0.j?.count ?? -1) > 1
-            PredicateExpressions.build_Comparison(
-                lhs: PredicateExpressions.build_NilCoalesce(
-                    lhs: PredicateExpressions.build_flatMap(
-                        PredicateExpressions.build_KeyPath(
-                            root: PredicateExpressions.build_Arg($0),
-                            keyPath: \.j
-                        ),
-                        {
-                            PredicateExpressions.build_KeyPath(
-                                root: PredicateExpressions.build_Arg($0),
-                                keyPath: \.count
-                            )
-                        }
-                    ),
-                    rhs: PredicateExpressions.build_Arg(-1)
-                ),
-                rhs: PredicateExpressions.build_Arg(1),
-                op: .greaterThan
-            )
+        predicate = #Predicate<ObjCObject> {
+            ($0.j?.count ?? -1) > 1
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), -1) > 1"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.j == nil
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.j
-                ),
-                rhs: PredicateExpressions.build_NilLiteral()
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.j == nil
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "j == nil"))
@@ -582,14 +300,8 @@ final class NSPredicateConversionTests: XCTestCase {
     func testUUID() {
         let obj = ObjCObject()
         let uuid = obj.k
-        let predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.k
-                ),
-                rhs: PredicateExpressions.build_Arg(uuid)
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.k == uuid
         }
         
         let converted = convert(predicate)
@@ -602,15 +314,8 @@ final class NSPredicateConversionTests: XCTestCase {
     
     func testDate() {
         let now = Date.now
-        let predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Comparison(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.i
-                ),
-                rhs: PredicateExpressions.build_Arg(now),
-                op: .greaterThan
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.i > now
         }
         
         let converted = convert(predicate)
@@ -620,14 +325,8 @@ final class NSPredicateConversionTests: XCTestCase {
     
     func testData() {
         let data = Data([1, 2, 3])
-        let predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.l
-                ),
-                rhs: PredicateExpressions.build_Arg(data)
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.l == data
         }
         let converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "l == %@", data as NSData))
@@ -635,19 +334,8 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testSequenceContainsWhere() {
-        let predicate = Predicate<ObjCObject> {
-            // $0.g.contains { $0 == 2 }
-            PredicateExpressions.build_contains(
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.g
-                )
-            ) {
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_Arg($0),
-                    rhs: PredicateExpressions.build_Arg(2)
-                )
-            }
+        let predicate = #Predicate<ObjCObject> {
+            $0.g.contains { $0 == 2 }
         }
         let converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, $_local_1 == 2).@count != 0"))
@@ -655,19 +343,8 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testSequenceAllSatisfy() {
-        let predicate = Predicate<ObjCObject> {
-            // $0.g.allSatisfy { $0 == 2 }
-            PredicateExpressions.build_allSatisfy(
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.g
-                )
-            ) {
-                PredicateExpressions.build_Equal(
-                    lhs: PredicateExpressions.build_Arg($0),
-                    rhs: PredicateExpressions.build_Arg(2)
-                )
-            }
+        let predicate = #Predicate<ObjCObject> {
+            $0.g.allSatisfy { $0 == 2 }
         }
         let converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "SUBQUERY(g, $_local_1, NOT ($_local_1 == 2)).@count == 0"))
@@ -675,21 +352,8 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testMaxMin() {
-        let predicate = Predicate<ObjCObject> {
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_max(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.g
-                    )
-                ),
-                rhs: PredicateExpressions.build_min(
-                    PredicateExpressions.build_KeyPath(
-                        root: $0,
-                        keyPath: \.g
-                    )
-                )
-            )
+        let predicate = #Predicate<ObjCObject> {
+            $0.g.max() == $0.g.min()
         }
         
         let converted = convert(predicate)
@@ -699,51 +363,24 @@ final class NSPredicateConversionTests: XCTestCase {
     
     func testStringComparison() {
         let equal = ComparisonResult.orderedSame
-        var predicate = Predicate<ObjCObject> {
-            // $0.b.caseInsensitiveCompare("ABC") == equal
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_caseInsensitiveCompare(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.b
-                    ),
-                    PredicateExpressions.build_Arg("ABC")
-                ),
-                rhs: PredicateExpressions.build_Arg(equal)
-            )
+        var predicate = #Predicate<ObjCObject> {
+            $0.b.caseInsensitiveCompare("ABC") == equal
         }
         
         var converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(b ==[c] 'ABC', 0, TERNARY(b <[c] 'ABC', -1, 1)) == 0"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.string.localizedStandardCompare("ABC") == equal
-            PredicateExpressions.build_Equal(
-                lhs: PredicateExpressions.build_localizedCompare(
-                    PredicateExpressions.build_KeyPath(
-                        root: PredicateExpressions.build_Arg($0),
-                        keyPath: \.b
-                    ),
-                    PredicateExpressions.build_Arg("ABC")
-                ),
-                rhs: PredicateExpressions.build_Arg(equal)
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.b.localizedCompare("ABC") == equal
         }
         
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(b ==[l] 'ABC', 0, TERNARY(b <[l] 'ABC', -1, 1)) == 0"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
-        predicate = Predicate<ObjCObject> {
-            // $0.string.localizedStandardContains("ABC")
-            PredicateExpressions.build_localizedStandardContains(
-                PredicateExpressions.build_KeyPath(
-                    root: PredicateExpressions.build_Arg($0),
-                    keyPath: \.b
-                ),
-                PredicateExpressions.build_Arg("ABC")
-            )
+        predicate = #Predicate<ObjCObject> {
+            $0.b.localizedStandardContains("ABC")
         }
         
         converted = convert(predicate)

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -53,7 +53,6 @@ final class PredicateTests: XCTestCase {
         try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
     }
     
-#if !FOUNDATION_FRAMEWORK
     func testBasicMacro() throws {
 #if compiler(<5.9) || os(Windows)
         throw XCTSkip("Macros are not supported on this platform")
@@ -66,7 +65,6 @@ final class PredicateTests: XCTestCase {
         try XCTAssertTrue(predicate.evaluate(Object(a: 2, b: "", c: 0, d: 0, e: "c", f: true, g: [])))
 #endif
     }
-#endif
     
     func testVariadic() throws {
         let predicate = Predicate<Object, Int> {


### PR DESCRIPTION
Previously due to a compiler limitation, the `Predicate` unit tests used manual constructions rather than the `#Predicate` macro. Now that the limitation has been lifted, we will update most of the unit tests to use the macro. However, we still leave the basic unit tests as-is until macros are supported on Windows.