### PR TITLE
Add import for _dyld_image_count

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -30,6 +30,7 @@ public enum AttributeScopes { }
 #if FOUNDATION_FRAMEWORK
 
 import Darwin
+@_implementationOnly import MachO.dyld
 @_implementationOnly import ReflectionInternal
 
 fileprivate struct ScopeDescription : Sendable {


### PR DESCRIPTION
Adds an import for use of `_dyld_image_count` in `FOUNDATION_FRAMEWORK` block.