### PR TITLE
Fix build error on main caused by a missing symbol

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -2027,4 +2027,8 @@ extension Date {
     internal var capped: Date {
         return max(min(self, Date.validCalendarRange.upperBound), Date.validCalendarRange.lowerBound)
     }
+
+    internal var isValidForEnumeration: Bool {
+        Date.validCalendarRange.contains(self)
+    }
 }


### PR DESCRIPTION
```
/FoundationInternationalization/Calendar/Calendar_Enumerate.swift:370:21: error: value of type 'Date' has no member 'isValidForEnumeration'
        guard start.isValidForEnumeration else {
              ~~~~~ ^~~~~~~~~~~~~~~~~~~~~
error: fatalError
```
