### PR TITLE
[GregorianCalendar] Implement TimeZone support for `date(from components: DateComponents)`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -90,7 +90,6 @@ enum ResolvedDateComponents {
 
     init(dateComponents components: DateComponents) {
         var (year, month) = Self.yearMonth(forDateComponent: components)
-        let minMonth = 1
         let minWeekdayOrdinal = 1
         if let d = components.day {
             if components.yearForWeekOfYear != nil, let weekOfYear = components.weekOfYear {
@@ -125,7 +124,6 @@ enum ResolvedDateComponents {
     }
 
     init(preferComponent c: Calendar.Component, dateComponents components: DateComponents) {
-        let minMonth = 1
         let minWeekdayOrdinal = 1
         switch c {
         case .day:
@@ -464,7 +462,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     }
 
 
-    func date(from components: DateComponents, inTimeZone timeZone: TimeZone?, resolvedComponents: ResolvedDateComponents? = nil) -> Date? {
+    func date(from components: DateComponents, inTimeZone timeZone: TimeZone, resolvedComponents: ResolvedDateComponents? = nil) -> Date? {
 
         let resolvedComponents = resolvedComponents ?? ResolvedDateComponents(dateComponents: components)
 
@@ -498,20 +496,14 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
             secondsInDay += Double(nanosecond) / Double(nano_coef)
         }
 
-        let timeZoneOffset: Int
-        if let timeZone = timeZone {
-            // TODO: Implement `TimeZone.secondsFromGMT(for date: Date)` to support DST
-            timeZoneOffset = timeZone.secondsFromGMT()
-        } else if let timeZone = components.timeZone {
-            timeZoneOffset = timeZone.secondsFromGMT()
-        } else {
-            timeZoneOffset = 0 // Assume GMT
-        }
+        // Rewind from Julian day, which starts at noon, back to midnight
+        var tmpDate = Date(julianDay: julianDay) - 43200 + secondsInDay
 
-        let timeInThisDay = secondsInDay - Double(timeZoneOffset)
+        // tmpDate now is in GMT. Adjust it back into local time zone
+        let (timeZoneOffset, dstOffset) = timeZone.rawAndDaylightSavingTimeOffset(forGMTDate: tmpDate)
+        tmpDate = tmpDate - Double(timeZoneOffset) - Double(dstOffset)
 
-        // rewind from Julian day, which starts at noon, back to midnight
-        return Date(julianDay: julianDay) - 43200 + timeInThisDay
+        return tmpDate
     }
 
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -501,7 +501,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
         // tmpDate now is in GMT. Adjust it back into local time zone
         let (timeZoneOffset, dstOffset) = timeZone.rawAndDaylightSavingTimeOffset(for: tmpDate)
-        tmpDate = tmpDate - Double(timeZoneOffset) - Double(dstOffset)
+        tmpDate = tmpDate - Double(timeZoneOffset) - dstOffset
 
         return tmpDate
     }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -500,7 +500,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         var tmpDate = Date(julianDay: julianDay) - 43200 + secondsInDay
 
         // tmpDate now is in GMT. Adjust it back into local time zone
-        let (timeZoneOffset, dstOffset) = timeZone.rawAndDaylightSavingTimeOffset(forGMTDate: tmpDate)
+        let (timeZoneOffset, dstOffset) = timeZone.rawAndDaylightSavingTimeOffset(for: tmpDate)
         tmpDate = tmpDate - Double(timeZoneOffset) - Double(dstOffset)
 
         return tmpDate

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -152,6 +152,10 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         _tz.secondsFromGMT(for: date)
     }
 
+    internal func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        _tz.rawAndDaylightSavingTimeOffset(forGMTDate: date)
+    }
+
     /// Returns the abbreviation for the time zone at a given date.
     ///
     /// Note that the abbreviation may be different at different dates. For example, during daylight saving time the US/Eastern time zone has an abbreviation of "EDT." At other times, its abbreviation is "EST."

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -152,8 +152,8 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         _tz.secondsFromGMT(for: date)
     }
 
-    internal func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
-        _tz.rawAndDaylightSavingTimeOffset(forGMTDate: date)
+    internal func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        _tz.rawAndDaylightSavingTimeOffset(for: date)
     }
 
     /// Returns the abbreviation for the time zone at a given date.

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -152,7 +152,7 @@ public struct TimeZone : Hashable, Equatable, Sendable {
         _tz.secondsFromGMT(for: date)
     }
 
