### PR TITLE
Implementation for "Additional Configuration Properties for Foundation's `FormatStyle` Implementations" proposal

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Date/Date+ComponentsFormatStyle+Stub.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+ComponentsFormatStyle+Stub.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#endif
+
+#if !FOUNDATION_FRAMEWORK
+
+// stub
+extension Date {
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public struct ComponentsFormatStyle : Codable, Hashable, Sendable {
+        public struct Field : Codable, Hashable, Sendable {
+            enum Option : Int, Codable, Hashable, CaseIterable, Comparable {
+                case year
+                case month
+                case week
+                case day
+                case hour
+                case minute
+                case second
+
+                var component: Calendar.Component {
+                    switch self {
+                    case .year:
+                        return .year
+                    case .month:
+                        return .month
+                    case .week:
+                        return .weekOfMonth
+                    case .day:
+                        return .day
+                    case .hour:
+                        return .hour
+                    case .minute:
+                        return .minute
+                    case .second:
+                        return .second
+                    }
+                }
+
+                init?(component: Calendar.Component) {
+                    switch component {
+                    case .year:
+                        self = .year
+                    case .month:
+                        self = .month
+                    case .weekOfYear, .weekOfMonth:
+                        self = .week
+                    case .day:
+                        self = .day
+                    case .hour:
+                        self = .hour
+                    case .minute:
+                        self = .minute
+                    case .second:
+                        self = .second
+                    default:
+                        return nil
+                    }
+                }
+
+                static func <(lhs: Self, rhs: Self) -> Bool {
+                    lhs.rawValue > rhs.rawValue
+                }
+            }
+
+            var option: Option
+            public static var year: Field { .init(option: .year) }
+            public static var month: Field { .init(option: .month) }
+            public static var week: Field { .init(option: .week) }
+            public static var day: Field { .init(option: .day) }
+            public static var hour: Field { .init(option: .hour) }
+            public static var minute: Field { .init(option: .minute) }
+            public static var second: Field { .init(option: .second) }
+        }
+    }
+}
+#endif // !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -98,7 +98,13 @@ extension Date {
         public var locale: Locale
         public var calendar: Calendar
 
-        var _allowedFields: Set<Date.ComponentsFormatStyle.Field>
+        #if FOUNDATION_FRAMEWORK
+        /// The fields that can be used in the formatted output.
+        @available(FoundationPreview 0.4, *)
+        public var allowedFields: Set<Field>
+        #else
+        // allowedFields is unavailable (publicly as well as internally)
+        // for FoundationPreview
 
         /// The fields that can be used in the formatted output.
         @available(FoundationPreview 0.4, *)
@@ -110,6 +116,18 @@ extension Date {
                 _allowedFields = newValue
             }
         }
+
+        var _allowedFields: Set<Date.ComponentsFormatStyle.Field>
+
+        private enum CodingKeys: String, CodingKey {
+            case presentation
+            case unitsStyle
+            case capitalizationContext
+            case locale
+            case calendar
+            case _allowedFields = "allowedFields"
+        }
+        #endif
 
         public init(presentation: Presentation = .numeric, unitsStyle: UnitsStyle = .wide, locale: Locale = .autoupdatingCurrent, calendar: Calendar = .autoupdatingCurrent, capitalizationContext: FormatStyleCapitalizationContext = .unknown) {
             self.presentation = presentation
@@ -233,7 +251,6 @@ extension Date {
                 }) else {
                     return nil
                 }
