### PR TITLE
String paragraph/line searching can attempt to form invalid indices

### DIFF
--- a/Sources/FoundationEssentials/String/StringBlocks.swift
+++ b/Sources/FoundationEssentials/String/StringBlocks.swift
@@ -71,18 +71,18 @@ extension BidirectionalCollection where Element == UTF8.CodeUnit {
             }
         }
         for separator in separators {
-            var matches = true
             var strIdx = start
             var separatorIdx = reverse ? separator.count - 1 : 0
-            while strIdx >= startIndex && strIdx < endIndex && separatorIdx >= 0 && separatorIdx < separator.count {
-                if separator[separatorIdx] != self[strIdx] {
-                    matches = false
+            let offset = reverse ? -1 : 1
+            let strLimit = reverse ? startIndex : index(before: endIndex)
+            let sepLimit = reverse ? 0 : separator.count - 1
+            while separator[separatorIdx] == self[strIdx] {
+                if !formIndex(&strIdx, offsetBy: offset, limitedBy: strLimit) ||
+                    !separator.formIndex(&separatorIdx, offsetBy: offset, limitedBy: sepLimit) {
                     break
                 }
-                strIdx = reverse ? index(before: strIdx) : index(after: strIdx)
-                separatorIdx += reverse ? -1 : 1
             }
-            if matches {
+            if separatorIdx == sepLimit {
                 return reverse ? index(after: strIdx)..<index(after: start) : start ..< strIdx
             }
         }

--- a/Sources/FoundationEssentials/String/StringBlocks.swift
+++ b/Sources/FoundationEssentials/String/StringBlocks.swift
@@ -77,13 +77,15 @@ extension BidirectionalCollection where Element == UTF8.CodeUnit {
             let strLimit = reverse ? startIndex : index(before: endIndex)
             let sepLimit = reverse ? 0 : separator.count - 1
             while separator[separatorIdx] == self[strIdx] {
-                if !formIndex(&strIdx, offsetBy: offset, limitedBy: strLimit) ||
-                    !separator.formIndex(&separatorIdx, offsetBy: offset, limitedBy: sepLimit) {
+                if !separator.formIndex(&separatorIdx, offsetBy: offset, limitedBy: sepLimit) {
+                    // We've fully matched the separator, return the appropriate range
+                    return (reverse ? strIdx ... start : start ... strIdx).relative(to: self)
+                }
+                
+                if !formIndex(&strIdx, offsetBy: offset, limitedBy: strLimit) {
+                    // We've run off the end of the string and haven't finished the separator, break out
                     break
                 }
-            }
-            if separatorIdx == sepLimit {
-                return reverse ? index(after: strIdx)..<index(after: start) : start ..< strIdx
             }
         }
         return nil

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -317,5 +317,13 @@ final class StringTests : XCTestCase {
             XCTAssertEqual(lineResult.start ..< lineResult.end, range)
         }
     }
+    
+    func testAlmostMatchingSeparator() {
+        let string = "A\u{200D}B" // U+200D Zero Width Joiner (ZWJ) matches U+2028 Line Separator except for the final UTF-8 scalar
+        let lineResult = string._lineBounds(around: string.startIndex ..< string.startIndex)
+        XCTAssertEqual(lineResult.start, string.startIndex)
+        XCTAssertEqual(lineResult.end, string.endIndex)
+        XCTAssertEqual(lineResult.contentsEnd, string.endIndex)
+    }
 
 }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -307,5 +307,15 @@ final class StringTests : XCTestCase {
         test("\u{1F425}")
         test("🏳️‍🌈AB👩‍👩‍👧‍👦ab🕵️‍♀️")
     }
+    
+    func testParagraphLineRangeOfSeparator() {
+        for separator in ["\n", "\r", "\r\n", "\u{2029}", "\u{2028}", "\u{85}"] {
+            let range = separator.startIndex ..< separator.endIndex
+            let paragraphResult = separator._paragraphBounds(around: range)
+            let lineResult = separator._lineBounds(around: range)
+            XCTAssertEqual(paragraphResult.start ..< paragraphResult.end, range)
+            XCTAssertEqual(lineResult.start ..< lineResult.end, range)
+        }
+    }
 
 }


### PR DESCRIPTION
In our implementation of `_getBlock` which is used to find the ranges of paragraphs/lines within strings, we can potentially attempt to form an invalid index of a string resulting in a runtime crash. If the range provided begins at the start of the string and only contains one separator character (as is the case with a string that is only a separator character), then we attempt to form an index before the `startIndex` of the string while iterating backwards to find the contents end. This PR updates the `_matchesSeparators` function to use the `formIndex(_:offsetBy:limitedBy:)` function rather than calling `index(before:)` on what may potentially be the `startIndex` to ensure that we don't form invalid indices and instead break out of the loop as soon as we reach the end of the separator or the string.