### PR TITLE
WIP Gregorian Calendar in FoundationEssentials

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -10,10 +10,66 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Julian date helper
+/// Julian dates are noon-based. Gregorian dates are midnight-based.
+/// JulianDates        `2451544.5 ..< 2451545.5` (Jan 01 2000, 00:00 - Jan 02 2000, 00:00)
+/// maps to JulianDay  `2451545`                 (Jan 01 2000, 12:00)
+extension Date {
+    static let julianDayAtDateReference: Double = 2_451_910.5 // 2001 Jan 1, midnight, UTC
+
+    var julianDate: Double {
+        timeIntervalSinceReferenceDate / 86400 + Self.julianDayAtDateReference
+    }
+
+    var julianDay: Int {
+        Int(julianDate.rounded())
+    }
+
+    init(julianDay: Int) {
+        self.init(julianDate: Double(julianDay))
+    }
+
+    init(julianDate: Double) {
+        let secondsSinceJulianReference = (julianDate - Self.julianDayAtDateReference) * 86400
+        self.init(timeIntervalSinceReferenceDate: secondsSinceJulianReference)
+    }
+}
 /// This class is a placeholder and work-in-progress to provide an implementation of the Gregorian calendar.
 internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
+    
+    let julianCutoverDay: Int// Julian day (noon-based) of cutover
+    let gregorianStartYear: Int
+    let gregorianStartDate: Date
+
+    // Only respects Gregorian identifier
     init(identifier: Calendar.Identifier, timeZone: TimeZone?, locale: Locale?, firstWeekday: Int?, minimumDaysInFirstWeek: Int?, gregorianStartDate: Date?) {
-        fatalError()
+
+        self.timeZone = timeZone ?? .gmt
+        if let gregorianStartDate {
+            self.gregorianStartDate = gregorianStartDate
+            self.julianCutoverDay = gregorianStartDate.julianDay
+            let (y, _, _) = Self.yearMonthDayFromJulianDay(julianCutoverDay, useJulianRef: false)
+            self.gregorianStartYear = y
+        } else {
+            self.gregorianStartYear = 1582
+            self.julianCutoverDay = 2299161
+            self.gregorianStartDate = Date(timeIntervalSince1970: -12219292800) // 1582-10-15T00:00:00Z
+        }
+
+        self.locale = locale
+        self.localeIdentifier = locale?.identifier ?? ""
+        if let firstWeekday, (firstWeekday >= 1 && firstWeekday <= 7) {
+            _firstWeekday = firstWeekday
+        }
+
+        if var minimumDaysInFirstWeek {
+            if minimumDaysInFirstWeek < 1 {
+                minimumDaysInFirstWeek = 1
+            } else if minimumDaysInFirstWeek > 7 {
+                minimumDaysInFirstWeek = 7
+            }
+            _minimumDaysInFirstWeek = minimumDaysInFirstWeek
+        }
     }
     
     var identifier: Calendar.Identifier {
@@ -21,15 +77,41 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     }
     
     var locale: Locale?
-    
+
     var localeIdentifier: String
     
     var timeZone: TimeZone
     
-    var firstWeekday: Int
-    
-    var minimumDaysInFirstWeek: Int
-    
+    var _firstWeekday: Int?
+    var firstWeekday: Int {
+        set {
+            if newValue >= 1 && newValue <= 7 {
+                _firstWeekday = newValue
+            }
+        }
+
+        get {
+            _firstWeekday ?? 1
+        }
+    }
+
+    var _minimumDaysInFirstWeek: Int?
+    var minimumDaysInFirstWeek: Int {
+        set {
+            if newValue < 1 {
+                _minimumDaysInFirstWeek = 1
+            } else if newValue > 7 {
+                _minimumDaysInFirstWeek = 7
+            } else {
+                _minimumDaysInFirstWeek = newValue
+            }
+        }
+
+        get {
+            _minimumDaysInFirstWeek ?? 1
+        }
+    }
+
     func copy(changingLocale: Locale?, changingTimeZone: TimeZone?, changingFirstWeekday: Int?, changingMinimumDaysInFirstWeek: Int?) -> _CalendarProtocol {
         fatalError()
     }
@@ -111,15 +193,223 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     func date(from components: DateComponents) -> Date? {
         fatalError()
     }
