### PR TITLE
Add descriptions to Predicate

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -209,6 +209,13 @@ extension PredicateExpressions.KeyPath : Sendable where Root : Sendable {}
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath : StandardPredicateExpression where Root : StandardPredicateExpression {}
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.KeyPath : CustomStringConvertible {
+    public var description: String {
+        "KeyPath(root: \(root), keyPath: \(keyPath.debugDescription))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Value : Codable where Output : Codable {
     public func encode(to encoder: Encoder) throws {
@@ -227,6 +234,22 @@ extension PredicateExpressions.Value : Sendable where Output : Sendable {}
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Value : StandardPredicateExpression where Output : Codable /*, Output : Sendable*/ {}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Value : CustomStringConvertible {
+    public var description: String {
+        var result = "Value<\(_typeName(Output.self))>("
+        debugPrint(value, separator: "", terminator: "", to: &result)
+        return result + ")"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Variable : CustomStringConvertible {
+    public var description: String {
+        "Variable(\(key.id))"
+    }
+}
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.KeyPath {

--- a/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Aggregate.swift
@@ -39,6 +39,13 @@ extension PredicateExpressions {
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMaximum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceMaximum : CustomStringConvertible {
+    public var description: String {
+        "SequenceMaximum(elements: \(elements))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMaximum : Codable where Elements : Codable {}
 
@@ -73,6 +80,13 @@ extension PredicateExpressions {
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMinimum : StandardPredicateExpression where Elements : StandardPredicateExpression {}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceMinimum : CustomStringConvertible {
+    public var description: String {
+        "SequenceMinimum(elements: \(elements))"
+    }
+}
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceMinimum : Codable where Elements : Codable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Arithmetic.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Arithmetic.swift
@@ -56,6 +56,13 @@ extension PredicateExpressions {
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Arithmetic : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Arithmetic : CustomStringConvertible {
+    public var description: String {
+        "Arithmetic(lhs: \(lhs), operator: \(op), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Arithmetic : Codable where LHS : Codable, RHS : Codable {
     public func encode(to encoder: Encoder) throws {

--- a/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Collection.swift
@@ -48,6 +48,13 @@ extension PredicateExpressions {
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionIndexSubscript : Sendable where Wrapped : Sendable, Index : Sendable {}
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionIndexSubscript : CustomStringConvertible {
+    public var description: String {
+        "CollectionIndexSubscript(wrapped: \(wrapped), index: \(index))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionIndexSubscript : Codable where Wrapped : Codable, Index : Codable {
     public func encode(to encoder: Encoder) throws {
@@ -106,6 +113,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionRangeSubscript : CustomStringConvertible {
+    public var description: String {
+        "CollectionRangeSubscript(wrapped: \(wrapped), range: \(range))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionRangeSubscript : Sendable where Wrapped : Sendable, Range : Sendable {}
 
@@ -160,6 +174,12 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionContainsCollection : CustomStringConvertible {
+    public var description: String {
+        "CollectionContainsCollection(base: \(base), other: \(other))"
+    }
+}
 
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.CollectionContainsCollection : Sendable where Base : Sendable, Other : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/Comparison.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Comparison.swift
@@ -54,6 +54,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Comparison : CustomStringConvertible {
+    public var description: String {
+        "Comparison(lhs: \(lhs), operator: \(op), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Comparison : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Conditional.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Conditional.swift
@@ -48,6 +48,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Conditional : CustomStringConvertible {
+    public var description: String {
+        "Conditional(test: \(test), trueBranch: \(trueBranch), falseBranch: \(falseBranch))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conditional : StandardPredicateExpression where Test : StandardPredicateExpression, If : StandardPredicateExpression, Else : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Conjunction.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Conjunction.swift
@@ -40,6 +40,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Conjunction : CustomStringConvertible {
+    public var description: String {
+        "Conjunction(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Conjunction : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Dictionary.swift
@@ -40,6 +40,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.DictionaryKeySubscript : CustomStringConvertible {
+    public var description: String {
+        "DictionaryKeySubscript(wrapped: \(wrapped), key: \(key))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.DictionaryKeySubscript : Sendable where Wrapped : Sendable, Key : Sendable {}
 
@@ -93,6 +100,13 @@ extension PredicateExpressions {
     
     public static func build_subscript<Wrapped, Key, Default>(_ wrapped: Wrapped, _ key: Key, default: Default) -> DictionaryKeyDefaultValueSubscript<Wrapped, Key, Default> {
         DictionaryKeyDefaultValueSubscript(wrapped: wrapped, key: key, default: `default`)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : CustomStringConvertible {
+    public var description: String {
+        "DictionaryKeyDefaultValueSubscript(wrapped: \(wrapped), key: \(key), defaultValue: \(`default`))"
     }
 }
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Disjunction.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Disjunction.swift
@@ -40,6 +40,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Disjunction : CustomStringConvertible {
+    public var description: String {
+        "Disjunction(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Disjunction : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Division.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Division.swift
@@ -100,6 +100,27 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.FloatDivision : CustomStringConvertible {
+    public var description: String {
+        "FloatDivision(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.IntDivision : CustomStringConvertible {
+    public var description: String {
+        "IntDivision(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.IntRemainder : CustomStringConvertible {
+    public var description: String {
+        "IntRemainder(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.FloatDivision : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Equality.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Equality.swift
@@ -40,6 +40,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Equal : CustomStringConvertible {
+    public var description: String {
+        "Equal(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Equal : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Filter.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Filter.swift
@@ -20,7 +20,6 @@ extension PredicateExpressions {
         LHS.Output: Sequence,
         RHS.Output == Bool
     {
-        // TODO: Refine Output type to a constrained "some Collection" ?
         public typealias Element = LHS.Output.Element
         public typealias Output = [Element]
         
@@ -45,6 +44,13 @@ extension PredicateExpressions {
     
     public static func build_filter<LHS, RHS>(_ lhs: LHS, _ builder: (Variable<LHS.Output.Element>) -> RHS) -> Filter<LHS, RHS> {
         Filter(lhs, builder)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Filter : CustomStringConvertible {
+    public var description: String {
+        "Filter(sequence: \(sequence), variable: \(variable), filter: \(filter))"
     }
 }
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Inequality.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Inequality.swift
@@ -40,6 +40,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.NotEqual : CustomStringConvertible {
+    public var description: String {
+        "NotEqual(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.NotEqual : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Negation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Negation.swift
@@ -31,6 +31,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Negation : CustomStringConvertible {
+    public var description: String {
+        "Negation(wrapped: \(wrapped))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Negation : StandardPredicateExpression where Wrapped : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Optional.swift
@@ -111,6 +111,27 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.OptionalFlatMap : CustomStringConvertible {
+    public var description: String {
+        "OptionalFlatMap(wrapped: \(wrapped), variable: \(variable), transform: \(transform))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.NilCoalesce : CustomStringConvertible {
+    public var description: String {
+        "NilCoalesce(lhs: \(lhs), rhs: \(rhs))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ForcedUnwrap : CustomStringConvertible {
+    public var description: String {
+        "ForcedUnwrap(inner: \(inner))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.OptionalFlatMap : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Range.swift
@@ -45,6 +45,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Range : CustomStringConvertible {
+    public var description: String {
+        "Range(lower: \(lower), upper: \(upper))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.Range : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
@@ -98,6 +105,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ClosedRange : CustomStringConvertible {
+    public var description: String {
+        "ClosedRange(lower: \(lower), upper: \(upper))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ClosedRange : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 
@@ -145,6 +159,13 @@ extension PredicateExpressions {
     
     public static func build_contains<RangeExpression, Element>(_ range: RangeExpression, _ element: Element) -> RangeExpressionContains<RangeExpression, Element> {
         RangeExpressionContains(range: range, element: element)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.RangeExpressionContains : CustomStringConvertible {
+    public var description: String {
+        "RangeExpressionContains(range: \(range), element: \(element))"
     }
 }
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Sequence.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Sequence.swift
@@ -141,6 +141,27 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceContains : CustomStringConvertible {
+    public var description: String {
+        "SequenceContains(sequence: \(sequence), element: \(element))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceContainsWhere : CustomStringConvertible {
+    public var description: String {
+        "SequenceContainsWhere(sequence: \(sequence), variable: \(variable), test: \(test))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceAllSatisfy : CustomStringConvertible {
+    public var description: String {
+        "SequenceAllSatisfy(sequence: \(sequence), variable: \(variable), test: \(test))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.SequenceContains : StandardPredicateExpression where LHS : StandardPredicateExpression, RHS : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/StringComparison.swift
@@ -41,6 +41,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringCaseInsensitiveCompare : CustomStringConvertible {
+    public var description: String {
+        "StringCaseInsensitiveCompare(root: \(root), other: \(other))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/Types.swift
@@ -68,6 +68,27 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ConditionalCast : CustomStringConvertible {
+    public var description: String {
+        "ConditionalCast(input: \(input), desiredType: \(_typeName(Desired.self)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ForceCast : CustomStringConvertible {
+    public var description: String {
+        "ForceCast(input: \(input), desiredType: \(_typeName(Desired.self)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.TypeCheck : CustomStringConvertible {
+    public var description: String {
+        "TypeCheck(input: \(input), desiredType: \(_typeName(Desired.self)))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.ConditionalCast : StandardPredicateExpression where Input : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Expressions/UnaryMinus.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/UnaryMinus.swift
@@ -31,6 +31,13 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.UnaryMinus : CustomStringConvertible {
+    public var description: String {
+        "UnaryMinus(wrapped: \(wrapped))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.UnaryMinus : StandardPredicateExpression where Wrapped : StandardPredicateExpression {}
 

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -1,0 +1,428 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(FoundationPreview 0.3, *)
+package struct DebugStringConversionState {
+    private var variables: [PredicateExpressions.VariableID : String]
+    private var nextVariable = 1
+    private var captures: [String] = []
+    private var nextCapture = 1
+
+    var captureDecl: String {
+        captures.joined(separator: "\n")
+    }
+
+    init(_ variables: [PredicateExpressions.VariableID]) {
+        self.variables = Dictionary(uniqueKeysWithValues: variables.enumerated().map {
+            ($1, "input\($0 + 1)")
+        })
+    }
+
+    subscript(_ variable: PredicateExpressions.VariableID) -> String {
+        variables[variable] ?? "unknownVariable\(variable.id)"
+    }
+
+    mutating func setupVariable(_ variable: PredicateExpressions.VariableID) {
+        variables[variable] = "variable\(nextVariable)"
+        nextVariable += 1
+    }
+
+    mutating func addCapture(_ value: Any) -> String {
+        let valueConstruction = switch value as Any {
+        case Optional<Any>.none: "nil"
+        case let b as Bool: "\(b)"
+        case let i as any Numeric: "\(i)"
+        case let s as String: "\"\(s.replacing("\"", with: "\\\""))\""
+        case let d as Date: "<Date \(d.timeIntervalSince1970)>"
+        case let d as Data: "<Data \(d.base64EncodedString())>"
+        case let u as UUID: "<UUID \(u.uuidString)>"
+        default: "<\(_typeName(type(of: value))): \(String(describing: value).replacing("\n", with: ", "))>"
+        }
+        captures.append("capture\(nextCapture) (\(_typeName(type(of: value)))): \(valueConstruction)")
+        defer { nextCapture += 1 }
+        return "capture\(nextCapture)"
+    }
+}
+
+extension String {
+    fileprivate func indentedWithinClosure() -> String {
+        var startIndex = self.startIndex
+        var endIndex = self.endIndex
+        if self.starts(with: "(") {
+            self.formIndex(after: &startIndex)
+        }
+        if self.hasSuffix(")") {
+            self.formIndex(before: &endIndex)
+        }
+        return String(self[startIndex ..< endIndex].replacing("\n", with: "\n    "))
+    }
+}
+
+extension AnyKeyPath {
+    fileprivate var debugStringWithoutType: String {
+        let pieces = self.debugDescription.split(separator: ".")
+        var idx = pieces.endIndex - 1
+        while idx > pieces.startIndex && !pieces[idx].hasSuffix(">") {
+            idx -= 1
+        }
+        return "." + pieces[(idx + 1)...].joined(separator: ".")
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+package protocol DebugStringConvertiblePredicateExpression : StandardPredicateExpression {
+    func debugString(state: inout DebugStringConversionState) -> String
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Variable : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state[self.key]
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.KeyPath : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        root.debugString(state: &state) + keyPath.debugStringWithoutType
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Value : DebugStringConvertiblePredicateExpression where Self : StandardPredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state.addCapture(value)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Conjunction : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) && \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Disjunction : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) || \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Equal : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) == \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.NotEqual : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) != \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Arithmetic : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        let op = switch self.op {
+        case .add: "+"
+        case .multiply: "*"
+        case .subtract: "-"
+        }
+        return "(\(lhs.debugString(state: &state)) \(op) \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Comparison : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        let op = switch self.op {
+        case .greaterThan: ">"
+        case .greaterThanOrEqual: ">="
+        case .lessThan: "<"
+        case .lessThanOrEqual: "<="
+        }
+        return "(\(lhs.debugString(state: &state)) \(op) \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.UnaryMinus : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "-\(wrapped.debugString(state: &state))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceMinimum : DebugStringConvertiblePredicateExpression where Elements : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(elements.debugString(state: &state)).min()"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceMaximum : DebugStringConvertiblePredicateExpression where Elements : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(elements.debugString(state: &state)).max()"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ClosedRange : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lower.debugString(state: &state)) ... \(upper.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Range : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lower.debugString(state: &state)) ..< \(upper.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Conditional : DebugStringConvertiblePredicateExpression where Test : DebugStringConvertiblePredicateExpression, If : DebugStringConvertiblePredicateExpression, Else : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        """
+        if \(test.debugString(state: &state)) {
+            \(trueBranch.debugString(state: &state).indentedWithinClosure())
+        } else {
+            \(falseBranch.debugString(state: &state).indentedWithinClosure())
+        }
+        """
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionIndexSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Index : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(wrapped.debugString(state: &state))[\(index.debugString(state: &state))]"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionRangeSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Range : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(wrapped.debugString(state: &state))[\(range.debugString(state: &state))]"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.CollectionContainsCollection : DebugStringConvertiblePredicateExpression where Base : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(base.debugString(state: &state)).contains(\(other.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ConditionalCast : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(input.debugString(state: &state)) as? \(_typeName(Desired.self)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ForceCast : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(input.debugString(state: &state)) as! \(_typeName(Desired.self)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.TypeCheck : DebugStringConvertiblePredicateExpression where Input : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(input.debugString(state: &state)) is \(_typeName(Desired.self)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.ForcedUnwrap : DebugStringConvertiblePredicateExpression where Inner : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(inner.debugString(state: &state))!"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.OptionalFlatMap : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state.setupVariable(variable.key)
+        return """
+            \(wrapped.debugString(state: &state)).flatMap({ \(state[variable.key]) in
+                \(transform.debugString(state: &state).indentedWithinClosure())
+            })
+            """
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.DictionaryKeySubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Key : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(wrapped.debugString(state: &state))[\(key.debugString(state: &state))]"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.DictionaryKeyDefaultValueSubscript : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression, Key : DebugStringConvertiblePredicateExpression, Default : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(wrapped.debugString(state: &state))[\(key.debugString(state: &state)), default: \(self.default.debugString(state: &state))]"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.FloatDivision : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) / \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.IntDivision : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) / \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.IntRemainder : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) % \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Negation : DebugStringConvertiblePredicateExpression where Wrapped : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "!\(wrapped.debugString(state: &state))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.NilCoalesce : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS: DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "(\(lhs.debugString(state: &state)) ?? \(rhs.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.NilLiteral : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "nil"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.RangeExpressionContains : DebugStringConvertiblePredicateExpression where RangeExpression : DebugStringConvertiblePredicateExpression, Element : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(range.debugString(state: &state)).contains(\(element.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceContains : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS: DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(sequence.debugString(state: &state)).contains(\(element.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceStartsWith : DebugStringConvertiblePredicateExpression where Base : DebugStringConvertiblePredicateExpression, Prefix : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(base.debugString(state: &state)).starts(with: \(prefix.debugString(state: &state)))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceContainsWhere : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state.setupVariable(variable.key)
+        return """
+            \(sequence.debugString(state: &state)).contains(where: { \(state[variable.key]) in
+                \(test.debugString(state: &state).indentedWithinClosure())
+            })
+            """
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.SequenceAllSatisfy : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state.setupVariable(variable.key)
+        return """
+            \(sequence.debugString(state: &state)).allSatisfy({ \(state[variable.key]) in
+                \(test.debugString(state: &state).indentedWithinClosure())
+            })
+            """
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.Filter : DebugStringConvertiblePredicateExpression where LHS : DebugStringConvertiblePredicateExpression, RHS : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        state.setupVariable(variable.key)
+        return """
+            \(sequence.debugString(state: &state)).filter({ \(state[variable.key]) in
+                \(filter.debugString(state: &state).indentedWithinClosure())
+            })
+            """
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringCaseInsensitiveCompare : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(root.debugString(state: &state)).caseInsensitiveCompare(\(other.debugString(state: &state)))"
+    }
+}
+
+#endif
+
+@available(FoundationPreview 0.3, *)
+extension Predicate : CustomStringConvertible {
+    public var description: String {
+        var variableIDs: [PredicateExpressions.VariableID] = []
+        repeat variableIDs.append((each variable).key)
+        guard let debugConvertible = self.expression as? any DebugStringConvertiblePredicateExpression else {
+            fatalError("Internal inconsistency: StandardPredicateExpression does not conform to DebugStringConvertiblePredicateExpression")
+        }
+        var types: [Any.Type] = []
+        repeat types.append((each Input).self)
+        let typeNames = types.map {
+            _typeName($0)
+        }.joined(separator: ", ")
+        var state = DebugStringConversionState(variableIDs)
+        let variableNames = variableIDs.map {
+            state[$0]
+        }.joined(separator: ", ")
+        let converted = debugConvertible.debugString(state: &state)
+        var result = state.captureDecl.isEmpty ? "" : "\(state.captureDecl)\n"
+        result.append("""
+                        Predicate<\(typeNames)> { \(variableNames) in
+                            \(converted.indentedWithinClosure())
+                        }
+                        """)
+        return result
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension Predicate : CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var variableDesc: [String] = []
+        repeat variableDesc.append((each variable).description)
+        return "\(_typeName(Self.self))(variable: (\(variableDesc.joined(separator: ", "))), expression: \(expression))"
+    }
+}

--- a/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
+++ b/Sources/FoundationInternationalization/Predicate/LocalizedString.swift
@@ -41,6 +41,20 @@ extension PredicateExpressions {
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringLocalizedStandardContains : CustomStringConvertible {
+    public var description: String {
+        "StringLocalizedStandardContains(root: \(root), other: \(other))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringLocalizedStandardContains : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(root.debugString(state: &state)).localizedStandardContains(\(other.debugString(state: &state)))"
+    }
+}
+
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions.StringLocalizedStandardContains : StandardPredicateExpression where Root : StandardPredicateExpression, Other : StandardPredicateExpression {}
 
@@ -88,6 +102,20 @@ extension PredicateExpressions {
     
     public static func build_localizedCompare<Root, Other>(_ root: Root, _ other: Other) -> StringLocalizedCompare<Root, Other> {
         StringLocalizedCompare(root: root, other: other)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringLocalizedCompare : CustomStringConvertible {
+    public var description: String {
+        "StringLocalizedCompare(root: \(root), other: \(other))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.StringLocalizedCompare : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        "\(root.debugString(state: &state)).localizedCompare(\(other.debugString(state: &state)))"
     }
 }
 

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -338,8 +338,12 @@ final class PredicateTests: XCTestCase {
             $0.a == $0.c && $0.b == now
         }
     }
-
-    func testDebugDescription() {
+    
+    func testDebugDescription() throws {
+        guard #available(FoundationPreview 0.3, *) else {
+            throw XCTSkip("This test is not available on this OS version")
+        }
+        
         let date = Date.now
         let predicate = Predicate<Object> {
             /*
@@ -392,7 +396,7 @@ final class PredicateTests: XCTestCase {
             """
         )
         
-        let debugDescription = predicate.debugDescription.replacing(/Variable\([0-9]+\)/, with: "Variable(#)")
+        let debugDescription = predicate.debugDescription.replacing(#/Variable\([0-9]+\)/#, with: "Variable(#)")
         XCTAssertEqual(
             debugDescription,
             "\(moduleName).Predicate<Pack{\(testModuleName).PredicateTests.Object}>(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\Object.a), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\Object.h), rhs: Value<\(moduleName).Date>(\(date.debugDescription)))))"


### PR DESCRIPTION
This PR adds descriptions to both `Predicate` and the individual `PredicateExpression` types. In particular, `Predicate` conforms to `CustomStringConvertible` and `CustomDebugStringConvertible` to provide expansive descriptions and compact single-line descriptions respectively and the expression types conform to `CustomStringConvertible` to provide a single, compact description each.