### PR TITLE
Address predicate test failures due to new uses of `#Predicate`

### DIFF
--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -255,7 +255,7 @@ final class PredicateCodableTests: XCTestCase {
         XCTAssertThrowsError(try _encodeDecode(predicate))
         XCTAssertThrowsError(try _encodeDecode(predicate, for: StandardConfig.self))
         XCTAssertThrowsError(try _encodeDecode(predicate, encoding: UUIDConfig.self, decoding: MinimalConfig.self)) {
-            XCTAssertEqual(String(describing: $0), "The 'Foundation.UUID' identifier is not in the provided allowlist (required by /PredicateExpressions.TypeCheck)")
+            XCTAssertEqual(String(describing: $0), "The 'Foundation.UUID' identifier is not in the provided allowlist (required by /PredicateExpressions.Equal/PredicateExpressions.Value)")
         }
         
         let decoded = try _encodeDecode(predicate, for: UUIDConfig.self)

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -221,7 +221,7 @@ final class NSPredicateConversionTests: XCTestCase {
         
         
         predicate = #Predicate<ObjCObject> {
-            $0.b.contains("foo")
+            $0.b.starts(with: "foo")
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "b BEGINSWITH 'foo'"))
@@ -258,7 +258,7 @@ final class NSPredicateConversionTests: XCTestCase {
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {
-            $0.f && true && false
+            ($0.f && true) == false
         }
         converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "TERNARY(f == YES AND YES == YES, YES, NO) == NO"))
@@ -286,7 +286,7 @@ final class NSPredicateConversionTests: XCTestCase {
             ($0.j?.count ?? -1) > 1
         }
         converted = convert(predicate)
-        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), -1) > 1"))
+        XCTAssertEqual(converted, NSPredicate(format: "TERNARY(TERNARY(j != nil, j.length, nil) != nil, TERNARY(j != nil, j.length, nil), 1 * -1) > 1"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
         
         predicate = #Predicate<ObjCObject> {


### PR DESCRIPTION
A few of our `FOUNDATION_FRAMEWORK`-only unit tests are failing due to new uses of the `#Predicate` macro