### PR TITLE
Add `SortDescriptor` and `SortComparator`

### DIFF
--- a/Sources/FoundationEssentials/ComparisonResult.swift
+++ b/Sources/FoundationEssentials/ComparisonResult.swift
@@ -12,20 +12,16 @@
 
 #if !FOUNDATION_FRAMEWORK
 
-/// These constants are used to indicate how items in a request are ordered,
-/// from the first one given in a method invocation or function call to the last
-/// (that is, left to right in code).
-///
+/// Used to indicate how items in a request are ordered, from the first one given in a method invocation or function call to the last (that is, left to right in code).
 /// Given the function:
-/// `func f(int a, int b) -> ComparisonResult`
+/// ```
+/// func f(a: Int, b: Int) -> ComparisonResult
+/// ```
 /// If:
-///    a < b then return `.orderedAscending`. The left operand is smaller than the right operand.
-///    a > b   then return `.orderedDescending`. The left operand is greater than the right operand.
-///    a == b  then return `.orderedSame`. The operands are equal.
-///
-/// NOTE: This enum comes from Foundation's Objective-C header on Darwin.
-@frozen
-@available(macOS 10.0, iOS 2.0, tvOS 9.0, watchOS 2.0, *)
+///   `a < b`   then return `.orderedAscending`. The left operand is smaller than the right operand.
+///   `a > b`   then return `.orderedDescending`. The left operand is greater than the right operand.
+///   `a == b`  then return `.orderedSame`. The operands are equal.
+@frozen @available(macOS 10.0, iOS 2.0, tvOS 9.0, watchOS 2.0, *)
 public enum ComparisonResult : Int, Codable, Sendable {
     case orderedAscending   = -1
     case orderedSame        = 0

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -41,6 +41,7 @@ open class JSONEncoder {
 
 #if FOUNDATION_FRAMEWORK
         // TODO: Reenable once String.compare is implemented
+        // https://github.com/apple/swift-foundation/issues/284
 
         /// Produce JSON with dictionary keys sorted in lexicographic order.
         @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)

--- a/Sources/FoundationEssentials/JSON/JSONWriter.swift
+++ b/Sources/FoundationEssentials/JSON/JSONWriter.swift
@@ -129,6 +129,7 @@ internal struct JSONWriter {
     private var indent = 0
     private let pretty: Bool
 #if FOUNDATION_FRAMEWORK
+    // https://github.com/apple/swift-foundation/issues/284
     private let sortedKeys: Bool
 #endif
     private let withoutEscapingSlashes: Bool
@@ -138,6 +139,7 @@ internal struct JSONWriter {
     init(options: WritingOptions) {
         pretty = options.contains(.prettyPrinted)
 #if FOUNDATION_FRAMEWORK
+        // https://github.com/apple/swift-foundation/issues/284
         sortedKeys = options.contains(.sortedKeys)
 #endif
         withoutEscapingSlashes = options.contains(.withoutEscapingSlashes)
@@ -352,6 +354,7 @@ internal struct JSONWriter {
 #if FOUNDATION_FRAMEWORK
         if sortedKeys {
             // TODO: Until we have a solution for sorting like Locale.system in FoundationEssentials or with the help of FoundationLocalization, this comparison requires bridging back to NSString. To avoid the extreme overhead of bridging the strings on every comparison, we'll do it up front instead.
+            // https://github.com/apple/swift-foundation/issues/284
             let nsKeysAndValues = dict.map {
                 (key: $0.key as NSString, value: $0.value)
             }

--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -1,0 +1,273 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A comparison algorithm for a given type.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public protocol SortComparator<Compared>: Hashable {
+    /// The type that the `SortComparator` provides a comparison for.
+    associatedtype Compared
+
+    /// The relative ordering of lhs, and rhs.
+    ///
+    /// The result of comparisons should be flipped if the current `order`
+    /// is `reverse`.
+    ///
+    /// If `compare(lhs, rhs)` is `.orderedAscending`, then `compare(rhs, lhs)`
+    /// must be `.orderedDescending`. If `compare(lhs, rhs)` is
+    /// `.orderedDescending`, then `compare(rhs, lhs)` must be
+    /// `.orderedAscending`.
+    ///
+    /// - Parameters:
+    ///     - lhs: A value to compare.
+    ///     - rhs: A value to compare.
+    func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult
+
+    /// If the `SortComparator`s resulting order is forward or reverse.
+    var order: SortOrder { get set }
+}
+
+/// The orderings that sorts can be performed with.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@frozen
+public enum SortOrder: Hashable, Codable, Sendable {
+    /// The ordering where if compare(a, b) == .orderedAscending,
+    /// a is placed before b.
+    case forward
+    /// The ordering where if compare(a, b) == .orderedAscending,
+    /// a is placed after b.
+    case reverse
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let isForward = try container.decode(Bool.self)
+        if isForward {
+            self = .forward
+        } else {
+            self = .reverse
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .forward: try container.encode(true)
+        case .reverse: try container.encode(false)
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension ComparisonResult {
+    package func withOrder(_ order: SortOrder) -> ComparisonResult {
+        if order == .reverse {
+            if self == .orderedAscending { return .orderedDescending }
+            if self == .orderedDescending { return .orderedAscending }
+        }
+        return self
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+package struct AnySortComparator: SortComparator {
+    var _base: Any // internal for testing
+
+    private var hashableBase: AnyHashable
+
+    /// Takes `base` and two values to be compared and compares the two values
+    /// using `base`.
+    private let _compare: (Any, Any, Any) -> ComparisonResult
+
+    /// Takes `base` inout, and a new `SortOrder` and changes `base`s `order`
+    /// to match the new `SortOrder`.
+    private let setOrder: (inout Any, SortOrder) -> AnyHashable
+
+    /// Gets the current `order` property of `base`.
+    private let getOrder: (Any) -> SortOrder
+
+    package init<Comparator: SortComparator>(_ comparator: Comparator) {
+        self.hashableBase = AnyHashable(comparator)
+        self._base = comparator
+        self._compare = { (base: Any, lhs: Any, rhs: Any) -> ComparisonResult in
+            (base as! Comparator).compare(lhs as! Comparator.Compared, rhs as! Comparator.Compared)
+        }
+        self.setOrder = { (base: inout Any, newOrder: SortOrder) -> AnyHashable in
+            var typedBase = base as! Comparator
+            typedBase.order = newOrder
+            base = typedBase
+            return AnyHashable(typedBase)
+        }
+        self.getOrder = { (base: Any) -> SortOrder in
+            (base as! Comparator).order
+        }
+    }
+
+    package var order: SortOrder {
+        get {
+            return getOrder(_base)
+        }
+        set {
+            hashableBase = setOrder(&_base, newValue)
+        }
+    }
+
+    package func compare(_ lhs: Any, _ rhs: Any) -> ComparisonResult {
+        return _compare(_base, lhs, rhs)
+    }
+
+    package func hash(into hasher: inout Hasher) {
+        hasher.combine(hashableBase)
+    }
+
+    package static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.hashableBase == rhs.hashableBase
+    }
+}
+
+/// Compares `Comparable` types using their comparable implementation.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct ComparableComparator<Compared: Comparable>: SortComparator, Sendable {
+    public var order: SortOrder
+    
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+    public init(order: SortOrder = .forward) {
+        self.order = order
+    }
+
+    private func unorderedCompare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
+        if lhs < rhs { return .orderedAscending }
+        if lhs > rhs { return .orderedDescending }
+        return .orderedSame
+    }
+
+    public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
+        return unorderedCompare(lhs, rhs).withOrder(order)
+    }
+}
+
+/// A comparator which orders optional values using a comparator which
+/// compares the optional's `Wrapped` type. `nil` values are ordered before
+/// non-nil values when `order` is `forward`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+package struct OptionalComparator<Base: SortComparator>: SortComparator {
+    private var base: Base
+
+    package init(_ base: Base) {
+        self.base = base
+    }
+
+    package var order: SortOrder {
+        get { base.order }
+        set { base.order = newValue }
+    }
+
+    package func compare(_ lhs: Base.Compared?, _ rhs: Base.Compared?) -> ComparisonResult {
+        guard let lhs else {
+            if rhs == nil { return .orderedSame }
+            return .orderedAscending.withOrder(order)
+        }
+        guard let rhs else { return .orderedDescending.withOrder(order) }
+        return base.compare(lhs, rhs)
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Never: SortComparator {
+    public typealias Compared = Never
+
+    public func compare(_ lhs: Never, _ rhs: Never) -> ComparisonResult {}
+
+    public var order: SortOrder {
+        get {
+            switch self {}
+        }
+        set {
+            switch self {}
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Sequence {
+    /// Returns the elements of the sequence, sorted using the given comparator
+    /// to compare elements.
+    ///
+    /// - Parameters:
+    ///   - comparator: the comparator to use in ordering elements
+    /// - Returns: an array of the elements sorted using `comparator`.
+    public func sorted<Comparator: SortComparator>(using comparator: Comparator) -> [Element] where Comparator.Compared == Element {
+        return self.sorted {
+            comparator.compare($0, $1) == .orderedAscending
+        }
+    }
+
+    /// Returns the elements of the sequence, sorted using the given array of
+    /// `SortComparator`s to compare elements.
+    ///
+    /// - Parameters:
+    ///   - comparators: an array of comparators used to compare elements. The
+    ///   first comparator specifies the primary comparator to be used in
+    ///   sorting the sequence's elements. Any subsequent comparators are used
+    ///   to further refine the order of elements with equal values.
+    /// - Returns: an array of the elements sorted using `comparators`.
+    public func sorted<S: Sequence, Comparator: SortComparator>(using comparators: S) -> [Element] where
+        S.Element == Comparator,
+        Element == Comparator.Compared
+    {
+        return self.sorted {
+            comparators.compare($0, $1) == .orderedAscending
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Sequence {
+    /// If `lhs` is ordered before `rhs` in the ordering described by the given
+    /// sequence of `SortComparator`s
+    ///
+    /// The first element of the sequence of comparators specifies the primary
+    /// comparator to be used in sorting the sequence's elements. Any subsequent
+    /// comparators are used to further refine the order of elements with equal
+    /// values.
+    public func compare<Comparator: SortComparator>(_ lhs: Comparator.Compared, _ rhs: Comparator.Compared) -> ComparisonResult where Element == Comparator {
+        for comparator in self {
+            let result = comparator.compare(lhs, rhs)
+            if result != .orderedSame { return result }
+        }
+        return .orderedSame
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension MutableCollection where Self: RandomAccessCollection {
+    /// Sorts the collection using the given comparator to compare elements.
+    /// - Parameters:
+    ///     - comparator: the sort comparator used to compare elements.
+    public mutating func sort<Comparator: SortComparator>(using comparator: Comparator) where Comparator.Compared == Element {
+        self.sort {
+            comparator.compare($0, $1) == .orderedAscending
+        }
+    }
+
+    /// Sorts the collection using the given array of `SortComparator`s to
+    /// compare elements.
+    ///
+    /// - Parameters:
+    ///   - comparators: an array of comparators used to compare elements. The
+    ///   first comparator specifies the primary comparator to be used in
+    ///   sorting the sequence's elements. Any subsequent comparators are used
+    ///   to further refine the order of elements with equal values.
+    public mutating func sort<S: Sequence, Comparator: SortComparator>(using comparators: S) where S.Element == Comparator, Element == Comparator.Compared {
+        self.sort {
+            comparators.compare($0, $1) == .orderedAscending
+        }
+    }
+}

--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -137,10 +137,17 @@ package struct AnySortComparator: SortComparator {
 public struct ComparableComparator<Compared: Comparable>: SortComparator, Sendable {
     public var order: SortOrder
     
-    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+#if FOUNDATION_FRAMEWORK
+    @available(FoundationPreview 0.1, *)
     public init(order: SortOrder = .forward) {
         self.order = order
     }
+#else
+    // No need for availability on this initializer in the package.
+    public init(order: SortOrder = .forward) {
+        self.order = order
+    }
+#endif
 
     private func unorderedCompare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
         if lhs < rhs { return .orderedAscending }

--- a/Sources/FoundationEssentials/String/StringProtocol+Stub.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Stub.swift
@@ -15,7 +15,7 @@
 extension StringProtocol {
     /// Compares the string using the specified options and
     /// returns the lexical ordering for the range.
-    internal func compare<T : StringProtocol>(_ aString: T, options mask: String.CompareOptions = [], range: Range<Index>? = nil) -> ComparisonResult {
+    package func compare<T : StringProtocol>(_ aString: T, options mask: String.CompareOptions = [], range: Range<Index>? = nil) -> ComparisonResult {
         // TODO: This method is modified from `public func compare<T : StringProtocol>(_ aString: T, options mask: String.CompareOptions = [], range: Range<Index>? = nil, locale: Locale? = nil) -> ComparisonResult`. Move that method here once `Locale` can be staged in `FoundationEssentials`.
         var substr = Substring(self)
         if let range {

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+/// Compares elements using a `KeyPath`, and a `SortComparator` which compares
+/// elements of the `KeyPath`s `Value` type.
+@_nonSendable
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct KeyPathComparator<Compared>: SortComparator {
+    /// The key path to the property to be used for comparisons.
+    public let keyPath: PartialKeyPath<Compared>
+
+    public var order: SortOrder {
+        get {
+            comparator.order
+        }
+        set {
+            comparator.order = newValue
+        }
+    }
+
+    var comparator: AnySortComparator
+
+    private let extractField: (Compared) -> Any
+
+    /// Get the field at `cachedOffset` if there is one, otherwise
+    /// access the field directly through the keypath.
+    private static func getField<T>(ofType fieldType: T.Type, offset maybeOffset: Int?, from base: Compared, fallback keyPath: KeyPath<Compared, T>) -> T {
+        guard let offset = maybeOffset else {
+            return base[keyPath: keyPath]
+        }
+        return withUnsafePointer(to: base) { pointer in
+            let rawPointer = UnsafeRawPointer(pointer)
+            return rawPointer
+                .advanced(by: offset)
+                .assumingMemoryBound(to: fieldType)
+                .pointee
+        }
+    }
+
+    /// Creates a `KeyPathComparator` that orders values based on a property
+    /// that conforms to the `Comparable` protocol.
+    ///
+    /// The underlying field comparison uses `ComparableComparator<Value>()`
+    /// unless the keyPath points to a `String` in which case the default string
+    /// comparator, `String.StandardComparator.localizedStandard`, will be used.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) {
+        self.keyPath = keyPath
+        if Value.self is String.Type {
+#if FOUNDATION_FRAMEWORK
+            self.comparator = AnySortComparator(String.StandardComparator.localizedStandard)
+#else
+            // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, use the lexical default
+            // https://github.com/apple/swift-foundation/issues/284
+            self.comparator = AnySortComparator(String.StandardComparator.lexical)
+#endif
+        } else {
+            self.comparator = AnySortComparator(ComparableComparator<Value>())
+        }
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath)
+        }
+        self.order = order
+    }
+
+    /// Creates a `KeyPathComparator` that orders values based on an optional
+    /// property whose wrapped value conforms to the `Comparable` protocol.
+    ///
+    /// The resulting `KeyPathComparator` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// The underlying field comparison uses `ComparableComparator<Value>()`
+    /// unless the keyPath points to a `String` in which case the default string
+    /// comparator, `String.StandardComparator.localizedStandard`, will be used.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) {
+        self.keyPath = keyPath
+        if Value.self is String.Type {
+#if FOUNDATION_FRAMEWORK
+            self.comparator = AnySortComparator(OptionalComparator(String.StandardComparator.localizedStandard))
+#else
+            // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, use the lexical default
+            // https://github.com/apple/swift-foundation/issues/284
+            self.comparator = AnySortComparator(OptionalComparator(String.StandardComparator.lexical))
+#endif
+        } else {
+            self.comparator = AnySortComparator(OptionalComparator(ComparableComparator<Value>()))
+        }
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value?.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath) as Any
+        }
+        self.order = order
+    }
+
+    /// Creates a `KeyPathComparator` with the given `keyPath` and
+    /// `SortComparator`.
+    ///
+    /// `comparator.order` is used for the initial `order` of the created
+    /// `KeyPathComparator`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the value used for the comparison.
+    ///   - comparator: The `SortComparator` used to order values.
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator) where Comparator.Compared == Value {
+        self.keyPath = keyPath
+        self.comparator = AnySortComparator(comparator)
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath)
+        }
+    }
+
+    /// Creates a `KeyPathComparator` with the given `keyPath` to an optional
+    /// value and `SortComparator`.
+    ///
+    /// The resulting `KeyPathComparator` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// `comparator.order` is used for the initial `order` of the created
+    /// `KeyPathComparator`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the value used for the comparison.
+    ///   - comparator: The `SortComparator` used to order values.
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator) where Comparator.Compared == Value {
+        self.keyPath = keyPath
+        self.comparator = AnySortComparator(OptionalComparator(comparator))
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value?.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath) as Any
+        }
+    }
+
+    /// Creates a `KeyPathComparator` with the given `keyPath`,
+    /// `SortComparator`, and initial order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the value used for the comparison.
+    ///   - comparator: The `SortComparator` used to order values.
+    ///   - order: The initial order to use for comparison.
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+        self.keyPath = keyPath
+        self.comparator = AnySortComparator(comparator)
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath)
+        }
+        self.order = order
+    }
+
+    /// Creates a `KeyPathComparator` with the given `keyPath`,
+    /// `SortComparator`, and initial order.
+    ///
+    ///  The resulting `KeyPathComparator` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the value used for the comparison.
+    ///   - comparator: The `SortComparator` used to order values.
+    ///   - order: The initial order to use for comparison.
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+        self.keyPath = keyPath
+        self.comparator = AnySortComparator(OptionalComparator(comparator))
+        let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
+        self.extractField = {
+            Self.getField(
+                ofType: Value?.self,
+                offset: cachedOffset,
+                from: $0,
+                fallback: keyPath) as Any
+        }
+        self.order = order
+    }
+
+    public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
+        let lhsField = extractField(lhs)
+        let rhsField = extractField(rhs)
+        return self.comparator.compare(lhsField, rhsField)
+    }
+
+    public static func ==(lhs: Self, rhs: Self) -> Bool {
+        return lhs.keyPath == rhs.keyPath && lhs.comparator == rhs.comparator
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(keyPath)
+        hasher.combine(comparator)
+    }
+}

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -142,7 +142,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// The key path to the field for comparison.
     ///
     /// This value is `nil` when `Compared` is not an NSObject
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public var keyPath: PartialKeyPath<Compared>? {
         switch comparison {
         case .comparable(_, let keyPath):
@@ -162,7 +162,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///
     /// This property is non-`nil` when the `SortDescriptor` value is created
     /// with one.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public var stringComparator: String.StandardComparator? {
         var result: String.StandardComparator?
         switch comparison {
@@ -203,7 +203,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
@@ -225,7 +225,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
@@ -254,7 +254,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
@@ -273,7 +273,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
@@ -293,7 +293,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
@@ -315,7 +315,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    @available(FoundationPreview 0.1, *)
     public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -1,0 +1,962 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+/// A serializable description of how to sort numeric and `String` types.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {    
+    /// The set of supported safely serializable comparisons.
+    enum AllowedComparison: Hashable, Codable {
+        /// Compare `String` by retrieving from key path, using using the given standard string comparator.
+        case comparableString(String.StandardComparator, KeyPath<Compared, String>)
+        
+        /// Compare `String?` by retrieving from key path, using using the given standard string comparator.
+        case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?>)
+        
+        /// Compares using `Swift.Comparable` implementation.
+        case comparable(AnySortComparator, PartialKeyPath<Compared>)
+        
+#if FOUNDATION_FRAMEWORK
+        /// Compares using the `compare` selector on the given type.
+        case compare
+        
+        /// Compares `String`s using the given standard string comparator.
+        case compareString(String.StandardComparator)
+#endif
+
+        enum CodingKeys: String, CodingKey {
+            case rawValue
+            case stringComparator
+        }
+
+#if FOUNDATION_FRAMEWORK
+        fileprivate var selector: Selector {
+            switch self {
+            case .compare:
+                return #selector(NSNumber.compare(_:))
+            case let .compareString(comparator):
+                return comparator.associatedSelector
+            case .comparable, .comparableString, .comparableOptionalString:
+                fatalError("Accessing `selector` for `comparable` comparison")
+            }
+        }
+#endif
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let rawValue = try container.decode(UInt.self, forKey: .rawValue)
+            switch rawValue {
+            case 0: 
+#if FOUNDATION_FRAMEWORK
+                self = .compare
+#else
+                throw DecodingError.dataCorruptedError(
+                    forKey: .rawValue,
+                    in: container,
+                    debugDescription: "`compare` is not supported on this platform.")
+#endif
+            case 1:
+#if FOUNDATION_FRAMEWORK
+                let comparator = try container.decode(String.StandardComparator.self, forKey: .stringComparator)
+                if comparator.equalsIgnoringOrder(.lexical) {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .rawValue,
+                        in: container,
+                        debugDescription: """
+                        Attempted to decode `AllowedSelector` in invalid
+                        configuration.
+                        """)
+                }
+                self = .compareString(comparator)
+#else
+                throw DecodingError.dataCorruptedError(
+                    forKey: .rawValue,
+                    in: container,
+                    debugDescription: "`compareString` is not supported on this platform.")
+#endif
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .rawValue,
+                    in: container,
+                    debugDescription: """
+                    Attempted to decode `AllowedSelector` in invalid
+                    configuration.
+                    """)
+            }
+        }
+
+#if FOUNDATION_FRAMEWORK
+        fileprivate init?(fromSelector selector: Selector) {
+            switch NSStringFromSelector(selector) {
+            case "compare:":
+                self = .compare
+            case "localizedStandardCompare:":
+                self = .compareString(.localizedStandard)
+            case "localizedCompare:":
+                self = .compareString(.localized)
+            default:
+                return nil
+            }
+        }
+#endif
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            let rawValue: Int
+            switch self {
+#if FOUNDATION_FRAMEWORK
+            case .compare:
+                rawValue = 0
+            case let .compareString(comparator):
+                rawValue = 1
+                try container.encode(comparator, forKey: .stringComparator)
+#endif
+            case .comparable, .comparableString, .comparableOptionalString:
+                throw EncodingError.invalidValue(
+                    self,
+                    .init(
+                        codingPath: [],
+                        debugDescription: """
+                            Encoding SortDescriptor with values of type \
+                            non-NSObject `Compared` is unsupported.
+                            """
+                    )
+                )
+            }
+            try container.encode(rawValue, forKey: .rawValue)
+        }
+    }
+
+    /// The key path to the field for comparison.
+    ///
+    /// This value is `nil` when `Compared` is not an NSObject
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public var keyPath: PartialKeyPath<Compared>? {
+        switch comparison {
+        case .comparable(_, let keyPath):
+            return keyPath
+        case .comparableString(_, let keyPath):
+            return keyPath
+        case .comparableOptionalString(_, let keyPath):
+            return keyPath
+#if FOUNDATION_FRAMEWORK
+        case .compare, .compareString(_:):
+            return nil
+#endif
+        }
+    }
+
+    /// A `String.StandardComparator` value.
+    ///
+    /// This property is non-`nil` when the `SortDescriptor` value is created
+    /// with one.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public var stringComparator: String.StandardComparator? {
+        var result: String.StandardComparator?
+        switch comparison {
+        case .comparableString(let comparator, _):
+            result = comparator
+        case .comparableOptionalString(let comparator, _):
+            result = comparator
+#if FOUNDATION_FRAMEWORK
+        case .compareString(let comparator):
+            result = comparator
+#endif
+        default:
+            result = nil
+        }
+
+        result?.order = .forward
+        return result
+    }
+
+    /// Sort order.
+    public var order: SortOrder
+
+    /// The `String` key specifying the property to be compared.
+    let keyString: String?
+
+    /// The comparison used to compare specified properties.
+    let comparison: AllowedComparison
+
+
+    // MARK: - Initializers for supported types.
+
+    /// Creates a `SortDescriptor` that orders values based on a `Value`'s
+    /// `Comparable` implementation.
+    ///
+    /// Instances of `SortDescriptor` created with this initializer should not
+    /// be used to convert to `NSSortDescriptor`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
+        self.order = order
+        self.keyString = nil
+        self.comparison = .comparable(
+            AnySortComparator(ComparableComparator<Value>(order: order)),
+            keyPath
+        )
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Value`'s
+    /// `Comparable` implementation.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// Instances of `SortDescriptor` created with this initializer should not
+    /// be used to convert to `NSSortDescriptor`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
+        self.order = order
+        self.keyString = nil
+        self.comparison = .comparable(
+            AnySortComparator(OptionalComparator(ComparableComparator<Value>(order: order))),
+            keyPath
+        )
+    }
+
+#if FOUNDATION_FRAMEWORK
+    // TODO: On Darwin, the following initializers use `.localizedStandard` as the default value. Without String.compare(_:options:locale:), we have to leave the default un-set for other platforms. Once we have it, we can re-unify the behavior again.
+    // https://github.com/apple/swift-foundation/issues/284
+    
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator.
+    ///
+    /// `comparator.order` is used for the initial `order` of the
+    /// created `SortDescriptor`.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// Instances of `SortDescriptor` created with this initializer should not
+    /// be used to convert to `NSSortDescriptor`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
+        self.order = comparator.order
+        self.keyString = nil
+        self.comparison = .comparableString(comparator, keyPath)
+    }
+
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator.
+    ///
+    /// `comparator.order` is used for the initial `order` of the
+    /// created `SortDescriptor`.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
+        self.order = comparator.order
+        self.keyString = nil
+        self.comparison = .comparableOptionalString(comparator, keyPath)
+    }
+
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// Instances of `SortDescriptor` created with this initializer should not
+    /// be used to convert to `NSSortDescriptor`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    ///   - order: The initial order to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+        self.order = order
+        self.keyString = nil
+        var comparator = comparator
+        comparator.order = order
+        self.comparison = .comparableString(comparator, keyPath)
+    }
+
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator.
+    ///
+    /// `comparator.order` is used for the initial `order` of the
+    /// created `SortDescriptor`.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    ///   - order: The initial order to use for comparison.
+    @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+        self.order = order
+        self.keyString = nil
+        var comparator = comparator
+        comparator.order = order
+        self.comparison = .comparableOptionalString(comparator, keyPath)
+    }
+#else
+    /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator) {
+        self.order = comparator.order
+        self.keyString = nil
+        self.comparison = .comparableString(comparator, keyPath)
+    }
+
+    /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator) {
+        self.order = comparator.order
+        self.keyString = nil
+        self.comparison = .comparableOptionalString(comparator, keyPath)
+    }
+
+    /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator, order: SortOrder) {
+        self.order = order
+        self.keyString = nil
+        var comparator = comparator
+        comparator.order = order
+        self.comparison = .comparableString(comparator, keyPath)
+    }
+
+    /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator, order: SortOrder) {
+        self.order = order
+        self.keyString = nil
+        var comparator = comparator
+        comparator.order = order
+        self.comparison = .comparableOptionalString(comparator, keyPath)
+    }
+#endif
+
+#if FOUNDATION_FRAMEWORK
+    
+    // We provide individual initializers for all supported types to ensure that we don't allow creation with custom types that conform to standard library numeric protocols.
+    // These types are all NSObject-based, so only valid in the framework.
+
+    /// Creates a `SortDescriptor` that orders values based on a `Bool`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Bool>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Bool?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Bool?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Double`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Double>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Double?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Double?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Float`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Float>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Float?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Float?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int8`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int8>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int8?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int8?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int16`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int16>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int16?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int16?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int32`
+    /// property
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int32>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int32?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int32?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int64`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int64>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int64?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int64?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Int?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Int?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt8`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt8>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt8?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt8?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt16`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt16>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt16?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt16?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt32`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt32>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt32?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt32?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt64`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt64>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt64?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt64?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UInt?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UInt?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Date`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Date>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `Date?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, Date?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UUID`
+    /// property.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UUID>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values based on a `UUID?`
+    /// property.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for the comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, UUID?>, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
+    }
+
+    /// Creates a `SortDescriptor` that orders values using the given
+    /// standard string comparator.
+    ///
+    /// `comparator.order` is used for the initial `order` of the
+    /// created `SortDescriptor`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+        self.init(
+            keyPath,
+            comparator: comparator,
+            order: comparator.order
+        )
+    }
+
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator.
+    ///
+    /// `comparator.order` is used for the initial `order` of the
+    /// created `SortDescriptor`.
+    ///
+    ///  The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+        self.init(
+            keyPath,
+            comparator: comparator,
+            order: comparator.order
+        )
+    }
+
+    /// Creates a `SortDescriptor` that orders values using the given
+    /// standard string comparator with the given initial order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+        guard let keyString = keyPath._kvcKeyPathString else {
+            fatalError("""
+            \(String(describing: Compared.self)) must be introspectable by \
+            the objective-c runtime in order to use it as the base type of \
+            a `SortDescriptor`.
+            """)
+        }
+        self.keyString = keyString
+        self.order = order
+        // `SortDescriptor` stores its own order, so set the passed comparator's
+        // order to forward, and ignore it from this point on.
+        var alwaysForwardComparator = comparator
+        alwaysForwardComparator.order = .forward
+        if comparator == .lexical {
+            self.comparison = .compare
+        } else {
+            self.comparison = .compareString(alwaysForwardComparator)
+        }
+    }
+
+    /// Creates a `SortDescriptor` that orders optional values using the given
+    /// standard string comparator with the given initial order.
+    ///
+    /// The resulting `SortDescriptor` orders `nil` values first when in
+    /// `forward` order.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the field to use for comparison.
+    ///   - comparator: The standard string comparator to use for comparison.
+    ///   - order: The initial order to use for comparison.
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+        guard let keyString = keyPath._kvcKeyPathString else {
+            fatalError("""
+            \(String(describing: Compared.self)) must be introspectable by \
+            the objective-c runtime in order to use it as the base type of \
+            a `SortDescriptor`.
+            """)
+        }
+        self.keyString = keyString
+        self.order = order
+        // `SortDescriptor` stores its own order, so set the passed comparator's
+        // order to forward, and ignore it from this point on.
+        var alwaysForwardComparator = comparator
+        alwaysForwardComparator.order = .forward
+        if comparator == .lexical {
+            self.comparison = .compare
+        } else {
+            self.comparison = .compareString(alwaysForwardComparator)
+        }
+    }
+
+    private init<Key>(uncheckedCompareBasedKeyPath keyPath: KeyPath<Compared, Key>, order: SortOrder) where Compared: NSObject {
+        guard let keyString = keyPath._kvcKeyPathString else {
+            fatalError("""
+            \(String(describing: Compared.self)) must be introspectable by \
+            the objective-c runtime in order to use it as the base type of \
+            a `SortDescriptor`.
+            """)
+        }
+        self.keyString = keyString
+        self.order = order
+        self.comparison = .compare
+    }
+    
+#endif // FOUNDATION_FRAMEWORK
+    
+
+#if FOUNDATION_FRAMEWORK
+    /// Creates a `SortDescriptor` describing the same sort as the
+    /// `NSSortDescriptor` over the given `Compared` type.
+    ///
+    /// Returns `nil` if there is no `SortDescriptor` equivalent to the given
+    /// `NSSortDescriptor`, or if the `NSSortDescriptor`s selector is not one of
+    /// the standard string comparison algorithms, or `compare(_:)`.
+    ///
+    /// The comparison for the created `SortDescriptor` uses the
+    /// `NSSortDescriptor`s associated selector directly, so in cases where
+    /// using the `NSSortDescriptor`s comparison would crash, the
+    /// `SortDescriptor`s comparison will as well.
+    ///
+    /// - Parameters:
+    ///     - descriptor: The `NSSortDescriptor` to convert.
+    ///     - comparedType: The type the resulting `SortDescriptor` compares.
+    public init?(_ descriptor: NSSortDescriptor, comparing comparedType: Compared.Type) where Compared: NSObject {
+        guard let keyString = descriptor.key else { return nil }
+        guard let selector = descriptor.selector else { return nil }
+        guard let comparison = AllowedComparison(
+            fromSelector: selector) else { return nil }
+        self.keyString = keyString
+        self.order = descriptor.ascending ? .forward : .reverse
+        self.comparison = comparison
+    }
+#endif
+    
+    public func compare(_ lhs: Compared, _ rhs: Compared) -> ComparisonResult {
+        switch comparison {
+        case .comparable(let comparator, let keyPath):
+            return comparator.compare(
+                lhs[keyPath: keyPath],
+                rhs[keyPath: keyPath]
+            )
+        case .comparableString(let comparator, let keyPath):
+            return comparator.compare(
+                lhs[keyPath: keyPath],
+                rhs[keyPath: keyPath]
+            )
+        case .comparableOptionalString(let comparator, let keyPath):
+            return switch (lhs[keyPath: keyPath], rhs[keyPath: keyPath]) {
+            case (nil, nil):
+                .orderedSame
+            case (nil, _):
+                order == .forward ? .orderedAscending : .orderedDescending
+            case (_, nil):
+                order == .forward ? .orderedDescending : .orderedAscending
+            case let (lhsString?, rhsString?):
+                comparator.compare(lhsString, rhsString)
+            }
+#if FOUNDATION_FRAMEWORK
+        case .compare, .compareString(_):
+            let bridged = NSSortDescriptor(_sortDescriptor: self)
+            return bridged.compare(lhs, to: rhs)
+#endif
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(keyString)
+        hasher.combine(order)
+        hasher.combine(comparison)
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension NSSortDescriptor {
+    /// Creates an `NSSortDescriptor` representing the same sort as the given
+    /// `SortDescriptor`.
+    ///
+    /// - Parameters:
+    ///     - sortDescriptor: The `SortDescriptor` to convert.
+    @backDeployed(before: iOS 17, macOS 14, tvOS 17, watchOS 10)
+    public convenience init<Compared>(_ sortDescriptor: SortDescriptor<Compared>) where Compared: NSObject {
+        self.init(_sortDescriptor: sortDescriptor)
+    }
+
+    @_alwaysEmitIntoClient
+    public convenience init<Compared>(_sortDescriptor: SortDescriptor<Compared>) {
+        self.init(_sortDescriptor)
+    }
+
+    @available(macOS, deprecated: 14,
+               message: """
+               Use `init(_:) where Compared: NSObject` instead. Attempt to \
+               convert SortDescriptor with Compared being non-NSObject will \
+               result in a fatalError at runtime.
+               """)
+    @available(iOS, deprecated: 17,
+               message: """
+               Use `init(_:) where Compared: NSObject` instead. Attempt to \
+               convert SortDescriptor with Compared being non-NSObject will \
+               result in a fatalError at runtime.
+               """)
+    @available(tvOS, deprecated: 17,
+               message: """
+               Use `init(_:) where Compared: NSObject` instead. Attempt to \
+               convert SortDescriptor with Compared being non-NSObject will \
+               result in a fatalError at runtime.
+               """)
+    @available(watchOS, deprecated: 10,
+               message: """
+               Use `init(_:) where Compared: NSObject` instead. Attempt to \
+               convert SortDescriptor with Compared being non-NSObject will \
+               result in a fatalError at runtime.
+               """)
+    @_disfavoredOverload
+    public convenience init<Compared>(_ sortDescriptor: SortDescriptor<Compared>) {
+        // This `init` used to unconditionally accept all `SortDescriptor`s,
+        // which were guaranteed to have a valid `keyString` property because
+        // the `Compared` value is an `NSObject`. This `init` was deprecated
+        // becasue we introduced ways to create `SortDescriptor` values that do
+        // not have such valid properties. At the deprecation, we introduced an
+        // replacement `init` that requires `Compared: NSObject`, providing the
+        // same level of always-valid-conversion to existing users.
+        //
+        // Under certain circumstances (new code linking against old,
+        // third-party binary that make calls to this `init`, for example),
+        // a `SortDescriptor` whose `Compared` isn't `NSObject` can get passed
+        // here. Instead of silently creating an invalid `NSSortDescriptor`,
+        // we'll fatalError to prevent the `NSSortDescriptor` from propagating
+        // further into user's program, which may result in data loss.
+        guard let keyString = sortDescriptor.keyString else {
+            fatalError("""
+                Attempt to convert SortDescriptor with Compared being \
+                non-NSObject
+                """)
+        }
+
+        self.init(
+            key: keyString,
+            ascending: sortDescriptor.order == .forward,
+            selector: sortDescriptor.comparison.selector)
+    }
+
+}
+
+#endif

--- a/Sources/FoundationInternationalization/String/String+SortComparator.swift
+++ b/Sources/FoundationInternationalization/String/String+SortComparator.swift
@@ -1,0 +1,289 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension String {
+    /// Compares `String`s using one of a fixed set of standard comparison
+    /// algorithms.
+    public struct StandardComparator: SortComparator, Codable, Sendable {
+        public typealias Compared = String
+#if FOUNDATION_FRAMEWORK
+        // https://github.com/apple/swift-foundation/issues/284
+        
+        /// Compares `String`s as compared by the Finder.
+        ///
+        /// Uses a localized, numeric comparison in the current locale.
+        ///
+        /// The default `SortComparator` used in `String` comparisons.
+        public static let localizedStandard = StandardComparator(
+            options: [
+                .numeric,
+                .caseInsensitive,
+                .widthInsensitive,
+                .forcedOrdering
+            ],
+            localized: true
+        )
+
+        /// Compares `String`s using a localized comparison in the current
+        /// locale.
+        public static let localized = StandardComparator(options: [], localized: true)
+#endif
+
+        /// Compares `String`s lexically.
+        public static let lexical = StandardComparator(options: [], localized: false)
+
+#if FOUNDATION_FRAMEWORK
+        private static let validAlgorithms: [StandardComparator: Selector] = [
+            .localizedStandard:
+                #selector(NSString.localizedStandardCompare(_:)),
+            .localizedStandard.flipped:
+                #selector(NSString.localizedStandardCompare(_:)),
+            .localized: #selector(NSString.localizedCompare(_:)),
+            .localized.flipped: #selector(NSString.localizedCompare(_:)),
+            .lexical: #selector(NSString.compare(_:)),
+            .lexical.flipped: #selector(NSString.compare(_:)),
+        ]
+#else
+        // https://github.com/apple/swift-foundation/issues/284
+        private static let validAlgorithms: [StandardComparator: Bool] = [
+            .lexical: true,
+            .lexical.flipped: true,
+        ]
+#endif
+        
+        private var flipped: StandardComparator {
+            var result = self
+            result.order = self.order == .forward ? .reverse : .forward
+            return result
+        }
+
+#if FOUNDATION_FRAMEWORK
+        var associatedSelector: Selector {
+            guard let selector = Self.validAlgorithms[self] else {
+                fatalError("""
+                Attempted to retreive selector from a \
+                String.StandardSortComparator with an invalid configuration.
+                """)
+            }
+            return selector
+        }
+#endif
+
+        func equalsIgnoringOrder(_ other: Self) -> Bool {
+            return options == other.options && isLocalized == other.isLocalized
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case options
+            case isLocalized
+            case order
+        }
+
+        /// The `String.CompareOptions` used in the
+        /// `String.compare(_:,options:)`invocation that performs an
+        /// equivalent comparison.
+        fileprivate let options: String.CompareOptions
+
+        /// If the comparator is localized.
+        private let isLocalized: Bool
+
+        public var order: SortOrder
+
+        private init(options: String.CompareOptions, localized: Bool) {
+            self.options = options
+            self.isLocalized = localized
+            self.order = .forward
+        }
+
+        /// Create a `StandardComparator` from the given `StandardComparator`
+        /// with the given new `order`.
+        ///
+        /// - Parameters:
+        ///     - base: The standard comparator to modify the order of.
+        ///     - order: The initial order of the new `StandardComparator`.
+        public init(_ base: StandardComparator, order: SortOrder = .forward) {
+            self = base
+            self.order = order
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let rawOptions = try container.decode(
+                UInt.self, forKey: .options)
+            options = String.CompareOptions(rawValue: rawOptions)
+            isLocalized = try container.decode(Bool.self, forKey: .isLocalized)
+            order = try container.decode(SortOrder.self, forKey: .order)
+            // Check if the decoded value is one of the valid cases.
+            // If in future, more flexibility is afforded to standard
+            // string comparators, this restriction can be removed.
+            if Self.validAlgorithms[self] == nil {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: container.codingPath,
+                        debugDescription: """
+                        Attempted to decode \
+                        \(String(describing: Self.self)) in invalid \
+                        configuration.
+                        """))
+            }
+        }
+
+        public func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
+#if FOUNDATION_FRAMEWORK
+            // https://github.com/apple/swift-foundation/issues/284
+            return lhs.compare(rhs, options: options, locale: Locale.current).withOrder(order)
+#else
+            // TODO: Until compare(_:options:locale:) is ported to FoundationInternationalization, only support unlocalized
+            return lhs.compare(rhs, options: options).withOrder(order)
+#endif
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(options.rawValue)
+            hasher.combine(isLocalized)
+            hasher.combine(order)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(options.rawValue, forKey: .options)
+            try container.encode(isLocalized, forKey: .isLocalized)
+            try container.encode(order, forKey: .order)
+        }
+    }
+
+    /// A `String` comparison performed using the given comparison options
+    /// and locale.
+    public struct Comparator: SortComparator, Codable, Sendable {
+        enum CodingKeys: String, CodingKey {
+            case options
+            case locale
+            case order
+        }
+
+        /// The options to use for comparison.
+        public let options: String.CompareOptions
+
+        /// The locale to use for comparison if the comparator is localized,
+        /// otherwise nil.
+        public let locale: Locale?
+
+        public var order: SortOrder
+
+#if FOUNDATION_FRAMEWORK
+        // https://github.com/apple/swift-foundation/issues/284
+        
+        /// Creates a `String.Comparator` with the given `CompareOptions` and
+        /// `Locale`.
+        ///
+        /// - Parameters:
+        ///     - options: The options to use for comparison.
+        ///     - locale: The locale to use for comparison. If `nil`, the
+        ///       comparison is unlocalized.
+        ///     - order: The initial order to use for ordered comparison.
+        public init(options: String.CompareOptions, locale: Locale? = Locale.current, order: SortOrder = .forward) {
+            self.options = options
+            self.locale = locale
+            self.order = order
+        }
+#else
+        // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, only support unlocalized comparisons
+        public init(options: String.CompareOptions, order: SortOrder = .forward) {
+            self.options = options
+            self.locale = nil
+            self.order = order
+        }
+#endif
+
+        /// Creates a `String.Comparator` that represents the same comparison
+        /// as the given `String.StandardComparator`.
+        ///
+        /// - Parameters:
+        ///    - standardComparison: The `String.StandardComparator` to convert.
+        public init(_ standardComparison: StandardComparator) {
+            self.order = standardComparison.order
+            self.options = standardComparison.options
+#if FOUNDATION_FRAMEWORK
+            self.locale = Locale.current
+#else
+            // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, only support unlocalized comparisons
+            // https://github.com/apple/swift-foundation/issues/284
+            self.locale = nil
+#endif
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let rawOptions = try container.decode(UInt.self, forKey: .options)
+            options = String.CompareOptions(rawValue: rawOptions)
+            locale = try container.decode(Locale?.self, forKey: .locale)
+            order = try container.decode(SortOrder.self, forKey: .order)
+        }
+
+        public func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
+#if FOUNDATION_FRAMEWORK
+            return lhs.compare(rhs, options: options, locale: locale).withOrder(order)
+#else
+            // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, only support unlocalized comparisons
+            // https://github.com/apple/swift-foundation/issues/284
+            return lhs.compare(rhs, options: options).withOrder(order)
+#endif
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(options.rawValue)
+            hasher.combine(locale)
+            hasher.combine(order)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(options.rawValue, forKey: .options)
+            try container.encode(locale, forKey: .locale)
+            try container.encode(order, forKey: .order)
+        }
+    }
+}
+
+// Provide access to standard string comparators via leading dot syntax
+// in the generic case.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SortComparator where Self == String.Comparator {
+#if FOUNDATION_FRAMEWORK
+    // https://github.com/apple/swift-foundation/issues/284
+    
+    /// Compares `String`s as compared by the Finder.
+    ///
+    /// Uses a localized, numeric comparison in the current locale.
+    ///
+    /// The default `String.Comparator` used in `String` comparisons.
+    public static var localizedStandard: String.Comparator {
+        String.Comparator(.localizedStandard)
+    }
+
+    /// Compares `String`s using a localized comparison in the current
+    /// locale.
+    public static var localized: String.Comparator {
+        String.Comparator(.localized)
+    }
+#endif
+
+    /// Compares `String`s lexically.
+    static var lexical: String.Comparator {
+        String.Comparator(.lexical)
+    }
+}
+

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -197,4 +197,9 @@ public typealias StandardPredicateExpression = FoundationEssentials.StandardPred
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateError = FoundationEssentials.PredicateError
 