-    internal func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    internal func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         _tz.rawAndDaylightSavingTimeOffset(for: date)
     }
 

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
@@ -51,7 +51,7 @@ internal final class _TimeZoneAutoupdating : _TimeZoneProtocol, Sendable {
         TimeZoneCache.cache.current.localizedName(for: style, locale: locale)
     }
     
-    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         TimeZoneCache.cache.current.rawAndDaylightSavingTimeOffset(for: date)
     }
 

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
@@ -51,8 +51,8 @@ internal final class _TimeZoneAutoupdating : _TimeZoneProtocol, Sendable {
         TimeZoneCache.cache.current.localizedName(for: style, locale: locale)
     }
     
-    func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
-        TimeZoneCache.cache.current.rawAndDaylightSavingTimeOffset(forGMTDate: date)
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        TimeZoneCache.cache.current.rawAndDaylightSavingTimeOffset(for: date)
     }
 
     var isAutoupdating: Bool {

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Autoupdating.swift
@@ -51,6 +51,10 @@ internal final class _TimeZoneAutoupdating : _TimeZoneProtocol, Sendable {
         TimeZoneCache.cache.current.localizedName(for: style, locale: locale)
     }
     
+    func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        TimeZoneCache.cache.current.rawAndDaylightSavingTimeOffset(forGMTDate: date)
+    }
+
     var isAutoupdating: Bool {
         true
     }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
@@ -47,6 +47,10 @@ package final class _TimeZoneGMT : _TimeZoneProtocol, @unchecked Sendable {
         0.0
     }
     
+    package func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        (offset, 0)
+    }
+
     package func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
         nil
     }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
@@ -47,7 +47,7 @@ package final class _TimeZoneGMT : _TimeZoneProtocol, @unchecked Sendable {
         0.0
     }
     
-    package func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    package func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         (offset, 0)
     }
 

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_GMT.swift
@@ -47,7 +47,7 @@ package final class _TimeZoneGMT : _TimeZoneProtocol, @unchecked Sendable {
         0.0
     }
     
-    package func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    package func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
         (offset, 0)
     }
 

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
@@ -17,6 +17,12 @@ package protocol _TimeZoneProtocol : AnyObject, Sendable, CustomDebugStringConve
     
     var identifier: String { get }
     func secondsFromGMT(for date: Date) -> Int
+
+    /// The returned `daylightSavingOffset` is different from that returned by `daylightSavingTimeOffset(:)` in that this interprets `Date` in GMT.
+    /// Essentially this is equivalent to adjusting `date` to this time zone using `rawOffset`, then passing the adjusted date to `daylightSavingTimeOffset(for: <adjusted date>)`.
+    /// This also handles the skipped time frame on DST start day differently from `daylightSavingTimeOffset(:)`, where dates in the skipped time frame are considered *not* in DST here, hence the DST offset would be 0.
+    func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int)
+
     func abbreviation(for date: Date) -> String?
     func isDaylightSavingTime(for date: Date) -> Bool
     func daylightSavingTimeOffset(for date: Date) -> TimeInterval

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
@@ -20,7 +20,7 @@ package protocol _TimeZoneProtocol : AnyObject, Sendable, CustomDebugStringConve
 
     /// Essentially this is equivalent to adjusting `date` to this time zone using `rawOffset`, then passing the adjusted date to `daylightSavingTimeOffset(for: <adjusted date>)`.
     /// This also handles the skipped time frame on DST start day differently from `daylightSavingTimeOffset(:)`, where dates in the skipped time frame are considered *not* in DST here, hence the DST offset would be 0.
