### PR TITLE
Do not attempt to cache based on a signature that uses a `Locale`

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -250,6 +250,15 @@ struct LocaleCache : Sendable {
         lock.withLock { $0.reset() }
     }
 
+    /// For testing of `autoupdatingCurrent` only. If you want to test `current`, create a custom `Locale` with the appropriate settings using `localeAsIfCurrent(name:overrides:disableBundleMatching:)` and use that instead.
+    /// This mutates global state of the current locale, so it is not safe to use in concurrent testing.
+    func resetCurrent(to preferences: LocalePreferences) {
+        lock.withLock {
+            $0.reset()
+            let _ = $0.current(preferences: preferences, cache: true)
+        }
+    }
+
     var current: any _LocaleProtocol {
         var result = lock.withLock {
             $0.current(preferences: nil, cache: false)

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -441,6 +441,46 @@ final class NumberFormatStyleTests: XCTestCase {
         XCTAssertEqual((-3.14159 as Decimal).formatted(.currency(code:"USD")), currencyStyle.format(-3.14159))
         XCTAssertEqual((-3000.14159 as Decimal).formatted(.currency(code:"USD")), currencyStyle.format(-3000.14159))
     }
+    
+    func test_autoupdatingCurrentChangesFormatResults() {
+        let locale = Locale.autoupdatingCurrent
+        let number = 50_000
+        let measurement = Measurement(value: 0.8, unit: UnitLength.meters)
+        let currency = Decimal(123.45)
+        let percent = 54.32
+        let bytes = 1_234_567_890
+        
+        // Get a formatted result from es-ES
+        var prefs = LocalePreferences()
+        prefs.languages = ["es-ES"]
+        prefs.locale = "es_ES"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedSpanishNumber = number.formatted(.number.locale(locale))
+        let formattedSpanishMeasurement = measurement.formatted(.measurement(width: .narrow).locale(locale))
+        let formattedSpanishCurrency = currency.formatted(.currency(code: "USD").locale(locale))
+        let formattedSpanishPercent = percent.formatted(.percent.locale(locale))
+        let formattedSpanishBytes = bytes.formatted(.byteCount(style: .decimal).locale(locale))
+        
+        // Get a formatted result from en-US
+        prefs.languages = ["en-US"]
+        prefs.locale = "en_US"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedEnglishNumber = number.formatted(.number.locale(locale))
+        let formattedEnglishMeasurement = measurement.formatted(.measurement(width: .narrow).locale(locale))
+        let formattedEnglishCurrency = currency.formatted(.currency(code: "USD").locale(locale))
+        let formattedEnglishPercent = percent.formatted(.percent.locale(locale))
+        let formattedEnglishBytes = bytes.formatted(.byteCount(style: .decimal).locale(locale))
+        
+        // Reset to current preferences before any possibility of failing this test
+        LocaleCache.cache.reset()
+
+        // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
+        XCTAssertNotEqual(formattedSpanishNumber, formattedEnglishNumber)
+        XCTAssertNotEqual(formattedSpanishMeasurement, formattedEnglishMeasurement)
+        XCTAssertNotEqual(formattedSpanishCurrency, formattedEnglishCurrency)
+        XCTAssertNotEqual(formattedSpanishPercent, formattedEnglishPercent)
+        XCTAssertNotEqual(formattedSpanishBytes, formattedEnglishBytes)
+    }
 }
 
 extension NumberFormatStyleConfiguration.Collection {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -445,7 +445,10 @@ final class NumberFormatStyleTests: XCTestCase {
     func test_autoupdatingCurrentChangesFormatResults() {
         let locale = Locale.autoupdatingCurrent
         let number = 50_000
+#if FOUNDATION_FRAMEWORK
+        // Measurement is not yet available in the package
         let measurement = Measurement(value: 0.8, unit: UnitLength.meters)
+#endif
         let currency = Decimal(123.45)
         let percent = 54.32
         let bytes = 1_234_567_890
@@ -456,7 +459,9 @@ final class NumberFormatStyleTests: XCTestCase {
         prefs.locale = "es_ES"
         LocaleCache.cache.resetCurrent(to: prefs)
         let formattedSpanishNumber = number.formatted(.number.locale(locale))
+#if FOUNDATION_FRAMEWORK
         let formattedSpanishMeasurement = measurement.formatted(.measurement(width: .narrow).locale(locale))
+#endif
         let formattedSpanishCurrency = currency.formatted(.currency(code: "USD").locale(locale))
         let formattedSpanishPercent = percent.formatted(.percent.locale(locale))
         let formattedSpanishBytes = bytes.formatted(.byteCount(style: .decimal).locale(locale))
@@ -466,7 +471,9 @@ final class NumberFormatStyleTests: XCTestCase {
         prefs.locale = "en_US"
         LocaleCache.cache.resetCurrent(to: prefs)
         let formattedEnglishNumber = number.formatted(.number.locale(locale))
+#if FOUNDATION_FRAMEWORK
         let formattedEnglishMeasurement = measurement.formatted(.measurement(width: .narrow).locale(locale))
+#endif
         let formattedEnglishCurrency = currency.formatted(.currency(code: "USD").locale(locale))
         let formattedEnglishPercent = percent.formatted(.percent.locale(locale))
         let formattedEnglishBytes = bytes.formatted(.byteCount(style: .decimal).locale(locale))
@@ -476,7 +483,9 @@ final class NumberFormatStyleTests: XCTestCase {
 
         // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
         XCTAssertNotEqual(formattedSpanishNumber, formattedEnglishNumber)
+#if FOUNDATION_FRAMEWORK
         XCTAssertNotEqual(formattedSpanishMeasurement, formattedEnglishMeasurement)
+#endif
         XCTAssertNotEqual(formattedSpanishCurrency, formattedEnglishCurrency)
         XCTAssertNotEqual(formattedSpanishPercent, formattedEnglishPercent)
         XCTAssertNotEqual(formattedSpanishBytes, formattedEnglishBytes)


### PR DESCRIPTION
`autoupdatingCurrentLocale` only considers its autoupdating-ness as far as hashing and equality goes. That means if we include it in the `Signature` of the caches used for number formatters (which is how we unique them), an underlying change to the current locale does not result in flushing the cache correctly.

Resolve this for number formatting by storing the identifier and preferences directly. Although we do not use the preferences yet, we will need to in the near future to resolve an issue where we do not honor users customized grouping separators.