### PR TITLE
Workaround type checker timeout

### DIFF
--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -209,7 +209,7 @@ class SortDescriptorTests: XCTestCase {
     }
 
     func test_encoding_comparable_throws() {
-        let descriptors = [
+        let descriptors : [SortDescriptor<SortDescriptorTests.NonNSObjectRoot>] = [
             SortDescriptor(\NonNSObjectRoot.word),
             SortDescriptor(\NonNSObjectRoot.maybeWord),
             SortDescriptor(\NonNSObjectRoot.gadget),


### PR DESCRIPTION
A recent change in the type checker seems to have caused this code to time out on build. For now specify the explicit type.