+public typealias SortDescriptor = FoundationInternationalization.SortDescriptor
+public typealias SortComparator = FoundationEssentials.SortComparator
+public typealias ComparableComparator = FoundationEssentials.ComparableComparator
+public typealias ComparisonResult = FoundationEssentials.ComparisonResult
+
 #endif // FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -20,9 +20,10 @@ import TestSupport
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
 
+@available(FoundationPreview 0.1, *)
 class SortComparatorTests: XCTestCase {
     func test_comparable_descriptors() {
-        let intDesc = ComparableComparator<Int>()
+        let intDesc : ComparableComparator<Int> = ComparableComparator<Int>()
         XCTAssertEqual(intDesc.compare(0, 1), .orderedAscending)
         let result = intDesc.compare(1000, -10)
         XCTAssertEqual(result, .orderedDescending)
@@ -30,7 +31,7 @@ class SortComparatorTests: XCTestCase {
     
     
     func test_order() {
-        var intDesc = ComparableComparator<Int>(order: .reverse)
+        var intDesc : ComparableComparator<Int> = ComparableComparator<Int>(order: .reverse)
         XCTAssertEqual(intDesc.compare(0, 1), .orderedDescending)
         XCTAssertEqual(intDesc.compare(1000, -10), .orderedAscending)
         XCTAssertEqual(intDesc.compare(100, 100), .orderedSame)

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationEssentials
+#endif // FOUNDATION_FRAMEWORK
+
+class SortComparatorTests: XCTestCase {
+    func test_comparable_descriptors() {
+        let intDesc = ComparableComparator<Int>()
+        XCTAssertEqual(intDesc.compare(0, 1), .orderedAscending)
+        let result = intDesc.compare(1000, -10)
+        XCTAssertEqual(result, .orderedDescending)
+    }
+    
+    
+    func test_order() {
+        var intDesc = ComparableComparator<Int>(order: .reverse)
+        XCTAssertEqual(intDesc.compare(0, 1), .orderedDescending)
+        XCTAssertEqual(intDesc.compare(1000, -10), .orderedAscending)
+        XCTAssertEqual(intDesc.compare(100, 100), .orderedSame)
+        
+        intDesc.order = .forward
+        XCTAssertEqual(intDesc.compare(0, 1), .orderedAscending)
+        XCTAssertEqual(intDesc.compare(1000, -10), .orderedDescending)
+        XCTAssertEqual(intDesc.compare(100, 100), .orderedSame)
+    }
+    
+    func test_compare_options_descriptor() {
+        let compareOptions = String.Comparator(options: [.numeric])
+        XCTAssertEqual(
+            compareOptions.compare("ttestest005", "test2"),
+            "test005".compare("test2", options: [.numeric]))
+        XCTAssertEqual(
+            compareOptions.compare("test2", "test005"),
+            "test2".compare("test005", options: [.numeric]))
+    }    
+}

--- a/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorConversionTests.swift
@@ -1,0 +1,391 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationEssentials
+#endif // FOUNDATION_FRAMEWORK
+
+#if FOUNDATION_FRAMEWORK
+
+/// Tests interop with Objective-C `NSSortDescriptor`.
+class SortDescriptorConversionTests: XCTestCase {
+    @objcMembers class Root: NSObject {
+        let word: String
+        let number: Int
+        let double: Double
+        let float: Float
+        let int16: Int16
+        let int32: Int32
+        let int64: Int64
+        let uInt8: UInt8
+        let uInt16: UInt16
+        let uInt32: UInt32
+        let uInt64: UInt64
+        let uInt: UInt
+        let data: Data
+
+        init(
+            word: String = "wow",
+            number: Int = 1,
+            double: Double = 1,
+            float: Float = 1,
+            int16: Int16 = 1,
+            int32: Int32 = 1,
+            int64: Int64 = 1,
+            uInt8: UInt8 = 1,
+            uInt16: UInt16 = 1,
+            uInt32: UInt32 = 1,
+            uInt64: UInt64 = 1,
+            uInt: UInt = 1,
+            data: Data = Data()
+        ) {
+            self.word = word
+            self.number = number
+            self.double = double
+            self.float = float
+            self.int16 = int16
+            self.int32 = int32
+            self.int64 = int64
+            self.uInt8 = uInt8
+            self.uInt16 = uInt16
+            self.uInt32 = uInt32
+            self.uInt64 = uInt64
+            self.uInt = uInt
+            self.data = data
+        }
+
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? Root else { return false }
+            return self == other
+        }
+
+        static func ==(_ lhs: Root, _ rhs: Root) -> Bool {
+            return lhs.word == rhs.word &&
+                lhs.number == rhs.number &&
+                lhs.double == rhs.double &&
+                lhs.float == rhs.float &&
+                lhs.int16 == rhs.int16 &&
+                lhs.int32 == rhs.int32 &&
+                lhs.int64 == rhs.int64 &&
+                lhs.uInt == rhs.uInt &&
+                lhs.data == rhs.data
+        }
+    }
+
+    func test_sortdescriptor_to_nssortdescriptor_selector_conversion() {
+        let localizedStandard = SortDescriptor(\Root.word, comparator: .localizedStandard)
+        let localized = SortDescriptor(\Root.word, comparator: .localized)
+        let lexical = SortDescriptor(\Root.word, comparator: .lexical)
+        let nsLocalizedStandard = NSSortDescriptor(localizedStandard)
+        let nsLocalized = NSSortDescriptor(localized)
+        let nsLexical = NSSortDescriptor(lexical)
+        
+        XCTAssert(nsLocalizedStandard.selector != nil)
+        XCTAssertEqual(NSStringFromSelector(nsLocalizedStandard.selector!), "localizedStandardCompare:")
+        XCTAssert(nsLocalized.selector != nil)
+        XCTAssertEqual(NSStringFromSelector(nsLocalized.selector!), "localizedCompare:")
+        XCTAssert(nsLexical.selector != nil)
+        XCTAssertEqual(NSStringFromSelector(nsLexical.selector!), "compare:")
+
+        let compareBased: [SortDescriptor<Root>] = [
+            .init(\.word, comparator: .lexical),
+            .init(\.double),
+            .init(\.float),
+            .init(\.int16),
+            .init(\.int32),
+            .init(\.int64),
+            .init(\.number),
+            .init(\.uInt16),
+            .init(\.uInt32),
+            .init(\.uInt64),
+            .init(\.uInt),
+        ]
+
+        for descriptor in compareBased {
+            let nsDescriptor = NSSortDescriptor(descriptor)
+            XCTAssert(nsDescriptor.selector != nil)
+            XCTAssertEqual(NSStringFromSelector(nsDescriptor.selector!), "compare:")
+        }
+    }
+
+    func test_sortdescriptor_to_nssortdescriptor_order_conversion() {
+        let forward = SortDescriptor(\Root.number, order: .forward)
+        let reverse = SortDescriptor(\Root.number, order: .reverse)
+        let nsAscending = NSSortDescriptor(forward)
+        let nsDescending = NSSortDescriptor(reverse)
+        XCTAssert(nsAscending.ascending)
+        XCTAssertFalse(nsDescending.ascending)
+    }
+
+    func test_nssortdescriptor_to_sortdescriptor_conversion() {
+        let intDescriptor = NSSortDescriptor(keyPath: \Root.number, ascending: true)
+        XCTAssertEqual(SortDescriptor(intDescriptor, comparing: Root.self), SortDescriptor(\Root.number))
+
+        let stringDescriptor = NSSortDescriptor(keyPath: \Root.word, ascending: true)
+        XCTAssertEqual(SortDescriptor(stringDescriptor, comparing: Root.self), SortDescriptor(\Root.word, comparator: .lexical))
+
+        // test custom string selector conversion
+        let localizedStandard = NSSortDescriptor(key: "word", ascending: true, selector: #selector(NSString.localizedStandardCompare))
+        XCTAssertEqual(SortDescriptor(localizedStandard, comparing: Root.self), SortDescriptor(\Root.word))
+
+        let localized = NSSortDescriptor(key: "word", ascending: true, selector: #selector(NSString.localizedCompare))
+        XCTAssertEqual(SortDescriptor(localized, comparing: Root.self), SortDescriptor(\Root.word, comparator: .localized))
+    }
+
+    func test_nssortdescriptor_to_sortdescriptor_conversion_failure() {
+        let ascending = NSSortDescriptor(keyPath: \Root.word, ascending: true)
+        let descending = NSSortDescriptor(keyPath: \Root.word, ascending: false)
+        guard let forward = SortDescriptor(ascending, comparing: Root.self) else {
+            XCTFail()
+            return
+        }
+        
+        guard let reverse = SortDescriptor(descending, comparing: Root.self) else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(forward.order, .forward)
+        XCTAssertEqual(reverse.order, .reverse)
+    }
+    
+    func test_conversion_from_uninitializable_descriptor() throws {
+        let nsDesc = NSSortDescriptor(key: "data", ascending: true)
+        let desc = try XCTUnwrap(SortDescriptor(nsDesc, comparing: Root.self))
+
+        //` NSSortDescriptor`s pointing to `Data` support equality, but not
+        // full comparison so we should be able to get a same result. Anything
+        // else will crash.
+        let compareResult = desc.compare(Root(), Root())
+        XCTAssertEqual(compareResult, .orderedSame)
+    }
+    
+    func test_conversion_from_invalid_descriptor() throws {
+        let localizedCaseInsensitive = NSSortDescriptor(key: "word", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare))
+        let caseInsensitive = NSSortDescriptor(key: "word", ascending: true, selector: #selector(NSString.caseInsensitiveCompare))
+        let caseInsensitiveNumeric = NSSortDescriptor(key: "word", ascending: true, selector: Selector(("_caseInsensitiveNumericCompare:")))
+        XCTAssertNil(SortDescriptor(localizedCaseInsensitive, comparing: Root.self))
+        XCTAssertNil(SortDescriptor(caseInsensitive, comparing: Root.self))
+        XCTAssertNil(SortDescriptor(caseInsensitiveNumeric, comparing: Root.self))
+    }
+    
+    func test_key_path_optionality() {
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.word).keyPath)
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.maybeWord).keyPath)
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.gadget).keyPath)
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.maybeGadget).keyPath)
+
+        XCTAssertNil(SortDescriptor(\Root.word).keyPath)
+        XCTAssertNil(SortDescriptor(\Root.number).keyPath)
+
+        let ns = NSSortDescriptor(key: "number", ascending: true)
+        XCTAssertNil(SortDescriptor(ns, comparing: Root.self)!.keyPath)
+    }
+
+    func test_string_comparator_optionality() {
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.word).stringComparator)
+        XCTAssertNotNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.maybeWord).stringComparator)
+        XCTAssertNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.gadget).stringComparator)
+        XCTAssertNil(SortDescriptor(\SortDescriptorTests.NonNSObjectRoot.maybeGadget).stringComparator)
+
+        XCTAssertNotNil(SortDescriptor(\Root.word).stringComparator)
+        XCTAssertNil(SortDescriptor(\Root.number).stringComparator)
+
+        let ns = NSSortDescriptor(key: "word", ascending: true)
+        XCTAssertNil(SortDescriptor(ns, comparing: Root.self)!.stringComparator)
+    }
+    
+    func test_ordering() {
+        let forwardInt = SortDescriptor(\Root.number)
+        XCTAssertEqual(forwardInt.compare(Root(number: 3), Root(number: 4)), ComparisonResult.orderedAscending)
+        XCTAssertEqual(forwardInt.compare(Root(number: 4), Root(number: 3)), .orderedDescending)
+        let reverseInt = SortDescriptor(\Root.number, order: .reverse)
+        XCTAssertEqual(reverseInt.compare(Root(number: 3), Root(number: 4)), .orderedDescending)
+        XCTAssertEqual(reverseInt.compare(Root(number: 4), Root(number: 3)), .orderedAscending)
+    }
+
+    func test_mutable_order() {
+        var intComparator = SortDescriptor(\Root.number)
+        XCTAssertEqual(intComparator.compare(Root(number: 3), Root(number: 4)), .orderedAscending)
+        intComparator.order = .reverse
+        XCTAssertEqual(intComparator.compare(Root(number: 3), Root(number: 4)), .orderedDescending)
+    }
+
+    func test_default_comparator() {
+        let stringComparator = SortDescriptor(\Root.word)
+        XCTAssertEqual(stringComparator.comparison, .compareString(.localizedStandard))
+        let intDescriptor = SortDescriptor(\Root.number)
+        let intCompare = intDescriptor.comparison
+        XCTAssertEqual(intCompare, .compare)
+    }
+
+    func test_sorting_by_keypath_comparator() {
+        let a = SortDescriptor(\Root.word)
+        let b = SortDescriptor(\Root.number)
+        let c = SortDescriptor(\Root.float, order: .reverse)
+
+        let items: [Root] = [
+            Root(word: "d", number: 10),
+            Root(word: "b", number: -10),
+            Root(word: "a", number: 0),
+            Root(word: "d", number: 10, float: 10),
+            Root(word: "d", number: 20),
+            Root(word: "d", number: 5),
+            Root(word: "c", number: 500),
+        ]
+
+        let expectedA: [Root] = [
+            Root(word: "a", number: 0),
+            Root(word: "b", number: -10),
+            Root(word: "c", number: 500),
+            Root(word: "d", number: 10),
+            Root(word: "d", number: 10, float: 10),
+            Root(word: "d", number: 20),
+            Root(word: "d", number: 5),
+        ]
+
+        let expectedAB: [Root] = [
+            Root(word: "a", number: 0),
+            Root(word: "b", number: -10),
+            Root(word: "c", number: 500),
+            Root(word: "d", number: 5),
+            Root(word: "d", number: 10),
+            Root(word: "d", number: 10, float: 10),
+            Root(word: "d", number: 20),
+        ]
+
+        let expectedABC: [Root] = [
+            Root(word: "a", number: 0),
+            Root(word: "b", number: -10),
+            Root(word: "c", number: 500),
+            Root(word: "d", number: 5),
+            Root(word: "d", number: 10, float: 10),
+            Root(word: "d", number: 10),
+            Root(word: "d", number: 20),
+        ]
+
+        XCTAssertEqual(items.sorted(using: a), expectedA)
+        XCTAssertEqual(items.sorted(using: [a, b]), expectedAB)
+        XCTAssertEqual(items.sorted(using: [a, b, c]), expectedABC)
+    }
+
+    func test_codability() throws {
+        let descriptor = SortDescriptor(\Root.word, comparator: .localizedStandard)
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(descriptor)
+        let decoder = JSONDecoder()
+        let reconstructed = try decoder.decode(SortDescriptor<Root>.self, from: encoded)
+        XCTAssertEqual(descriptor, reconstructed)
+
+        // ensure the comparison still works after reconstruction
+        XCTAssertEqual(reconstructed.compare(Root(word: "a"), Root(word: "b")), .orderedAscending)
+    }
+
+    func test_decoding_dissallow_invaled() throws {
+        var otherLocale: Locale {
+            let attempt = Locale(identifier: "ta")
+            if Locale.current == attempt {
+                return Locale(identifier: "en_US")
+            }
+            return attempt
+        }
+
+        let encoder = JSONEncoder()
+        let localeStr = String(data: try encoder.encode(Locale.current), encoding: .utf8)!
+        let otherLocaleStr = String(data: try encoder.encode(otherLocale), encoding: .utf8)!
+
+        let invalidRawValue = """
+        {
+            "order": true,
+            "keyString": "word",
+            "comparison": {
+                "rawValue": 2131,
+                "stringComparator": {
+                    "options": 1,
+                    "locale": \(localeStr),
+                    "order": true
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let nonStandardComparator = """
+        {
+            "order": true,
+            "keyString": "word",
+            "comparison": {
+                "rawValue": 13,
+                "stringComparator": {
+                    "options": 8,
+                    "locale": \(localeStr),
+                    "order": true
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let nonStandardLocale = """
+        {
+            "order": true,
+            "keyString": "word",
+            "comparison": {
+                "rawValue": 13,
+                "stringComparator": {
+                    "options": 8,
+                    "locale": \(otherLocaleStr),
+                    "order": true
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+
+        do {
+            let _ = try decoder.decode(SortDescriptor<Root>.self, from: invalidRawValue)
+            XCTFail()
+        } catch {}
+
+        do {
+            let _ = try decoder.decode(SortDescriptor<Root>.self, from: nonStandardComparator)
+            XCTFail()
+        } catch {}
+
+        do {
+            let _ = try decoder.decode(SortDescriptor<Root>.self, from: nonStandardLocale)
+            XCTFail()
+        } catch {}
+    }
+    
+    func test_string_comparator_property_polarity() {
+        // `.stringComparator?.order` should always be `.forward` regardless
+        // of the value of `SortDescriptor().order`
+        XCTAssertEqual(
+            SortDescriptor(\Root.word).stringComparator?.order,
+            .forward
+        )
+        
+        XCTAssertEqual(
+            SortDescriptor(\Root.word, order: .reverse).stringComparator?.order,
+            .forward
+        )
+    }
+
+}
+
+#endif // FOUNDATION_FRAMEWORK

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -1,0 +1,308 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationEssentials
+@testable import FoundationInternationalization
+#endif // FOUNDATION_FRAMEWORK
+
+class SortDescriptorTests: XCTestCase {
+    struct NonNSObjectRoot {
+        enum Gadget: Int, Comparable {
+            case foo = 0
+            case bar = 2
+            case baz = 1
+
+            static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+                lhs.rawValue < rhs.rawValue
+            }
+        }
+
+        let number: Int
+        let word: String
+        let maybeWord: String?
+        let gadget: Gadget
+        let maybeGadget: Gadget?
+
+        init(number: Int = 0, word: String = "", maybeWord: String? = nil, gadget: Gadget = .foo, maybeGadget: Gadget? = nil) {
+            self.number = number
+            self.word = word
+            self.maybeWord = maybeWord
+            self.gadget = gadget
+            self.maybeGadget = maybeGadget
+        }
+    }
+
+    func test_none_nsobject_comparable() {
+        let forwardComparator = SortDescriptor(\NonNSObjectRoot.gadget)
+        let reverseComparator = SortDescriptor(\NonNSObjectRoot.gadget, order: .reverse)
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(gadget: .foo), NonNSObjectRoot(gadget: .bar)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(gadget: .foo), NonNSObjectRoot(gadget: .bar)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(gadget: .bar), NonNSObjectRoot(gadget: .baz)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(gadget: .bar), NonNSObjectRoot(gadget: .baz)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(gadget: .baz), NonNSObjectRoot(gadget: .baz)),
+            .orderedSame
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(gadget: .baz), NonNSObjectRoot(gadget: .baz)),
+            .orderedSame
+        )
+    }
+
+    func test_none_nsobject_optional_comparable() {
+        let forwardComparator = SortDescriptor(\NonNSObjectRoot.maybeGadget)
+        let reverseComparator = SortDescriptor(
+            \NonNSObjectRoot.maybeGadget, order: .reverse)
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: .foo), NonNSObjectRoot(maybeGadget: .bar)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: .foo), NonNSObjectRoot(maybeGadget: .bar)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: nil), NonNSObjectRoot(maybeGadget: .bar)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: nil), NonNSObjectRoot(maybeGadget: .bar)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: .bar), NonNSObjectRoot(maybeGadget: .baz)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: .bar), NonNSObjectRoot(maybeGadget: .baz)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: .bar), NonNSObjectRoot(maybeGadget: nil)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: .bar), NonNSObjectRoot(maybeGadget: nil)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: .baz), NonNSObjectRoot(maybeGadget: .baz)),
+            .orderedSame
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: .baz), NonNSObjectRoot(maybeGadget: .baz)),
+            .orderedSame
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeGadget: nil), NonNSObjectRoot(maybeGadget: nil)),
+            .orderedSame
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeGadget: nil), NonNSObjectRoot(maybeGadget: nil)),
+            .orderedSame
+        )
+    }
+
+    func test_none_nsobject_optional_string_comparable() {
+        let forwardComparator = SortDescriptor(\NonNSObjectRoot.maybeWord)
+        let reverseComparator = SortDescriptor(\NonNSObjectRoot.maybeWord, order: .reverse)
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeWord: "a"), NonNSObjectRoot(maybeWord: "b")),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeWord: "a"), NonNSObjectRoot(maybeWord: "b")),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeWord: nil), NonNSObjectRoot(maybeWord: "b")),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeWord: nil), NonNSObjectRoot(maybeWord: "b")),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeWord: "a"), NonNSObjectRoot(maybeWord: nil)),
+            .orderedDescending
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeWord: "a"), NonNSObjectRoot(maybeWord: nil)),
+            .orderedAscending
+        )
+
+        XCTAssertEqual(
+            forwardComparator.compare(NonNSObjectRoot(maybeWord: nil), NonNSObjectRoot(maybeWord: nil)),
+            .orderedSame
+        )
+
+        XCTAssertEqual(
+            reverseComparator.compare(NonNSObjectRoot(maybeWord: nil), NonNSObjectRoot(maybeWord: nil)),
+            .orderedSame
+        )
+    }
+
+    func test_none_nsobject_string_comparison() {
+        let forwardComparator = SortDescriptor(\NonNSObjectRoot.word)
+        let reverseComparator = SortDescriptor(\NonNSObjectRoot.word, order: .reverse)
+
+        XCTAssert(
+            forwardComparator.compare(NonNSObjectRoot(word: "a"), NonNSObjectRoot(word: "b")) == .orderedAscending
+        )
+
+        XCTAssert(
+            reverseComparator.compare(NonNSObjectRoot(word: "a"), NonNSObjectRoot(word: "b")) == .orderedDescending
+        )
+    }
+
+    func test_encoding_comparable_throws() {
+        let descriptors = [
+            SortDescriptor(\NonNSObjectRoot.word),
+            SortDescriptor(\NonNSObjectRoot.maybeWord),
+            SortDescriptor(\NonNSObjectRoot.gadget),
+            SortDescriptor(\NonNSObjectRoot.maybeGadget),
+        ]
+
+        for descriptor in descriptors {
+            let encoder = JSONEncoder()
+            XCTAssertThrowsError(try encoder.encode(descriptor))
+        }
+    }
+
+#if FOUNDATION_FRAMEWORK
+    // TODO: When String.compare(_:options:locale:) is available in FoundationInternationalization, enable these tests
+    // https://github.com/apple/swift-foundation/issues/284
+    
+    func test_string_comparator_order() {
+        let reverseComparator = {
+            var comparator = String.StandardComparator.localized
+            comparator.order = .reverse
+            return comparator
+        }()
+
+        XCTAssertEqual(SortDescriptor(\NonNSObjectRoot.word).order, .forward)
+
+        XCTAssertEqual(SortDescriptor(\NonNSObjectRoot.maybeWord).order, .forward)
+
+        XCTAssertEqual(SortDescriptor(\NonNSObjectRoot.word, comparator: .localized).order, .forward)
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, comparator: .localized).order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word, comparator: reverseComparator).order,
+            .reverse
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, comparator: reverseComparator).order,
+            .reverse
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word, comparator: .localized, order: .forward).order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, comparator: .localized, order: .forward).order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word, comparator: reverseComparator, order: .forward).order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, comparator: reverseComparator, order: .forward).order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word, comparator: .localized, order: .reverse).order,
+            .reverse
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, comparator: .localized, order: .reverse).order,
+            .reverse
+        )
+    }
+    
+    func test_string_comparator_property_polarity() {
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word).stringComparator?.order,
+            .forward
+        )
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord).stringComparator?.order,
+            .forward
+        )
+
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.word, order: .reverse).stringComparator?.order,
+            .forward
+        )
+        XCTAssertEqual(
+            SortDescriptor(\NonNSObjectRoot.maybeWord, order: .reverse).stringComparator?.order,
+            .forward
+        )
+    }
+#endif
+
+}

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -21,6 +21,7 @@ import TestSupport
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
+@available(FoundationPreview 0.1, *)
 class SortDescriptorTests: XCTestCase {
     struct NonNSObjectRoot {
         enum Gadget: Int, Comparable {

--- a/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
+++ b/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationEssentials
+@testable import FoundationInternationalization
+#endif // FOUNDATION_FRAMEWORK
+
+class StringSortComparatorTests: XCTestCase {
+#if FOUNDATION_FRAMEWORK
+    // TODO: Until we support String.compare(_:options:locale:) in FoundationInternationalization, only support unlocalized comparisons
+    // https://github.com/apple/swift-foundation/issues/284
+    func test_locale() {
+        let swedishComparator = String.Comparator(options: [], locale: Locale(identifier: "sv"))
+        XCTAssertEqual(swedishComparator.compare("ă", "ã"), .orderedAscending)
+        XCTAssertEqual(swedishComparator.locale, Locale(identifier: "sv"))
+    }
+#endif    
+}


### PR DESCRIPTION
Ports the `SortComparator` protocol to FoundationEssentials and the `SortDescriptor` type to FoundationInternationalization. The latter is only really useful with localized sorting.