-
 
             let secondLargest = ICURelativeDateFormatter.sortedAllowedComponents.first(where: { component in
                 Date.ComponentsFormatStyle.Field.Option(component: component)! < Date.ComponentsFormatStyle.Field.Option(component: largest)!

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+VerbatimFormatStyle.swift
@@ -79,6 +79,7 @@ extension Date.VerbatimFormatStyle {
     /// The type preserving attributed variant of this style.
     ///
     /// This style attributes the formatted date with the `AttributeScopes.FoundationAttributes.DateFormatFieldAttribute`.
+    @dynamicMemberLookup
     public struct Attributed : FormatStyle, Sendable {
         var base: Date.VerbatimFormatStyle
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFieldSymbol.swift
@@ -20,22 +20,22 @@ extension Date.FormatStyle {
     public struct Symbol : Hashable, Sendable {
         let symbolType: SymbolType
 
-        public struct Era : Hashable, Sendable { let option: SymbolType.EraOption }
-        public struct Year : Hashable, Sendable { let option: SymbolType.YearOption }
-        public struct YearForWeekOfYear : Hashable, Sendable { let option: SymbolType.YearForWeekOfYearOption }
-        public struct CyclicYear : Hashable, Sendable { let option: SymbolType.CyclicYearOption }
-        public struct Quarter : Hashable, Sendable { let option: SymbolType.QuarterOption }
-        public struct Month : Hashable, Sendable { let option: SymbolType.MonthOption }
-        public struct Week : Hashable, Sendable { let option: SymbolType.WeekOption }
-        public struct Day : Hashable, Sendable { let option: SymbolType.DayOption }
-        public struct DayOfYear : Hashable, Sendable { let option: SymbolType.DayOfYearOption }
-        public struct Weekday : Hashable, Sendable { let option: SymbolType.WeekdayOption }
-        public struct DayPeriod : Hashable, Sendable { let option: SymbolType.DayPeriodOption }
-        public struct Hour : Hashable, Sendable { let option: SymbolType.HourOption }
-        public struct Minute : Hashable, Sendable { let option: SymbolType.MinuteOption }
-        public struct Second : Hashable, Sendable { let option: SymbolType.SecondOption }
-        public struct SecondFraction : Hashable, Sendable { let option: SymbolType.SecondFractionOption }
-        public struct TimeZone : Hashable, Sendable { let option: SymbolType.TimeZoneSymbolOption }
+        public struct Era : Hashable, Sendable { let option: SymbolType.EraOption? }
+        public struct Year : Hashable, Sendable { let option: SymbolType.YearOption? }
+        public struct YearForWeekOfYear : Hashable, Sendable { let option: SymbolType.YearForWeekOfYearOption? }
+        public struct CyclicYear : Hashable, Sendable { let option: SymbolType.CyclicYearOption? }
+        public struct Quarter : Hashable, Sendable { let option: SymbolType.QuarterOption? }
+        public struct Month : Hashable, Sendable { let option: SymbolType.MonthOption? }
+        public struct Week : Hashable, Sendable { let option: SymbolType.WeekOption? }
+        public struct Day : Hashable, Sendable { let option: SymbolType.DayOption? }
+        public struct DayOfYear : Hashable, Sendable { let option: SymbolType.DayOfYearOption? }
+        public struct Weekday : Hashable, Sendable { let option: SymbolType.WeekdayOption? }
+        public struct DayPeriod : Hashable, Sendable { let option: SymbolType.DayPeriodOption? }
+        public struct Hour : Hashable, Sendable { let option: SymbolType.HourOption? }
+        public struct Minute : Hashable, Sendable { let option: SymbolType.MinuteOption? }
+        public struct Second : Hashable, Sendable { let option: SymbolType.SecondOption? }
+        public struct SecondFraction : Hashable, Sendable { let option: SymbolType.SecondFractionOption? }
+        public struct TimeZone : Hashable, Sendable { let option: SymbolType.TimeZoneSymbolOption? }
 
         public struct StandaloneQuarter : Hashable, Sendable { let option: SymbolType.StandaloneQuarterOption }
         public struct StandaloneMonth : Hashable, Sendable { let option: SymbolType.StandaloneMonthOption }
@@ -995,4 +995,102 @@ public extension Date.FormatStyle.Symbol.TimeZone {
     /// The generic location format. Falls back to `longLocalizedGMT` if unavailable. Recommends for presenting possible time zone choices for user selection.
     /// For example, "Los Angeles Time".
     static var genericLocation: Self { .init(option: .genericLocation) }
+}
+
+// MARK: Omitted Symbol Options
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Era {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Year {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.YearForWeekOfYear {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.CyclicYear {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Quarter {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Month {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Week {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Day {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.DayOfYear {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Weekday {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.DayPeriod {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Hour {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Minute {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.Second {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.SecondFraction {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
+}
+
+@available(FoundationPreview 0.4, *)
+extension Date.FormatStyle.Symbol.TimeZone {
+    /// The option for not including the symbol in the formatted output.
+    public static let omitted: Self = .init(option: nil)
 }

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatString.swift
@@ -56,23 +56,38 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         }
 
         mutating public func appendInterpolation(era: Date.FormatStyle.Symbol.Era) {
-            format.append(era.option.rawValue)
+            guard let option = era.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(year: Date.FormatStyle.Symbol.Year) {
-            format.append(year.option.rawValue)
+            guard let option = year.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(yearForWeekOfYear: Date.FormatStyle.Symbol.YearForWeekOfYear) {
-            format.append(yearForWeekOfYear.option.rawValue)
+            guard let option = yearForWeekOfYear.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(cyclicYear: Date.FormatStyle.Symbol.CyclicYear) {
-            format.append(cyclicYear.option.rawValue)
+            guard let option = cyclicYear.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(quarter: Date.FormatStyle.Symbol.Quarter) {
-            format.append(quarter.option.rawValue)
+            guard let option = quarter.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(standaloneQuarter: Date.FormatStyle.Symbol.StandaloneQuarter) {
@@ -80,7 +95,10 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         }
 
         mutating public func appendInterpolation(month: Date.FormatStyle.Symbol.Month) {
-            format.append(month.option.rawValue)
+            guard let option = month.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(standaloneMonth: Date.FormatStyle.Symbol.StandaloneMonth) {
@@ -88,19 +106,31 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         }
 
         mutating public func appendInterpolation(week: Date.FormatStyle.Symbol.Week) {
-            format.append(week.option.rawValue)
+            guard let option = week.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(day: Date.FormatStyle.Symbol.Day) {
-            format.append(day.option.rawValue)
+            guard let option = day.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(dayOfYear: Date.FormatStyle.Symbol.DayOfYear) {
-            format.append(dayOfYear.option.rawValue)
+            guard let option = dayOfYear.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(weekday: Date.FormatStyle.Symbol.Weekday) {
-            format.append(weekday.option.rawValue)
+            guard let option = weekday.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(standaloneWeekday: Date.FormatStyle.Symbol.StandaloneWeekday) {
@@ -108,7 +138,10 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         }
 
         mutating public func appendInterpolation(dayPeriod: Date.FormatStyle.Symbol.DayPeriod) {
-            format.append(dayPeriod.option.rawValue)
+            guard let option = dayPeriod.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(hour: Date.FormatStyle.Symbol.VerbatimHour) {
@@ -116,19 +149,31 @@ extension Date.FormatString : ExpressibleByStringInterpolation {
         }
 
         mutating public func appendInterpolation(minute: Date.FormatStyle.Symbol.Minute) {
-            format.append(minute.option.rawValue)
+            guard let option = minute.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(second: Date.FormatStyle.Symbol.Second) {
-            format.append(second.option.rawValue)
+            guard let option = second.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(secondFraction: Date.FormatStyle.Symbol.SecondFraction) {
-            format.append(secondFraction.option.rawValue)
+            guard let option = secondFraction.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
 
         mutating public func appendInterpolation(timeZone: Date.FormatStyle.Symbol.TimeZone) {
-            format.append(timeZone.option.rawValue)
+            guard let option = timeZone.option else {
+                return
+            }
+            format.append(option.rawValue)
         }
     }
 }

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -400,6 +400,7 @@ extension Date.FormatStyle {
     /// The type preserving attributed variant of this style.
     ///
     /// This style attributes the formatted date with the `AttributeScopes.FoundationAttributes.DateFormatFieldAttribute`.
+    @dynamicMemberLookup
     public struct Attributed : FormatStyle, Sendable {
         var base: Date.FormatStyle
 

--- a/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
@@ -174,6 +174,7 @@ extension Duration.TimeFormatStyle {
     /// 26.25 { durationField: .seconds }
     /// ```
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @dynamicMemberLookup
     public struct Attributed : FormatStyle, Sendable {
 
         typealias Pattern = Duration.TimeFormatStyle.Pattern

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -608,3 +608,21 @@ extension Duration.UnitsFormatStyle {
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension UATimeUnitStyle : Codable, Hashable {}
+
+// MARK: Dynamic Member Lookup
+
+@available(FoundationPreview 0.4, *)
+extension Duration.UnitsFormatStyle.Attributed {
+    public subscript<T>(dynamicMember key: KeyPath<Duration.UnitsFormatStyle, T>) -> T {
+        innerStyle[keyPath: key]
+    }
+
+    public subscript<T>(dynamicMember key: WritableKeyPath<Duration.UnitsFormatStyle, T>) -> T {
+        get {
+            innerStyle[keyPath: key]
+        }
+        set {
+            innerStyle[keyPath: key] = newValue
+        }
+    }
+}

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -528,6 +528,7 @@ extension Duration.UnitsFormatStyle {
     /// seconds { durationField: .seconds, component: .unit }
     /// ```
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @dynamicMemberLookup
     public struct Attributed : FormatStyle, Sendable {
 
         var innerStyle: Duration.UnitsFormatStyle

--- a/Sources/_FoundationInternals/BinaryFloatingPoint.swift
+++ b/Sources/_FoundationInternals/BinaryFloatingPoint.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension BinaryFloatingPoint {
+    func rounded<T: BinaryFloatingPoint>(increment: T, rule: FloatingPointRoundingRule) -> Self {
+        guard increment != 0 else {
+            return self
+        }
+
+        return (self / Self(increment)).rounded(rule) * Self(increment)
+    }
+}

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -585,6 +585,40 @@ final class DateFormatStyleTests : XCTestCase {
             verifyWithFormat(evening, expected: "09:50:00 PM")
         }
     }
+
+    @available(FoundationPreview 0.4, *)
+    func testRemovingFields() {
+        var format: Date.FormatStyle = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
+        func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #file, line: UInt = #line) {
+            let formatted = format.format(date)
+            XCTAssertEqual(formatted, expected, file: file, line: line)
+        }
+
+        #if FOUNDATION_FRAMEWORK
+            let separator = "\u{202f}"
+        #else
+            let separator = " "
+        #endif
+
+        let date = Date(timeIntervalSince1970: 0)
+
+        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        format = format.day(.omitted)
+        verifyWithFormat(date, expected: "1/1970, 12:00\(separator)AM")
+        format = format.day(.defaultDigits)
+        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        format = format.minute()
+        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        format = format.minute(.omitted)
+        verifyWithFormat(date, expected: "1/1/1970, 12\(separator)AM")
+        format = format.day(.omitted)
+        verifyWithFormat(date, expected: "1/1970, 12\(separator)AM")
+
+        format = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
+        format = format.day()
+        format = format.day(.omitted)
+        verifyWithFormat(date, expected: "")
+    }
 }
 
 extension Sequence where Element == (String, AttributeScopes.FoundationAttributes.DateFieldAttribute.Field?) {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -591,28 +591,22 @@ final class DateFormatStyleTests : XCTestCase {
         var format: Date.FormatStyle = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
         func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #file, line: UInt = #line) {
             let formatted = format.format(date)
-            XCTAssertEqual(formatted, expected, file: file, line: line)
+            XCTAssertEqualIgnoreSeparator(formatted, expected, file: file, line: line)
         }
-
-        #if FOUNDATION_FRAMEWORK
-            let separator = "\u{202f}"
-        #else
-            let separator = " "
-        #endif
 
         let date = Date(timeIntervalSince1970: 0)
 
-        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        verifyWithFormat(date, expected: "1/1/1970, 12:00 AM")
         format = format.day(.omitted)
-        verifyWithFormat(date, expected: "1/1970, 12:00\(separator)AM")
+        verifyWithFormat(date, expected: "1/1970, 12:00 AM")
         format = format.day(.defaultDigits)
-        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        verifyWithFormat(date, expected: "1/1/1970, 12:00 AM")
         format = format.minute()
-        verifyWithFormat(date, expected: "1/1/1970, 12:00\(separator)AM")
+        verifyWithFormat(date, expected: "1/1/1970, 12:00 AM")
         format = format.minute(.omitted)
-        verifyWithFormat(date, expected: "1/1/1970, 12\(separator)AM")
+        verifyWithFormat(date, expected: "1/1/1970, 12 AM")
         format = format.day(.omitted)
-        verifyWithFormat(date, expected: "1/1970, 12\(separator)AM")
+        verifyWithFormat(date, expected: "1/1970, 12 AM")
 
         format = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
         format = format.day()

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyle.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyle.swift
@@ -294,6 +294,15 @@ final class TestDurationTimeFormatStyle : XCTestCase {
         XCTAssertEqual(Duration(seconds: Int64(seconds), milliseconds: Int64(milliseconds)).formatted(.time(pattern: pattern).locale(enUS)), expected, file: file, line: line)
     }
 
+    @available(FoundationPreview 0.4, *)
+    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, grouping: NumberFormatStyleConfiguration.Grouping?, expected: String, file: StaticString = #file, line: UInt = #line) {
+        var style = Duration.TimeFormatStyle(pattern: pattern).locale(enUS)
+        if let grouping {
+            style.grouping = grouping
+        }
+        XCTAssertEqual(Duration(seconds: Int64(seconds), milliseconds: Int64(milliseconds)).formatted(style), expected, file: file, line: line)
+    }
+
     func testDurationPatternStyle() {
         assertFormattedWithPattern(seconds: 3695, pattern: .hourMinute, expected: "1:02")
         assertFormattedWithPattern(seconds: 3695, pattern: .hourMinute(padHourToLength: 1, roundSeconds: .down), expected: "1:01")
@@ -311,6 +320,13 @@ final class TestDurationTimeFormatStyle : XCTestCase {
         assertFormattedWithPattern(seconds: 3695, pattern: .hourMinuteSecond(padHourToLength: 2), expected: "01:01:35")
         assertFormattedWithPattern(seconds: 3695, pattern: .hourMinuteSecond(padHourToLength: 2, fractionalSecondsLength: 2), expected: "01:01:35.00")
         assertFormattedWithPattern(seconds: 3695, milliseconds: 500, pattern: .hourMinuteSecond(padHourToLength: 2, fractionalSecondsLength: 2), expected: "01:01:35.50")
+    }
+
+    @available(FoundationPreview 0.4, *)
+    func testDurationPatternGrouping() {
+        assertFormattedWithPattern(seconds: 36950000, pattern: .hourMinute(padHourToLength: 2), grouping: nil, expected: "10,263:53")
+        assertFormattedWithPattern(seconds: 36950000, pattern: .hourMinute(padHourToLength: 2), grouping: .automatic, expected: "10,263:53")
+        assertFormattedWithPattern(seconds: 36950000, pattern: .hourMinute(padHourToLength: 2), grouping: .never, expected: "10263:53")
     }
 
     func testNoFractionParts() {

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyle.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyle.swift
@@ -290,12 +290,8 @@ final class DurationToMeasurementAdditionTests : XCTestCase {
 
 final class TestDurationTimeFormatStyle : XCTestCase {
     let enUS = Locale(identifier: "en_US")
-    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, expected: String, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(Duration(seconds: Int64(seconds), milliseconds: Int64(milliseconds)).formatted(.time(pattern: pattern).locale(enUS)), expected, file: file, line: line)
-    }
 
-    @available(FoundationPreview 0.4, *)
-    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, grouping: NumberFormatStyleConfiguration.Grouping?, expected: String, file: StaticString = #file, line: UInt = #line) {
+    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, grouping: NumberFormatStyleConfiguration.Grouping? = nil, expected: String, file: StaticString = #file, line: UInt = #line) {
         var style = Duration.TimeFormatStyle(pattern: pattern).locale(enUS)
         if let grouping {
             style.grouping = grouping
@@ -322,7 +318,6 @@ final class TestDurationTimeFormatStyle : XCTestCase {
         assertFormattedWithPattern(seconds: 3695, milliseconds: 500, pattern: .hourMinuteSecond(padHourToLength: 2, fractionalSecondsLength: 2), expected: "01:01:35.50")
     }
 
-    @available(FoundationPreview 0.4, *)
     func testDurationPatternGrouping() {
         assertFormattedWithPattern(seconds: 36950000, pattern: .hourMinute(padHourToLength: 2), grouping: nil, expected: "10,263:53")
         assertFormattedWithPattern(seconds: 36950000, pattern: .hourMinute(padHourToLength: 2), grouping: .automatic, expected: "10,263:53")


### PR DESCRIPTION
This PR lists all changes proposed in the ["Additional Configuration Properties for Foundation's `FormatStyle` Implementations" proposal](https://github.com/apple/swift-foundation/pull/339), with few exceptions:

1. the proposed changes to `Measurement.AttributedStyle` are not included as that type is not part of Foundation Preview yet
2. a stub for `Date.ComponentsFormatStyle` was added, because it is not part of Foundation Preview yet and `Date.RelativeFormatStyle.Field` is a type alias to `Date.ComponentsFormatStyle.Field`