-    
+
+    // MARK: - Julian day number calculation
+    // Algorithm from Explanatory Supplement to the Astronomical Almanac, ch 15. Calendars, by E.G. Richards
+    // Return day and month are 1-based
+    static func yearMonthDayFromJulianDay(_ julianDay: Int, useJulianRef: Bool) -> (year: Int, month: Int, day: Int) {
+        let y = 4716 // number of years from epoch of computation to epoch of calendar
+        let j = 1401 // number of days from the epoch of computation to the first day of the Julian period
+        let m = 2 // value of M for which M' is zero
+        let n = 12 // the number of effective months in the year, counting the epagomenal days of the mobile calendars as an additional month
+        let r = 4 // number of years in leap-year cycle
+        let p = 1461
+        let v = 3
+        let u = 5 // length of any cycle there may be in the pattern of month lengths
+        let s = 153
+        let w = 2
+        let B = 274277
+        let C = -38
+        let f1 = julianDay + j
+        let f: Int
+        if useJulianRef {
+            f = f1
+        } else { // Gregorian
+            f = f1 + (((4 * julianDay + B) / 146097) * 3) / 4 + C
+        }
+        let e = r * f + v
+        let g = (e % p) / r
+        let h = u * g + w
+
+        let day = (h % s) / u + 1 // day of month
+        let month = (((h / s) + m) % n) + 1
+        let year = e / p - y + (n + m - month) / n
+
+        return (year, month, day)
+    }
+
+    // day and month are 1-based
+    static func julianDay(ofDay day: Int, month: Int, year: Int) -> Int {
+        let y = 4716 // number of years from epoch of computation to epoch of calendar
+        let j = 1401 // number of days from the epoch of computation to the first day of the Julian period
+        let m = 2 // value of M for which M' is zero
+        let n = 12 // the number of effective months in the year, counting the epagomenal days of the mobile calendars as an additional month
+        let r = 4 // number of years in leap-year cycle
+        let p = 1461
+        let q = 0
+        let u = 5 // length of any cycle there may be in the pattern of month lengths
+        let s = 153
+        let t = 2
+        let A = 184
+        let C = -38
+
+        let h = month - m
+        let g = year + y - (n - h) / n
+        let f = (h - 1 + n) % n
+        let e = (p * g + q) / r + day - 1 - j
+        let J = e + (s * f + t) / u
+        let julianDayNumber = J - (3 * ((g + A) / 100)) / 4 - C
+
+        return julianDayNumber
+    }
+
+    // MARK: -
+    func useJulianReference(_ date: Date) -> Bool {
+        return date < gregorianStartDate
+    }
+
+    func dayOfYear(fromYear year: Int, month: Int, day: Int) -> Int {
+        let daysBeforeMonthNonLeap = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+        let daysBeforeMonthLeap =    [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
+
+        let julianDay = Self.julianDay(ofDay: day, month: month, year: year)
+        let useJulianCalendar = julianDay < julianCutoverDay
+        let isLeapYear = gregorianYearIsLeap(year)
+        var dayOfYear = (isLeapYear ? daysBeforeMonthLeap : daysBeforeMonthNonLeap)[month - 1] + day
+        if !useJulianCalendar && year == gregorianStartYear {
+            // Use julian's week number for 1582, so recalculate day of year
+            let gregorianDayShift = (year - 1) / 400 - (year - 1) / 100 + 2
+            dayOfYear += gregorianDayShift
+        }
+        return dayOfYear
+    }
+
+    func gregorianYearIsLeap(_ year: Int) -> Bool {
+        if year >= gregorianStartYear {
+            return (year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0))
+        } else {
+            return (year % 4 == 0)
+        }
+    }
+
+    // from ICU calendar.cpp
+    func weekNumber(desiredDay: Int, dayOfPeriod: Int, weekday: Int) -> Int {
+        // Determine the day of the week of the first day of the period in question (either a year or a month).  Zero represents the first day of the week on this calendar.
+        var periodStartDayOfWeek = (weekday - firstWeekday - dayOfPeriod + 1) % 7
+        if periodStartDayOfWeek < 0 { periodStartDayOfWeek += 7 }
+
+        // Compute the week number.  Initially, ignore the first week, which may be fractional (or may not be).  We add periodStartDayOfWeek in order to fill out the first week, if it is fractional.
+        var weekNo = (desiredDay + periodStartDayOfWeek - 1) / 7
+
+        // If the first week is long enough, then count it.  If the minimal days in the first week is one, or if the period start is zero, we always increment weekNo.
+        if ((7 - periodStartDayOfWeek) >= minimumDaysInFirstWeek) { weekNo = weekNo + 1 }
+
+        return weekNo
+    }
+
     func dateComponents(_ components: Calendar.ComponentSet, from date: Date, in timeZone: TimeZone) -> DateComponents {
-        fatalError()
+        let date = date + Double(timeZone.secondsFromGMT(for: date))
+
+        let julianDay = date.julianDay
+
+        let useJulianRef = useJulianReference(date)
+
+        var timeInDay = date.timeIntervalSinceReferenceDate.remainder(dividingBy: 86400)
+        if (timeInDay < 0) {
+            timeInDay += 86400
+        }
+
+        let (year, month, day) = Self.yearMonthDayFromJulianDay(julianDay, useJulianRef: useJulianRef)
+
+        let era = year < 1 ? 0 : 1
+        let isLeapYear = gregorianYearIsLeap(year)
+
+        let hour = Int(timeInDay / 3600) // zero-based
+        timeInDay = timeInDay.truncatingRemainder(dividingBy: 3600.0)
+
+        let minute = Int(timeInDay / 60)
+        timeInDay = timeInDay.truncatingRemainder(dividingBy: 60.0)
+
+        let second = Int(timeInDay)
+        timeInDay = timeInDay.truncatingRemainder(dividingBy: 1)
+
+        let nanosecond = Int(timeInDay * 1_000_000_000)
+        // To calculate day of year, work backwards with month/day
+        let dayOfYear = dayOfYear(fromYear: year, month: month, day: day)
+
+        // Week of year calculation, from ICU calendar.cpp :: computeWeekFields
+        // 1-based: 1...7
+        let weekday = 1 + (julianDay + 1) % 7
+        // 0-based 0...6
+        let relativeWeekday = (weekday + 7 - firstWeekday) % 7
+        let relativeWeekdayForJan1 = (weekday - dayOfYear + 7001 - firstWeekday) % 7
+        var weekOfYear = (dayOfYear - 1 + relativeWeekdayForJan1) / 7 // 0...53
+        if (7 - relativeWeekdayForJan1) >= minimumDaysInFirstWeek {
+            weekOfYear += 1
+        }
+
+        var yearForWeekOfYear = year
+        // Adjust for weeks at end of the year that overlap into previous or next calendar year
+        if weekOfYear == 0 {
+            let previousDayOfYear = dayOfYear + (gregorianYearIsLeap(year - 1) ? 366 : 365)
+            weekOfYear = weekNumber(desiredDay: previousDayOfYear, dayOfPeriod: previousDayOfYear, weekday: weekday)
+            yearForWeekOfYear -= 1
+        } else {
+            let lastDayOfYear = (gregorianYearIsLeap(year) ? 366 : 365)
+            // Fast check: For it to be week 1 of the next year, the DOY
+            // must be on or after L-5, where L is yearLength(), then it
+            // cannot possibly be week 1 of the next year:
+            //          L-5                  L
+            // doy: 359 360 361 362 363 364 365 001
+            // dow:      1   2   3   4   5   6   7
+            if dayOfYear >= lastDayOfYear - 5 {
+                var lastRelativeDayOfWeek = (relativeWeekday + lastDayOfYear - dayOfYear) % 7
+                if lastRelativeDayOfWeek < 0 {
+                    lastRelativeDayOfWeek += 7
+                }
+
+                if ((6 - lastRelativeDayOfWeek) >= minimumDaysInFirstWeek) && ((dayOfYear + 7 - relativeWeekday) > lastDayOfYear) {
+                    weekOfYear = 1
+                    yearForWeekOfYear += 1
+                }
+            }
+        }
+
+        let weekOfMonth = weekNumber(desiredDay: day, dayOfPeriod: day, weekday: weekday)
+        let weekdayOrdinal = (day - 1) / 7 + 1
+
+        var dc = DateComponents()
+        if components.contains(.calendar) { dc.calendar = Calendar(identifier: .gregorian) }
+        if components.contains(.timeZone) { dc.timeZone = timeZone }
+        if components.contains(.era) { dc.era = era }
+        if components.contains(.year) { dc.year = year }
+        if components.contains(.month) { dc.month = month }
+        if components.contains(.day) { dc.day = day }
+        if components.contains(.hour) { dc.hour = hour }
+        if components.contains(.minute) { dc.minute = minute }
+        if components.contains(.second) { dc.second = second }
+        if components.contains(.weekday) { dc.weekday = weekday }
+        if components.contains(.weekdayOrdinal) { dc.weekdayOrdinal = weekdayOrdinal }
+        if components.contains(.quarter) {
+            let quarter = if isLeapYear {
+                if dayOfYear < 90 { 1 }
+                else if dayOfYear < 181 { 2 }
+                else if dayOfYear < 273 { 3 }
+                else if dayOfYear < 366 { 4 }
+                else { fatalError() }
+            } else {
+                if dayOfYear < 91 { 1 }
+                else if dayOfYear < 182 { 2 }
+                else if dayOfYear < 274 { 3 }
+                else if dayOfYear < 367 { 4 }
+                else { fatalError() }
+            }
+
+            dc.quarter = quarter
+        }
+        if components.contains(.weekOfMonth) { dc.weekOfMonth = weekOfMonth }
+        if components.contains(.weekOfYear) { dc.weekOfYear = weekOfYear }
+        if components.contains(.yearForWeekOfYear) { dc.yearForWeekOfYear = yearForWeekOfYear }
+        if components.contains(.nanosecond) { dc.nanosecond = nanosecond }
+
+        if components.contains(.isLeapMonth) || components.contains(.month) { dc.isLeapMonth = false }
+        return dc
     }
     
     func dateComponents(_ components: Calendar.ComponentSet, from date: Date) -> DateComponents {
-        fatalError()
+        dateComponents(components, from: date, in: timeZone)
     }
