### PR TITLE
Update remaining Predicate tests to use the #Predicate macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
           name: "FoundationEssentials",
           dependencies: [
             "_CShims",
+            "FoundationMacros",
             .product(name: "_RopeModule", package: "swift-collections"),
           ],
           swiftSettings: [
@@ -116,11 +117,4 @@ package.targets.append(contentsOf: [
         "FoundationInternationalization"
     ], swiftSettings: availabilityMacros),
 ])
-#endif
-
-#if !os(Windows)
-// Using macros at build-time is not yet supported on Windows
-if let index = package.targets.firstIndex(where: { $0.name == "FoundationEssentials" }) {
-    package.targets[index].dependencies.append("FoundationMacros")
-}
 #endif

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -27,11 +27,9 @@ public struct Predicate<each Input> : Sendable {
     }
 }
 
-#if compiler(>=5.9) && !os(Windows)
 @freestanding(expression)
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
-#endif
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension Predicate {


### PR DESCRIPTION
This updates the last of the predicate tests to use `#Predicate` instead of manual construction and removes the windows restrictions for usage of the macro