### PR TITLE
Fix remaining FormatStyle caches of autoupdating locales

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -166,7 +166,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
                 }
 
                 let configuration = DescriptiveNumberFormatConfiguration.Collection(presentation: .cardinal, capitalizationContext: .beginningOfSentence)
-                let spellOutFormatter = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: .descriptive(configuration), locale: locale)
+                let spellOutFormatter = ICULegacyNumberFormatter.formatter(for: .descriptive(configuration), locale: locale)
 
                 guard let zeroFormatted = spellOutFormatter.format(Int64.zero) else {
                     return attributedFormat

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+IntervalFormatStyle.swift
@@ -26,6 +26,9 @@ extension Date {
         public var timeZone: TimeZone
         public var calendar: Calendar
 
+        // Internal
+        internal var symbols =  Date.FormatStyle.DateFieldCollection()
+
         /// Creates a new `FormatStyle` with the given configurations.
         /// - Parameters:
         ///   - date: The style for formatting the date part of the given date pairs. Note that if `.omitted` is specified, but the date interval spans more than one day, a locale-specific fallback will be used.
@@ -53,19 +56,7 @@ extension Date {
         // MARK: - FormatStyle conformance
 
         public func format(_ v: Range<Date>) -> String {
-            let formatter = Self.cache.formatter(for: self) {
-                var template = symbols.formatterTemplate(overridingDayPeriodWithLocale: locale)
-
-                if template.isEmpty {
-                    let defaultSymbols = Date.FormatStyle.DateFieldCollection()
-                        .collection(date: .numeric)
-                        .collection(time: .shortened)
-                    template = defaultSymbols.formatterTemplate(overridingDayPeriodWithLocale: locale)
-                }
-
-                return ICUDateIntervalFormatter(locale: locale, calendar: calendar, timeZone: timeZone, dateTemplate: template)
-            }
-            return formatter.string(from: v)
+            ICUDateIntervalFormatter.formatter(for: self).string(from: v)
         }
 
         public func locale(_ locale: Locale) -> Self {
@@ -73,10 +64,6 @@ extension Date {
             new.locale = locale
             return new
         }
-
-        // Internal
-        private var symbols =  Date.FormatStyle.DateFieldCollection()
-        private static let cache = FormatterCache<Self, ICUDateIntervalFormatter>()
     }
 }
 

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -132,7 +132,7 @@ extension Date {
             }
 
             let (component, value) = _largestNonZeroComponent(destDate, reference: refDate, adjustComponent: strategy)
-            return ICURelativeDateFormatter.formatterCreateIfNeeded(format: self).format(value: value, component: component, presentation: self.presentation)!
+            return ICURelativeDateFormatter.formatter(for: self).format(value: value, component: component, presentation: self.presentation)!
         }
 
 

--- a/Sources/FoundationInternationalization/Formatting/ListFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ListFormatStyle.swift
@@ -29,7 +29,7 @@ public struct ListFormatStyle<Style: FormatStyle, Base: Sequence>: FormatStyle w
     }
 
     public func format(_ value: Base) -> String {
-        let formatter = ICUListFormatter.formatterCreateIfNeeded(format: self)
+        let formatter = ICUListFormatter.formatter(for: self)
         return formatter.format(strings: value.map(memberStyle.format(_:)))
     }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -62,7 +62,7 @@ extension Decimal.ParseStrategy {
             locale = .autoupdatingCurrent
         }
 
