### PR TITLE
Increase `swift-syntax` dependency to 509.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             revision: "0c1de7149a39a9ff82d4db66234dec587b30a3ad"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0")
+            from: "509.0.2")
     ],
     targets: [
         // Foundation (umbrella)


### PR DESCRIPTION
This bumps the swift-syntax dependency to 509.0.2 to resolve a compiler crasher that was recently fixed by this tag