-    
+
     func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool) -> Date? {
         fatalError()
     }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -85,9 +85,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     var _firstWeekday: Int?
     var firstWeekday: Int {
         set {
-            if newValue >= 1 && newValue <= 7 {
-                _firstWeekday = newValue
-            }
+            precondition(newValue >= 1 && newValue <= 7, "Weekday should be in the range of 1...7")
+            _firstWeekday = newValue
         }
 
         get {

--- a/Sources/TestSupport/Utilities.swift
+++ b/Sources/TestSupport/Utilities.swift
@@ -102,6 +102,45 @@ public func expectEqualSequence< Expected: Sequence, Actual: Sequence>(
     }
 }
 
+func expectEqual(_ actual: Date, _ expected: Date , within: Double = 0.001, file: StaticString = #file, line: UInt = #line) {
+    let debugDescription = "\nactual: \(actual.formatted(.iso8601));\nexpected: \(expected.formatted(.iso8601))"
+    XCTAssertEqual(actual.timeIntervalSinceReferenceDate, expected.timeIntervalSinceReferenceDate, accuracy: within, debugDescription, file: file, line: line)
+}
+
+// Compare two date components like the original equality, but compares nanosecond within a reasonable epsilon, and optionally ignores quarter and calendar equality since they were often not supported in the original implementation
+public func expectEqual(_ first: DateComponents, _ second: DateComponents, within nanosecondAccuracy: Int = 5000, expectQuarter: Bool = true, expectCalendar: Bool = true, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(first.era, second.era, message(), file: file, line: line)
+    XCTAssertEqual(first.year, second.year, message(), file: file, line: line)
+    XCTAssertEqual(first.month, second.month, message(), file: file, line: line)
+    XCTAssertEqual(first.day, second.day, message(), file: file, line: line)
+    XCTAssertEqual(first.hour, second.hour, message(), file: file, line: line)
+    XCTAssertEqual(first.minute, second.minute, message(), file: file, line: line)
+    XCTAssertEqual(first.second, second.second, message(), file: file, line: line)
+    XCTAssertEqual(first.weekday, second.weekday, message(), file: file, line: line)
+    XCTAssertEqual(first.weekdayOrdinal, second.weekdayOrdinal, message(), file: file, line: line)
+    XCTAssertEqual(first.weekOfMonth, second.weekOfMonth, message(), file: file, line: line)
+    XCTAssertEqual(first.weekOfYear, second.weekOfYear, message(), file: file, line: line)
+    XCTAssertEqual(first.yearForWeekOfYear, second.yearForWeekOfYear, message(), file: file, line: line)
+    if expectQuarter {
+        XCTAssertEqual(first.quarter, second.quarter, message(), file: file, line: line)
+    }
+
+    if let ns = first.nanosecond, let otherNS = second.nanosecond {
+        XCTAssertLessThan(abs(ns - otherNS), nanosecondAccuracy, message(), file: file, line: line)
+    } else {
+        XCTAssertEqual(first.nanosecond, second.nanosecond, message(), file: file, line: line)
+    }
+
+    XCTAssertEqual(first.isLeapMonth, second.isLeapMonth, message(), file: file, line: line)
+
+    if expectCalendar {
+        XCTAssertEqual(first.calendar, second.calendar, message(), file: file, line: line)
+    }
+
+    XCTAssertEqual(first.timeZone, second.timeZone, message(), file: file, line: line)
+
+}
+
 func expectChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) rethrows {
     let valueBefore = check()
     try expression()

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -689,7 +689,8 @@ final class CalendarBridgingTests : XCTestCase {
 // This test validates the results against FoundationInternationalization's calendar implementation temporarily until we completely ported the calendar
 final class GregorianCalendarTests: XCTestCase {
 
-
+#if GREGORIAN_CALENDAR
+    // Enable this test when the function is implemented.
     func testDateFromComponentsCompatibility() {
         let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: nil, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: nil, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
@@ -730,6 +731,7 @@ final class GregorianCalendarTests: XCTestCase {
         test(.init(month: 1, day: 1))
         test(.init(month: 1, day: 1, hour: 1))
     }
+#endif
 
     func testDateComponentsFromDateCompatibility() {
         let componentSet = Calendar.ComponentSet([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .calendar])


### PR DESCRIPTION
### Part 1: `dateComponents(from date:)`
Implement `dateComponents(from date:)`. The implementation largely follows that of ICU in calendar.cpp and gregocal.cpp. Julian day calculation algorithm is referenced [The Explanatory Supplement to the Astronomical Almanac](https://aa.usno.navy.mil/publications/exp_supp).

First, calculate the Julian day number from a given `Date`. Then, convert the Julian day number to Gregorian calendar date fields[^1]. The remaining part is the time within the day.

There are a few things to look out for
- Julian day starts at noon, while `Date` uses midnight as the reference time, so we need to adjust it acccordingly at every conversion. Note that ICU uses Modified Julian Day number throughout their codebase, which starts at midnight, so
- Dates close to Gregorian calendar adoption, which is also referred as "cutover" or "transition" date interchangeably, needs to be handled with care. Date before the adoption date were represented in Julian Calendar and Gregorian Calendar after the adoption date. The common Gregorian Calendar adoption date is Friday, 15 October 1582. It's also customizable in the API.
- The week number of a month and a year depends on `firstWeekday` and `minimumDaysInFirstWeek` values. The week starts at `firstWeekday`. Week one must contain `minimumDaysInFirstWeek` number of days.

[^1]: A nice readable version of the Julain - Gregorian converting algorithm: https://en.wikipedia.org/wiki/Julian_day#Julian_day_number_calculation.

Co-authored by @parkera 

### Part 2: `date(from components:)`

The implementation also largely follows that of ICU. The logic follows this pattern generally
- Calculate the Julian day number from a given year, month, day of month number
- Add time field values if they are set
- Adjust for timezone offset

The complexity lies in the following situations
(1) The passed-in date components lacks essential fields to determine the Julian day number
(2) The date components has week-related fields set, but no year, month, day of month fields set
(3) The date components has both week-related fields and month, day of month fields set
(4) The day is near Gregorian calendar transition date

For (1), simply assume the start of the year/month/day if the field is missing. The value would be either 0 or 1, depending on if it's 0 or 1 indexed.
For (2), calculate the julian day of the start of the month. Advance by multiples of the given week number.
For (3), we need to determine which fields take over precedence of others. ICU tracks the order of when the fields are modified; newly modified ones always take precedence over past ones. We have not been using this mechanism at all in existing Calendar_ICU's implementation. Instead we've been setting the fields arbitrarily. Therefore, here we simplify ICU's heuristics by  assuming the timestamps of modified fields are all equal.
For (4), recalculate the date using Julian calendar if the found date is before Gregorian transition date.