### PR TITLE
Date comparison handles nanoseconds incorrectly

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -721,8 +721,8 @@ public struct Calendar : Hashable, Equatable, Sendable {
             }
         case .minute:
             // assumes that time zone or other adjustments are always whole minutes
-            var (int1, _) = modf(date1.timeIntervalSinceReferenceDate)
-            var (int2, _) = modf(date2.timeIntervalSinceReferenceDate)
+            var int1 = date1.timeIntervalSinceReferenceDate.rounded(.down)
+            var int2 = date2.timeIntervalSinceReferenceDate.rounded(.down)
             int1 = floor(int1 / 60.0)
             int2 = floor(int2 / 60.0)
             if int1 == int2 {
@@ -733,8 +733,8 @@ public struct Calendar : Hashable, Equatable, Sendable {
                 return .orderedAscending
             }
         case .second:
-            let (int1, _) = modf(date1.timeIntervalSinceReferenceDate)
-            let (int2, _) = modf(date2.timeIntervalSinceReferenceDate)
+            let int1 = date1.timeIntervalSinceReferenceDate.rounded(.down)
+            let int2 = date2.timeIntervalSinceReferenceDate.rounded(.down)
             if int1 == int2 {
                 return .orderedSame
             } else if int2 < int1 {
@@ -743,22 +743,22 @@ public struct Calendar : Hashable, Equatable, Sendable {
                 return .orderedAscending
             }
         case .nanosecond:
-            let (int1, frac1) = modf(date1.timeIntervalSinceReferenceDate)
-            let (int2, frac2) = modf(date2.timeIntervalSinceReferenceDate)
-            if int1 == int2 {
-                let nano1 = floor(frac1 * 1000000000.0)
-                let nano2 = floor(frac2 * 1000000000.0)
+            func split(_ timeInterval: Double) -> (secs: Double, nano: Double) {
+                let secs = timeInterval.rounded(.towardZero)
+                let nano = (1e9 * (timeInterval - secs)).rounded(.towardZero)
+                return (secs, nano)
+            }
+            
+            let (secs1, nano1) = split(date1.timeIntervalSinceReferenceDate)
+            let (secs2, nano2) = split(date2.timeIntervalSinceReferenceDate)
+            if secs1 == secs2 {
                 if nano1 == nano2 {
                     return .orderedSame
                 } else if nano1 < nano2 {
-                    return .orderedDescending
+                    return .orderedAscending
                 } else {
-                    return .orderedSame
+                    return .orderedDescending
                 }
-            } else if int2 < int1 {
-                return .orderedDescending
-            } else {
-                return .orderedAscending
             }
         default:
             break


### PR DESCRIPTION
The comparison result for nanoseconds was backwards. This also takes the chance to switch to a more Swift-friendly version of `modf`.

rdar://116433981