### PR TITLE
FoundationEssentials: repair the `TimeZone` implementation on Windows

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -154,10 +154,10 @@ struct TimeZoneCache : Sendable {
                 _ = GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwSize, DWORD(VOLUME_NAME_DOS))
                 return String(decodingCString: $0.baseAddress!, as: UTF16.self)
             }
-            if let rangeOfZoneInfo = path.range(of: "\(TimeZone.TZDIR)\\") {
+            if let rangeOfZoneInfo = path._range(of: "\(TimeZone.TZDIR)\\", anchored: false, backwards: false) {
                 let name = path[rangeOfZoneInfo.upperBound...]
                 if let result = fixed(String(name)) {
-                    return result
+                    return TimeZone(inner: result)
                 }
             }
 #else


### PR DESCRIPTION
Update the Windows path for `String.range(of:)` being altered to `String._range(of:anchored:backwards:)`. This repairs the build of FoundationEssentials on Windows.