### PR TITLE
FoundationInternationalizationTests: explicitly cast to `CLong`

### DIFF
--- a/Tests/FoundationInternationalizationTests/DateComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/DateComponentsTests.swift
@@ -74,7 +74,7 @@ final class DateComponentsTests : XCTestCase {
         let dateWithNS = cal.date(from: comps)!
         let newComps = cal.dateComponents([.nanosecond], from: dateWithNS)
 
-        let nanosecondsApproximatelyEqual = labs(newComps.nanosecond! - 123456789) <= 500
+        let nanosecondsApproximatelyEqual = labs(CLong(newComps.nanosecond!) - 123456789) <= 500
         XCTAssertTrue(nanosecondsApproximatelyEqual)
     }
 


### PR DESCRIPTION
This adds support for Windows which is a LLP64 environment.  That maps `Long` to 32-bit, and thus we need to explicitly cast the value to `CLong` which matches the `labs` signature.