### PR TITLE
Update swift-syntax tag to 509.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             revision: "0c1de7149a39a9ff82d4db66234dec587b30a3ad"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-08-15-a")
+            from: "509.0.0")
     ],
     targets: [
         // Foundation (umbrella)


### PR DESCRIPTION
Now that Swift 5.9 is released and swift-syntax has tagged their 509.0.0 release, we should update our dependency on swift-syntax to specify this tag rather than a snapshot.