### PR TITLE
Hour-override isn't respected when formatting date

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
@@ -251,7 +251,7 @@ internal final class _LocaleAutoupdating : _LocaleProtocol, @unchecked Sendable 
     
 #if FOUNDATION_FRAMEWORK
     func pref(for key: String) -> Any? {
-        LocaleCache.cache.current.pref
+        LocaleCache.cache.current.pref(for: key)
     }
     
     func bridgeToNSLocale() -> NSLocale {


### PR DESCRIPTION
We wrongly returned the entire pref dictionary instead of the demanded value.

I did not want to spend too much time adding a test since this is dependent on the the autoupdating current locale. I did verify the following test failed before but passed after the fix.

```Obj-C
- (void)test24HourOverride {
    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
    [formatter setLocale:[NSLocale autoupdatingCurrentLocale]];
    [formatter setLocalizedDateFormatFromTemplate:@"Jmm"];

    NSString *dateFormat = formatter.dateFormat;
    XCTAssertEqualObjects(dateFormat, @"HH:mm");
}
```
