### PR TITLE
(116548255) test decoding dynamic subclasses

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -724,6 +724,21 @@ final class JSONEncoderTests : XCTestCase {
         _ = try? JSONEncoder().encode(ReferencingEncoderWrapper([Float.infinity]))
     }
 
+    func testDecodeDynamicSubclass() throws {
+        // https://github.com/apple/swift-corelibs-foundation/issues/4806
+        class BaseTestType: Decodable { }
+        class ChildTestType: BaseTestType { }
+
+        func dynamicTestType() -> BaseTestType.Type {
+            return ChildTestType.self
+        }
+
+        let decoder = JSONDecoder()
+        let testType = dynamicTestType()
+        let instance = try decoder.decode(testType, from: Data(#"{}"#.utf8))
+        XCTAssertTrue(instance is ChildTestType)
+    }
+
     func testEncoderStateThrowOnEncodeCustomDate() {
         // This test is identical to testEncoderStateThrowOnEncode, except throwing via a custom Date closure.
         struct ReferencingEncoderWrapper<T : Encodable> : Encodable {


### PR DESCRIPTION
Adapt a test from swift-corelibs-foundation, where JSON decoding could produce the wrong dynamic type. Add this test to prevent regressions. Original issue: https://github.com/apple/swift-corelibs-foundation/issues/4806

Addresses rdar://116548255