### PR TITLE
Adjust symbol visibility for CShims

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1159,7 +1159,7 @@ extension JSON5Scanner {
             jsonBytes.formIndex(after: &index)
         }
 
-        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _cshims_strncasecmp_l($0, "0x", $1, nil) })
+        let cmp = jsonBytes[index..<endIndex].prefix(2).withUnsafePointer({ _stringshims_strncasecmp_l($0, "0x", $1, nil) })
         if cmp == 0 {
             jsonBytes.formIndex(&index, offsetBy: 2)
 

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -1183,7 +1183,7 @@ extension Double : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Double? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _cshims_strtod_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtod_l(nptr, &endPtr, nil)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {
@@ -1199,7 +1199,7 @@ extension Float : PrevalidatedJSONNumberBufferConvertible {
     init?(prevalidatedBuffer buffer: BufferView<UInt8>) {
         let decodedValue = buffer.withUnsafePointer { nptr, count -> Float? in
             var endPtr: UnsafeMutablePointer<CChar>? = nil
-            let decodedValue = _cshims_strtof_l(nptr, &endPtr, nil)
+            let decodedValue = _stringshims_strtof_l(nptr, &endPtr, nil)
             if let endPtr, nptr.advanced(by: count) == endPtr {
                 return decodedValue
             } else {

--- a/Sources/_CShims/include/_CShimsMacros.h
+++ b/Sources/_CShims/include/_CShimsMacros.h
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _C_SHIMS_MACROS_H
+#define _C_SHIMS_MACROS_H
+
+#if FOUNDATION_FRAMEWORK
+// This macro prevents the symbol from being exported from the framework, where library evolution is enabled.
+#define INTERNAL __attribute__((__visibility__("hidden")))
+#else
+// This macro makes the symbol available for package users. With library evolution disabled, it is possible for clients to end up referencing these normally-internal symbols.
+#define INTERNAL extern
+#endif
+
+#endif

--- a/Sources/_CShims/include/string_shims.h
+++ b/Sources/_CShims/include/string_shims.h
@@ -13,6 +13,8 @@
 #ifndef CSHIMS_STRING_H
 #define CSHIMS_STRING_H
 
+#include "_CShimsMacros.h"
+
 #if __has_include(<locale.h>)
 #include <locale.h>
 #endif
@@ -30,12 +32,12 @@
 #define locale_t void *
 #endif
 
-int _cshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
+INTERNAL int _stringshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
 
-double _cshims_strtod_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+INTERNAL double _stringshims_strtod_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
 
-float _cshims_strtof_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+INTERNAL float _stringshims_strtof_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
 
-int _cshims_get_formatted_str_length(double value);
+INTERNAL int _stringshims_get_formatted_str_length(double value);
 
 #endif /* CSHIMS_STRING_H */

--- a/Sources/_CShims/include/uuid.h
+++ b/Sources/_CShims/include/uuid.h
@@ -34,6 +34,7 @@
 #define _UUID_UUID_H
 
 #include "_CShimsTargetConditionals.h"
+#include "_CShimsMacros.h"
 
 #if TARGET_OS_MAC
 #include <sys/_types.h>
@@ -60,23 +61,23 @@ typedef __darwin_uuid_string_t    uuid_string_t;
 extern "C" {
 #endif
 
-void uuid_clear(uuid_t uu);
+INTERNAL void uuid_clear(uuid_t uu);
 
-int uuid_compare(const uuid_t uu1, const uuid_t uu2);
+INTERNAL int uuid_compare(const uuid_t uu1, const uuid_t uu2);
 
-void uuid_copy(uuid_t dst, const uuid_t src);
+INTERNAL void uuid_copy(uuid_t dst, const uuid_t src);
 
-void uuid_generate(uuid_t out);
-void uuid_generate_random(uuid_t out);
-void uuid_generate_time(uuid_t out);
+INTERNAL void uuid_generate(uuid_t out);
+INTERNAL void uuid_generate_random(uuid_t out);
+INTERNAL void uuid_generate_time(uuid_t out);
 
-int uuid_is_null(const uuid_t uu);
+INTERNAL int uuid_is_null(const uuid_t uu);
 
-int uuid_parse(const uuid_string_t in, uuid_t uu);
+INTERNAL int uuid_parse(const uuid_string_t in, uuid_t uu);
 
-void uuid_unparse(const uuid_t uu, uuid_string_t out);
-void uuid_unparse_lower(const uuid_t uu, uuid_string_t out);
-void uuid_unparse_upper(const uuid_t uu, uuid_string_t out);
+INTERNAL void uuid_unparse(const uuid_t uu, uuid_string_t out);
+INTERNAL void uuid_unparse_lower(const uuid_t uu, uuid_string_t out);
+INTERNAL void uuid_unparse_upper(const uuid_t uu, uuid_string_t out);
 
 #ifdef __cplusplus
 }

--- a/Sources/_CShims/string_shims.c
+++ b/Sources/_CShims/string_shims.c
@@ -19,15 +19,11 @@
 #include <float.h>
 #include <assert.h>
 
-#if !defined(CF_PRIVATE)
-#define CF_PRIVATE __attribute__((__visibility__("hidden"))) extern
-#endif
-
 #if defined(TARGET_OS_EXCLAVEKIT) && TARGET_OS_EXCLAVEKIT
 #include <strings.h>
 #endif
 
-CF_PRIVATE int _cshims_strncasecmp_l(const char * _Nullable s1,
+int _stringshims_strncasecmp_l(const char * _Nullable s1,
                       const char * _Nullable s2,
                       size_t n,
                       locale_t _Nullable loc)
@@ -61,7 +57,7 @@ CF_PRIVATE int _cshims_strncasecmp_l(const char * _Nullable s1,
 #endif // TARGET_OS_WINDOWS
 }
 
-CF_PRIVATE double _cshims_strtod_l(const char * _Nullable restrict nptr,
+double _stringshims_strtod_l(const char * _Nullable restrict nptr,
                  char * _Nullable * _Nullable restrict endptr,
                  locale_t _Nullable loc)
 {
@@ -83,7 +79,7 @@ CF_PRIVATE double _cshims_strtod_l(const char * _Nullable restrict nptr,
 #endif
 }
 
-CF_PRIVATE float _cshims_strtof_l(const char * _Nullable restrict nptr,
+float _stringshims_strtof_l(const char * _Nullable restrict nptr,
                  char * _Nullable * _Nullable restrict endptr,
                  locale_t _Nullable loc)
 {
@@ -105,7 +101,7 @@ CF_PRIVATE float _cshims_strtof_l(const char * _Nullable restrict nptr,
 #endif
 }
 
-CF_PRIVATE int _cshims_get_formatted_str_length(double value)
+int _stringshims_get_formatted_str_length(double value)
 {
     char empty[1];
     return snprintf(empty, 0, "%0.*g", DBL_DECIMAL_DIG, value);

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -167,7 +167,7 @@ final class JSONEncoderTests : XCTestCase {
 
         func formattedLength(of value: Double) -> Int {
         #if canImport(_CShims)
-            return Int(_cshims_get_formatted_str_length(value))
+            return Int(_stringshims_get_formatted_str_length(value))
         #else
             let empty = UnsafeMutablePointer<Int8>.allocate(capacity: 0)
             defer { empty.deallocate() }


### PR DESCRIPTION
Make sure that CShim functions are (a) hidden in framework mode, because external clients don't use them and (b) exported in package mode, because external clients may end up calling them.