-    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int)
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval)
 
     func abbreviation(for date: Date) -> String?
     func isDaylightSavingTime(for date: Date) -> Bool

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Protocol.swift
@@ -18,10 +18,9 @@ package protocol _TimeZoneProtocol : AnyObject, Sendable, CustomDebugStringConve
     var identifier: String { get }
     func secondsFromGMT(for date: Date) -> Int
 
-    /// The returned `daylightSavingOffset` is different from that returned by `daylightSavingTimeOffset(:)` in that this interprets `Date` in GMT.
     /// Essentially this is equivalent to adjusting `date` to this time zone using `rawOffset`, then passing the adjusted date to `daylightSavingTimeOffset(for: <adjusted date>)`.
     /// This also handles the skipped time frame on DST start day differently from `daylightSavingTimeOffset(:)`, where dates in the skipped time frame are considered *not* in DST here, hence the DST offset would be 0.
-    func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int)
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int)
 
     func abbreviation(for date: Date) -> String?
     func isDaylightSavingTime(for date: Date) -> Bool

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1729,7 +1729,7 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
         let start = date - 48.0 * 60.0 * 60.0
 
 
-        guard let nextDSTTransition = _locked_nextDaylightSavingTimeTransition(startingAt: start, limit: start + 4 * 8600 * 1000.0) else {
+        guard let nextDSTTransition = _locked_nextDaylightSavingTimeTransition(startingAt: start, limit: start + 4 * 86400 * 1000.0) else {
             return nil
         }
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
@@ -82,7 +82,11 @@ internal final class _TimeZoneBridged: _TimeZoneProtocol, @unchecked Sendable {
     func localizedName(for style: TimeZone.NameStyle, locale: Locale?) -> String? {
         _timeZone.localizedName(style, locale: locale)
     }
-    
+
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
+        (_timeZone.secondsFromGMT(for: date), _timeZone.daylightSavingTimeOffset(for: date))
+    }
+
     func bridgeToNSTimeZone() -> NSTimeZone {
         _timeZone.copy() as! NSTimeZone
     }

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -61,6 +61,10 @@ internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
         nil
     }
     
+    func rawAndDaylightSavingTimeOffset(forGMTDate date: FoundationEssentials.Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+        (offset, 0)
+    }
+
     var debugDescription: String {
         "gmt icu offset \(offset)"
     }

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -61,7 +61,7 @@ internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
         nil
     }
     
-    func rawAndDaylightSavingTimeOffset(for date: FoundationEssentials.Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         (offset, 0)
     }
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -61,7 +61,7 @@ internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
         nil
     }
     
-    func rawAndDaylightSavingTimeOffset(forGMTDate date: FoundationEssentials.Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: FoundationEssentials.Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
         (offset, 0)
     }
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -162,7 +162,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: TimeInterval) {
         return lock.withLock {
             guard let calendar = $0.calendar(identifier) else { return (0, 0) }
             var rawOffset: Int32 = 0
@@ -177,7 +177,8 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
             // If the date falls into the skipped time frame when transitioning into DST (e.g. 1:00 - 3:00 AM for PDT), we want to treat it as if DST hasn't happened yet. So, use UCAL_TZ_LOCAL_FORMER for nonExistingTimeOpt.
             // If the date falls into the repeated time frame when DST ends (e.g. 1:00 - 2:00 AM for PDT), we want the first instance, i.e. the instance before turning back the clock. So, use UCAL_TZ_LOCAL_FORMER for duplicatedTimeOpt.
             ucal_getTimeZoneOffsetFromLocal(calendar, UCAL_TZ_LOCAL_FORMER, UCAL_TZ_LOCAL_FORMER, &rawOffset, &dstOffset, &status)
-            return (Int(rawOffset / 1000), Int(dstOffset / 1000))
+
+            return (Int(rawOffset / 1000), TimeInterval(dstOffset / 1000))
         }
     }
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -162,7 +162,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
         }
     }
 
