### PR TITLE
Fix mismatched Locale hash/equality implementation

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -736,34 +736,20 @@ public struct Locale : Hashable, Equatable, Sendable {
     //
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(!_locale.isAutoupdating)
-        hasher.combine(_locale.identifier)
-        hasher.combine(_locale.prefs)
+        if _locale.isAutoupdating {
+            hasher.combine(true)
+        } else {
+            hasher.combine(false)
+            hasher.combine(_locale.identifier)
+            hasher.combine(prefs)
+        }
     }
 
     public static func ==(lhs: Locale, rhs: Locale) -> Bool {
-        if lhs._locale.isAutoupdating {
-            if rhs._locale.isAutoupdating {
-                return true
-            } else {
-                return false
-            }
-        } else if !lhs._locale.isBridged /* fixed, 'normal' */ {
-            if rhs._locale.isAutoupdating {
-                return false
-            } else if rhs._locale.isBridged {
-                // Only compare identifier
-                return lhs.identifier == rhs.identifier
-            } else {
-                // Compare identifiers and prefs
-                return lhs.identifier == rhs.identifier && lhs.prefs == rhs.prefs
-            }
-        } else /* lhs.isBridged */ {
-            if rhs._locale.isAutoupdating {
-                return false
-            } else {
-                return lhs.identifier == rhs.identifier
-            }
+        if lhs._locale.isAutoupdating || rhs._locale.isAutoupdating {
+            return lhs._locale.isAutoupdating && rhs._locale.isAutoupdating
+        } else {
+            return lhs.identifier == rhs.identifier && lhs.prefs == rhs.prefs
         }
     }
 }


### PR DESCRIPTION
Recently, we accidentally updated `Locale`'s hashing and equatable implementations to differ - the `hash(into:)` function sometimes took more information (such as the identifier and preferences) into account than the equatable checking leading to multiple `Locale`s being equal but having different hashes. This change updates the two implementations to be compatible and simplifies the logic.