### PR TITLE
Work around SwiftSyntax crash due to keypath usage

### DIFF
--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -1087,10 +1087,10 @@ public struct PredicateMacro: ExpressionMacro, Sendable {
         guard let closure = node.trailingClosure else {
             let fixIts: [FixIt]
             if let argument = node.argumentList.first?.expression.as(ClosureExprSyntax.self) {
-                let newNode = node.with(\.leftParen, nil)
+                var newNode = node.with(\.leftParen, nil)
                     .with(\.rightParen, nil)
-                    .with(\.argumentList, [])
                     .with(\.trailingClosure, argument.with(\.leadingTrivia, [.spaces(1)]).with(\.trailingTrivia, []))
+                newNode.argumentList = []
                 fixIts = [
                     FixIt(message: PredicateExpansionDiagnostic("Use a trailing closure instead of a function parameter", severity: .note), changes: [
                         .replace(oldNode: Syntax(node), newNode: Syntax(newNode))


### PR DESCRIPTION
In some situations, using the `\.argumentList` key path here causes a crash. While that crash is being investigated, switch to assigning to the property directly to avoid the crash.