-    func rawAndDaylightSavingTimeOffset(forGMTDate date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
+    func rawAndDaylightSavingTimeOffset(for date: Date) -> (rawOffset: Int, daylightSavingOffset: Int) {
         return lock.withLock {
             guard let calendar = $0.calendar(identifier) else { return (0, 0) }
             var rawOffset: Int32 = 0

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif
+
+// Tests for _GregorianCalendar
+final class GregorianCalendarTests : XCTestCase {
+
+    func testDateFromComponents_DST() {
+        // The expected dates were generated using ICU Calendar
+
+        let tz = TimeZone(identifier: "America/Los_Angeles")!
+        let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: tz, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
+        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #file, line: UInt = #line) {
+            let date = gregorianCalendar.date(from: dateComponents)!
+            XCTAssertEqual(date, expected, "DateComponents: \(dateComponents)", file: file, line: line)
+        }
+
+        test(.init(year: 2023, month: 10, day: 16), expected: Date(timeIntervalSince1970: 1697439600.0))
+        test(.init(year: 2023, month: 10, day: 16, hour: 1, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1697445292.0))
+        test(.init(year: 2023, month: 11, day: 6), expected: Date(timeIntervalSince1970: 1699257600.0))
+        test(.init(year: 2023, month: 3, day: 12), expected: Date(timeIntervalSince1970: 1678608000.0))
+        test(.init(year: 2023, month: 3, day: 12, hour: 1, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1678613692.0))
+        test(.init(year: 2023, month: 3, day: 12, hour: 2, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1678617292.0))
+        test(.init(year: 2023, month: 3, day: 12, hour: 3, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1678617292.0))
+        test(.init(year: 2023, month: 3, day: 13, hour: 0, minute: 0, second: 0), expected: Date(timeIntervalSince1970: 1678690800.0))
+        test(.init(year: 2023, month: 11, day: 5), expected: Date(timeIntervalSince1970: 1699167600.0))
+        test(.init(year: 2023, month: 11, day: 5, hour: 1, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1699173292.0))
+        test(.init(year: 2023, month: 11, day: 5, hour: 2, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1699180492.0))
+        test(.init(year: 2023, month: 11, day: 5, hour: 3, minute: 34, second: 52), expected: Date(timeIntervalSince1970: 1699184092.0))
+    }
+
+    func testDateFromComponents() {
+        // The expected dates were generated using ICU Calendar
+        let tz = TimeZone.gmt
+        let cal = _CalendarGregorian(identifier: .gregorian, timeZone: tz, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
+        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #file, line: UInt = #line) {
+            let date = cal.date(from: dateComponents)
+            XCTAssertEqual(date, expected, "date components: \(dateComponents)", file: file, line: line)
+        }
+
+        test(.init(year: 1582, month: -7, weekday: 5, weekdayOrdinal: 0), expected: Date(timeIntervalSince1970: -12264739200.0))
+        test(.init(year: 1582, month: -3, weekday: 0, weekdayOrdinal: -5), expected: Date(timeIntervalSince1970: -12253680000.0))
+        test(.init(year: 1582, month: 5, weekday: -2, weekdayOrdinal: 3), expected: Date(timeIntervalSince1970: -12231475200.0))
+        test(.init(year: 1582, month: 5, weekday: 4, weekdayOrdinal: 6), expected: Date(timeIntervalSince1970: -12229747200.0))
+        test(.init(year: 2014, month: -4, weekday: -1, weekdayOrdinal: 4), expected: Date(timeIntervalSince1970: 1377216000.0))
+        test(.init(year: 2446, month: -1, weekday: -1, weekdayOrdinal: -1), expected: Date(timeIntervalSince1970: 15017875200.0))
+        test(.init(year: 2878, month: -9, weekday: -9, weekdayOrdinal: 1), expected: Date(timeIntervalSince1970: 28627603200.0))
+        test(.init(year: 2878, month: -5, weekday: 1, weekdayOrdinal: -6), expected: Date(timeIntervalSince1970: 28636934400.0))
+        test(.init(year: 2878, month: 7, weekday: -7, weekdayOrdinal: 8), expected: Date(timeIntervalSince1970: 28673740800.0))
+        test(.init(year: 2878, month: 11, weekday: -1, weekdayOrdinal: 4), expected: Date(timeIntervalSince1970: 28682121600.0))
+
+        test(.init(year: 1582, month: -7, day: 2), expected: Date(timeIntervalSince1970: -12264307200.0))
+        test(.init(year: 1582, month: 1, day: -1), expected: Date(timeIntervalSince1970: -12243398400.0))
+        test(.init(year: 1705, month: 6, day: -6), expected: Date(timeIntervalSince1970: -8350128000.0))
+        test(.init(year: 1705, month: 6, day: 3), expected: Date(timeIntervalSince1970: -8349350400.0))
+        test(.init(year: 1828, month: -9, day: -3), expected: Date(timeIntervalSince1970: -4507920000.0))
+        test(.init(year: 1828, month: 3, day: 0), expected: Date(timeIntervalSince1970: -4476038400.0))
+        test(.init(year: 1828, month: 7, day: 5), expected: Date(timeIntervalSince1970: -4465065600.0))
+        test(.init(year: 2074, month: -4, day: 2), expected: Date(timeIntervalSince1970: 3268857600.0))
+        test(.init(year: 2197, month: 5, day: -2), expected: Date(timeIntervalSince1970: 7173619200.0))
+        test(.init(year: 2197, month: 5, day: 1), expected: Date(timeIntervalSince1970: 7173878400.0))
+        test(.init(year: 2320, month: -2, day: -2), expected: Date(timeIntervalSince1970: 11036649600.0))
+        test(.init(year: 2320, month: 6, day: -3), expected: Date(timeIntervalSince1970: 11057644800.0))
+        test(.init(year: 2443, month: 7, day: 5), expected: Date(timeIntervalSince1970: 14942448000.0))
+        test(.init(year: 2812, month: 5, day: 4), expected: Date(timeIntervalSince1970: 26581651200.0))
+        test(.init(year: 2935, month: 6, day: -3), expected: Date(timeIntervalSince1970: 30465158400.0))
+        test(.init(year: 2935, month: 6, day: 3), expected: Date(timeIntervalSince1970: 30465676800.0))
+
+        test(.init(year: 1582, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: -12232857600.0))
+        test(.init(year: 1582, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: -12232857600.0))
+        test(.init(year: 1705, month: 2, weekOfMonth: 1), expected: Date(timeIntervalSince1970: -8359891200.0))
+        test(.init(year: 1705, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: -8349523200.0))
+        test(.init(year: 1828, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: -4465411200.0))
+        test(.init(year: 1828, month: 7, weekOfMonth: 5), expected: Date(timeIntervalSince1970: -4465411200.0))
+        test(.init(year: 1828, month: 11, weekOfMonth: 0), expected: Date(timeIntervalSince1970: -4454784000.0))
+        test(.init(year: 2197, month: 5, weekOfMonth: -2), expected: Date(timeIntervalSince1970: 7173878400.0))
+        test(.init(year: 2197, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 7173878400.0))
+        test(.init(year: 2320, month: 2, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 11047536000.0))
+        test(.init(year: 2320, month: 6, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 11057990400.0))
+        test(.init(year: 2443, month: -5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 14910566400.0))
+        test(.init(year: 2443, month: -1, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14921193600.0))
+        test(.init(year: 2443, month: 7, weekOfMonth: -1), expected: Date(timeIntervalSince1970: 14942102400.0))
+        test(.init(year: 2443, month: 7, weekOfMonth: 2), expected: Date(timeIntervalSince1970: 14942102400.0))
+        test(.init(year: 2812, month: -3, weekOfMonth: -3), expected: Date(timeIntervalSince1970: 26560396800.0))
+        test(.init(year: 2812, month: 5, weekOfMonth: 1), expected: Date(timeIntervalSince1970: 26581392000.0))
+        test(.init(year: 2812, month: 5, weekOfMonth: 4), expected: Date(timeIntervalSince1970: 26581392000.0))
+        test(.init(year: 2935, month: 6, weekOfMonth: 0), expected: Date(timeIntervalSince1970: 30465504000.0))
+
+        test(.init(weekOfYear: 20, yearForWeekOfYear: 1582), expected: Date(timeIntervalSince1970: -12231820800.0))
+        test(.init(weekOfYear: -25, yearForWeekOfYear: 1705), expected: Date(timeIntervalSince1970: -8378035200.0))
+        test(.init(weekOfYear: -4, yearForWeekOfYear: 1705), expected: Date(timeIntervalSince1970: -8365334400.0))
+        test(.init(weekOfYear: 3, yearForWeekOfYear: 1705), expected: Date(timeIntervalSince1970: -8361100800.0))
+        test(.init(weekOfYear: 0, yearForWeekOfYear: 1828), expected: Date(timeIntervalSince1970: -4481913600.0))
+        test(.init(weekOfYear: 25, yearForWeekOfYear: 1951), expected: Date(timeIntervalSince1970: -585187200.0))
+        test(.init(weekOfYear: -34, yearForWeekOfYear: 2074), expected: Date(timeIntervalSince1970: 3260736000.0))
+        test(.init(weekOfYear: 1, yearForWeekOfYear: 2074), expected: Date(timeIntervalSince1970: 3281904000.0))
+        test(.init(weekOfYear: 8, yearForWeekOfYear: 2074), expected: Date(timeIntervalSince1970: 3286137600.0))
+        test(.init(weekOfYear: -1, yearForWeekOfYear: 2443), expected: Date(timeIntervalSince1970: 14925513600.0))
+        test(.init(weekOfYear: 3, yearForWeekOfYear: 2566), expected: Date(timeIntervalSince1970: 18808934400.0))
+        test(.init(weekOfYear: 0, yearForWeekOfYear: 2689), expected: Date(timeIntervalSince1970: 22688726400.0))
+        test(.init(weekOfYear: -52, yearForWeekOfYear: 2812), expected: Date(timeIntervalSince1970: 26538883200.0))
+        test(.init(weekOfYear: 1, yearForWeekOfYear: 2935), expected: Date(timeIntervalSince1970: 30452544000.0))
+        test(.init(weekOfYear: 43, yearForWeekOfYear: 2935), expected: Date(timeIntervalSince1970: 30477945600.0))
+    }
+}

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -20,7 +20,6 @@ import TestSupport
 @testable import FoundationInternationalization
 @testable import FoundationEssentials
 #endif // FOUNDATION_FRAMEWORK
-import FoundationICU
 
 final class CalendarTests : XCTestCase {
 

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -687,7 +687,7 @@ final class CalendarBridgingTests : XCTestCase {
 #endif
 
 // This test validates the results against FoundationInternationalization's calendar implementation temporarily until we completely ported the calendar
-final class GregorianCalendarTests: XCTestCase {
+final class GregorianCalendarCompatibilityTests: XCTestCase {
 
     func testDateFromComponentsCompatibility() {
         let icuCalendar = _CalendarICU(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -14,7 +14,9 @@
 import TestSupport
 #endif
 
-#if canImport(FoundationInternationalization)
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#elseif canImport(FoundationInternationalization)
 @testable import FoundationInternationalization
 #endif
 

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -209,7 +209,7 @@ final class TimeZoneICUTests: XCTestCase {
         gmt_calendar.timeZone = .gmt
         func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: Int, file: StaticString = #file, line: UInt = #line) {
             let d = gmt_calendar.date(from: dateComponent)! // date in GMT
-            let (rawOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(forGMTDate: d)
+            let (rawOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(for: d)
             XCTAssertEqual(rawOffset, expectedRawOffset, file: file, line: line)
             XCTAssertEqual(dstOffset, expectedDSTOffset, file: file, line: line)
         }

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -14,6 +14,10 @@
 import TestSupport
 #endif
 
+#if canImport(FoundationInternationalization)
+@testable import FoundationInternationalization
+#endif
+
 final class TimeZoneTests : XCTestCase {
 
     func test_timeZoneBasics() {
@@ -50,7 +54,7 @@ final class TimeZoneTests : XCTestCase {
     func testPredefinedTimeZone() {
         XCTAssertEqual(TimeZone.gmt, TimeZone(identifier: "GMT"))
     }
-    
+
     func testLocalizedName_103036605() {
         func test(_ tzIdentifier: String, _ localeIdentifier: String, _ style: TimeZone.NameStyle, _ expected: String?, file: StaticString = #file, line: UInt = #line) {
             let tz = TimeZone(identifier: tzIdentifier)
@@ -195,6 +199,49 @@ final class TimeZoneGMTTests : XCTestCase {
     }
 }
 
+final class TimeZoneICUTests: XCTestCase {
+    func testTimeZoneOffset() {
+        let tz = _TimeZoneICU(identifier: "America/Los_Angeles")!
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+
+        var gmt_calendar = Calendar(identifier: .gregorian)
+        gmt_calendar.timeZone = .gmt
+        func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: Int, file: StaticString = #file, line: UInt = #line) {
+            let d = gmt_calendar.date(from: dateComponent)! // date in GMT
+            let (rawOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(forGMTDate: d)
+            XCTAssertEqual(rawOffset, expectedRawOffset, file: file, line: line)
+            XCTAssertEqual(dstOffset, expectedDSTOffset, file: file, line: line)
+        }
+
+        // Not in DST
+        test(.init(year: 2023, month: 3, day: 12, hour: 1, minute: 00, second: 00), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        test(.init(year: 2023, month: 3, day: 12, hour: 1, minute: 00, second: 00, nanosecond: 1), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        test(.init(year: 2023, month: 3, day: 12, hour: 1, minute: 00, second: 01), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        test(.init(year: 2023, month: 3, day: 12, hour: 1, minute: 59, second: 59), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        
+        // These times do not exist; we treat it as if in the previous time zone, i.e. not in DST
+        test(.init(year: 2023, month: 3, day: 12, hour: 2, minute: 00, second: 00), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        test(.init(year: 2023, month: 3, day: 12, hour: 2, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 0)
+
+        // After DST starts
+        test(.init(year: 2023, month: 3, day: 12, hour: 3, minute: 00, second: 00), expectedRawOffset: -28800, expectedDSTOffset: 3600)
+        test(.init(year: 2023, month: 3, day: 12, hour: 3, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 3600)
+        test(.init(year: 2023, month: 3, day: 12, hour: 4, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 3600)
+
+        // These times happen twice; we treat it as if in the previous time zone, i.e. still in DST
+        test(.init(year: 2023, month: 11, day: 5, hour: 1, minute: 00, second: 00), expectedRawOffset: -28800, expectedDSTOffset: 3600)
+        test(.init(year: 2023, month: 11, day: 5, hour: 1, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 3600)
+        
+        // Clock should turn right back as this moment, so if we insist on being at this point, then we've moved past the transition point -- hence not DST
+        test(.init(year: 2023, month: 11, day: 5, hour: 2, minute: 00, second: 00), expectedRawOffset: -28800, expectedDSTOffset: 0)
+
+        // Not in DST
+        test(.init(year: 2023, month: 11, day: 5, hour: 2, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 0)
+        test(.init(year: 2023, month: 11, day: 5, hour: 3, minute: 34, second: 52), expectedRawOffset: -28800, expectedDSTOffset: 0)
+    }
+
+}
 // MARK: - FoundationPreview disabled tests
 #if FOUNDATION_FRAMEWORK
 extension TimeZoneTests {

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -207,7 +207,7 @@ final class TimeZoneICUTests: XCTestCase {
 
         var gmt_calendar = Calendar(identifier: .gregorian)
         gmt_calendar.timeZone = .gmt
-        func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: Int, file: StaticString = #file, line: UInt = #line) {
+        func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: TimeInterval, file: StaticString = #file, line: UInt = #line) {
             let d = gmt_calendar.date(from: dateComponent)! // date in GMT
             let (rawOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(for: d)
             XCTAssertEqual(rawOffset, expectedRawOffset, file: file, line: line)


### PR DESCRIPTION
To support DST-observing time zone, add a helper function for TimeZone to return the raw offset and DST offset individually so we can fine-tune the behavior for the time during the skipped time frame and the repeated time frame.