-        let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
+        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         guard let value = parser.parseAsDecimal(substr, upperBound: &upperBound) else {

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -29,7 +29,7 @@ extension FloatingPointParseStrategy : Sendable where Format : Sendable {}
 extension FloatingPointParseStrategy: ParseStrategy {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
-        let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
+        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
         if let v = parser.parseAsDouble(value._trimmingWhitespace()) {
             return Format.FormatInput(v)
         } else {
@@ -51,7 +51,7 @@ extension FloatingPointParseStrategy: ParseStrategy {
             return nil
         }
 
-        let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
+        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         if let value = parser.parseAsDouble(substr, upperBound: &upperBound) {

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -28,7 +28,7 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerParseStrategy: ParseStrategy {
     public func parse(_ value: String) throws -> Format.FormatInput {
-        let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
+        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
         let trimmedString = value._trimmingWhitespace()
         if let v = parser.parseAsInt(trimmedString) {
             return Format.FormatInput(v)
@@ -52,7 +52,7 @@ extension IntegerParseStrategy: ParseStrategy {
             return nil
         }
 
-        let parser = ICULegacyNumberFormatter.numberFormatterCreateIfNeeded(type: numberFormatType, locale: locale, lenient: lenient)
+        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         if let value = parser.parseAsInt(substr, upperBound: &upperBound) {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -204,4 +204,27 @@ final class DateIntervalFormatStyleTests: XCTestCase {
         }
     }
 
+    func testAutoupdatingCurrentChangesFormatResults() {
+        let locale = Locale.autoupdatingCurrent
+        let range = Date.now..<(Date.now + 3600)
+        
+        // Get a formatted result from es-ES
+        var prefs = LocalePreferences()
+        prefs.languages = ["es-ES"]
+        prefs.locale = "es_ES"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedSpanish = range.formatted(.interval.locale(locale))
+        
+        // Get a formatted result from en-US
+        prefs.languages = ["en-US"]
+        prefs.locale = "en_US"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedEnglish = range.formatted(.interval.locale(locale))
+        
+        // Reset to current preferences before any possibility of failing this test
+        LocaleCache.cache.reset()
+
+        // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
+        XCTAssertNotEqual(formattedSpanish, formattedEnglish)
+    }
 }

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -303,4 +303,28 @@ final class DateRelativeFormatStyleTests: XCTestCase {
         _verifyStyle(725759999.0, relativeTo: 645019200.0, expected: "in 2 years")
 
     }
+    
+    func testAutoupdatingCurrentChangesFormatResults() {
+        let locale = Locale.autoupdatingCurrent
+        let date = Date.now + 3600
+        
+        // Get a formatted result from es-ES
+        var prefs = LocalePreferences()
+        prefs.languages = ["es-ES"]
+        prefs.locale = "es_ES"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedSpanish = date.formatted(.relative(presentation: .named).locale(locale))
+        
+        // Get a formatted result from en-US
+        prefs.languages = ["en-US"]
+        prefs.locale = "en_US"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedEnglish = date.formatted(.relative(presentation: .named).locale(locale))
+        
+        // Reset to current preferences before any possibility of failing this test
+        LocaleCache.cache.reset()
+
+        // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
+        XCTAssertNotEqual(formattedSpanish, formattedEnglish)
+    }
 }

--- a/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ListFormatStyleTests.swift
@@ -14,6 +14,15 @@
 import TestSupport
 #endif
 
+#if canImport(FoundationInternationalization)
+@testable import FoundationEssentials
+@testable import FoundationInternationalization
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#endif
+
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 class ListFormatStyleTests : XCTestCase {
     func test_orList() {
@@ -55,4 +64,28 @@ class ListFormatStyleTests : XCTestCase {
         let _ = [1, 2].formatted(.list(memberStyle: .number, type: .or, width: .standard))
     }
 #endif
+    
+    func testAutoupdatingCurrentChangesFormatResults() {
+        let locale = Locale.autoupdatingCurrent
+        let list = ["one", "two", "three", "four"]
+        
+        // Get a formatted result from es-ES
+        var prefs = LocalePreferences()
+        prefs.languages = ["es-ES"]
+        prefs.locale = "es_ES"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedSpanish = list.formatted(.list(type: .and).locale(locale))
+        
+        // Get a formatted result from en-US
+        prefs.languages = ["en-US"]
+        prefs.locale = "en_US"
+        LocaleCache.cache.resetCurrent(to: prefs)
+        let formattedEnglish = list.formatted(.list(type: .and).locale(locale))
+        
+        // Reset to current preferences before any possibility of failing this test
+        LocaleCache.cache.reset()
+
+        // No matter what 'current' was before this test was run, formattedSpanish and formattedEnglish should be different.
+        XCTAssertNotEqual(formattedSpanish, formattedEnglish)
+    }
 }


### PR DESCRIPTION
Fix up remaining issues where we cache a `Locale` for format styles, and an autoupdating locale will not cause a refreshed format.

Follows up on 18ac5ac (#334 )

Fixes rdar://119010483