### PR TITLE
Support combining Predicates

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -348,6 +348,7 @@ extension PredicateCodableConfiguration {
         configuration.allowPartialType(Set<Int>.self, identifier: "Swift.Set")
         configuration.allowPartialType(Optional<Int>.self, identifier: "Swift.Optional")
         configuration.allowPartialType(Slice<String>.self, identifier: "Swift.Slice")
+        configuration.allowPartialType(Predicate<Int>.self, identifier: "Foundation.Predicate")
         
         // Foundation-defined PredicateExpression types
         configuration.allowPartialType(PredicateExpressions.Arithmetic<PredicateExpressions.Value<Int>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.Arithmetic")
@@ -383,6 +384,7 @@ extension PredicateCodableConfiguration {
         configuration.allowPartialType(PredicateExpressions.TypeCheck<PredicateExpressions.Value<Int>, Int>.self, identifier: "PredicateExpressions.TypeCheck")
         configuration.allowPartialType(PredicateExpressions.UnaryMinus<PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.UnaryMinus")
         configuration.allowPartialType(PredicateExpressions.NilLiteral<Int>.self, identifier: "PredicateExpressions.NilLiteral")
+        configuration.allowPartialType(PredicateExpressions.PredicateEvaluate<PredicateExpressions.Value<Predicate<Int>>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.PredicateEvaluate")
         
         #if FOUNDATION_FRAMEWORK
         configuration.allowPartialType(PredicateExpressions.StringCaseInsensitiveCompare<PredicateExpressions.Value<String>, PredicateExpressions.Value<String>>.self, identifier: "PredicateExpressions.StringCaseInsensitiveCompare")

--- a/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+extension PredicateExpressions {
+    @available(FoundationPreview 0.3, *)
+    public struct PredicateEvaluate<
+        Condition : PredicateExpression,
+        each Input : PredicateExpression
+    > : PredicateExpression
+    where
+        Condition.Output == Predicate<repeat (each Input).Output>
+    {
+        
+        public typealias Output = Bool
+        
+        public let predicate: Condition
+        public let input: (repeat each Input)
+        
+        public init(predicate: Condition, input: repeat each Input) {
+            self.predicate = predicate
+            self.input = (repeat each input)
+        }
+        
+        public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+            try predicate.evaluate(bindings).evaluate(repeat try (each input).evaluate(bindings))
+        }
+    }
+    
+    @available(FoundationPreview 0.3, *)
+    public static func build_evaluate<Condition, each Input>(_ predicate: Condition, _ input: repeat each Input) -> PredicateEvaluate<Condition, repeat each Input> {
+        PredicateEvaluate<Condition, repeat each Input>(predicate: predicate, input: repeat each input)
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.PredicateEvaluate : CustomStringConvertible {
+    public var description: String {
+        "PredicateEvaluate(predicate: \(predicate), input: \(input))"
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.PredicateEvaluate : StandardPredicateExpression where Condition : StandardPredicateExpression, repeat each Input : StandardPredicateExpression {}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.PredicateEvaluate : Codable where Condition : Codable, repeat each Input : Codable {
+    public func encode(to encoder: Encoder) throws {
+        throw EncodingError.invalidValue(self, EncodingError.Context(codingPath: encoder.codingPath, debugDescription: "Encoding the PredicateEvaluate operator is not yet supported"))
+    }
+    
+    public init(from decoder: Decoder) throws {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Decoding the PredicateEvaluate operator is not yet supported"))
+    }
+}
+
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.PredicateEvaluate : Sendable where Condition : Sendable, repeat each Input : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/PredicateEvaluation.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 extension PredicateExpressions {
     @available(FoundationPreview 0.3, *)
@@ -65,3 +66,4 @@ extension PredicateExpressions.PredicateEvaluate : Codable where Condition : Cod
 
 @available(FoundationPreview 0.3, *)
 extension PredicateExpressions.PredicateEvaluate : Sendable where Condition : Sendable, repeat each Input : Sendable {}
+#endif

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -379,6 +379,15 @@ extension PredicateExpressions.Filter : DebugStringConvertiblePredicateExpressio
     }
 }
 
+@available(FoundationPreview 0.3, *)
+extension PredicateExpressions.PredicateEvaluate : DebugStringConvertiblePredicateExpression where Condition : DebugStringConvertiblePredicateExpression, repeat each Input : DebugStringConvertiblePredicateExpression {
+    package func debugString(state: inout DebugStringConversionState) -> String {
+        var inputStrings: [String] = []
+        repeat inputStrings.append((each input).debugString(state: &state))
+        return "\(predicate.debugString(state: &state)).evaluate(\(inputStrings.joined(separator: ", ")))"
+    }
+}
+
 #if FOUNDATION_FRAMEWORK
 
 @available(FoundationPreview 0.3, *)

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -379,6 +379,8 @@ extension PredicateExpressions.Filter : DebugStringConvertiblePredicateExpressio
     }
 }
 
+#if FOUNDATION_FRAMEWORK
+
 @available(FoundationPreview 0.3, *)
 extension PredicateExpressions.PredicateEvaluate : DebugStringConvertiblePredicateExpression where Condition : DebugStringConvertiblePredicateExpression, repeat each Input : DebugStringConvertiblePredicateExpression {
     package func debugString(state: inout DebugStringConversionState) -> String {
@@ -387,8 +389,6 @@ extension PredicateExpressions.PredicateEvaluate : DebugStringConvertiblePredica
         return "\(predicate.debugString(state: &state)).evaluate(\(inputStrings.joined(separator: ", ")))"
     }
 }
-
-#if FOUNDATION_FRAMEWORK
 
 @available(FoundationPreview 0.3, *)
 extension PredicateExpressions.StringCaseInsensitiveCompare : DebugStringConvertiblePredicateExpression where Root : DebugStringConvertiblePredicateExpression, Other : DebugStringConvertiblePredicateExpression {

--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -24,7 +24,7 @@ package import SwiftSyntaxBuilder
 // A list of all functions supported by Predicate itself, any other functions called will be diagnosed as an error
 // This allows for checking the function name, the number of arguments, and the argument labels, but the types of the arguments will need to be validated by the post-expansion type checking pass
 // The trailingClosure parameter indicates whether the final argument is a closure and therefore supports dropping the final argument label in favor of a trailing closure
-private let knownSupportedFunctions: Set<FunctionStructure> = [
+private var _knownSupportedFunctions: Set<FunctionStructure> = [
     FunctionStructure("contains", arguments: [.unlabeled]),
     FunctionStructure("contains", arguments: [.closure(labeled: "where")]),
     FunctionStructure("allSatisfy", arguments: [.closure(labeled: nil)]),
@@ -37,9 +37,18 @@ private let knownSupportedFunctions: Set<FunctionStructure> = [
     FunctionStructure("max", arguments: []),
     FunctionStructure("localizedStandardContains", arguments: [.unlabeled]),
     FunctionStructure("localizedCompare", arguments: [.unlabeled]),
-    FunctionStructure("caseInsensitiveCompare", arguments: [.unlabeled]),
-    FunctionStructure("evaluate", arguments: [.pack(labeled: nil)])
+    FunctionStructure("caseInsensitiveCompare", arguments: [.unlabeled])
 ]
+
+private var knownSupportedFunctions: Set<FunctionStructure> {
+    #if FOUNDATION_FRAMEWORK
+    var result = _knownSupportedFunctions
+    result.insert(FunctionStructure("evaluate", arguments: [.pack(labeled: nil)]))
+    return result
+    #else
+    _knownSupportedFunctions
+    #endif
+}
 
 private let supportedFunctionSuggestions: [FunctionStructure : FunctionStructure] = [
     FunctionStructure("hasPrefix", arguments: [.unlabeled]) : FunctionStructure("starts", arguments: ["with"]),

--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -37,7 +37,8 @@ private let knownSupportedFunctions: Set<FunctionStructure> = [
     FunctionStructure("max", arguments: []),
     FunctionStructure("localizedStandardContains", arguments: [.unlabeled]),
     FunctionStructure("localizedCompare", arguments: [.unlabeled]),
-    FunctionStructure("caseInsensitiveCompare", arguments: [.unlabeled])
+    FunctionStructure("caseInsensitiveCompare", arguments: [.unlabeled]),
+    FunctionStructure("evaluate", arguments: [.pack(labeled: nil)])
 ]
 
 private let supportedFunctionSuggestions: [FunctionStructure : FunctionStructure] = [
@@ -47,6 +48,47 @@ private let supportedFunctionSuggestions: [FunctionStructure : FunctionStructure
     FunctionStructure("localizedStandardCompare", arguments: [.unlabeled]) : FunctionStructure("localizedCompare", arguments: [.unlabeled])
 ]
 
+extension Array where Element == FunctionStructure.Argument {
+    fileprivate func argumentsEqual(_ other: Self) -> Bool {
+        let currentPackIndex = self.firstIndex { $0.kind == .pack }
+        let otherPackIndex = other.firstIndex { $0.kind == .pack }
+
+        var full: [FunctionStructure.Argument]
+        var prefix: ArraySlice<FunctionStructure.Argument>
+        var suffix: ArraySlice<FunctionStructure.Argument>
+        switch (currentPackIndex, otherPackIndex) {
+        // If neither contains a pack or both contain a pack, just compare arguments as-is
+        case (nil, nil), (.some(_), .some(_)):
+            return self == other
+
+        // If one of them contains a pack, compare the prefix and suffix to allow the pack to lazily consume multiple arguments
+        case (let .some(idx), nil):
+            full = other
+            prefix = self[..<idx]
+            suffix = self[self.index(after: idx)...]
+        case (nil, let .some(idx)):
+            full = self
+            prefix = other[..<idx]
+            suffix = other[other.index(after: idx)...]
+        }
+        return full.starts(with: prefix) && full.reversed().starts(with: suffix.reversed())
+    }
+
+    fileprivate func expandingPackToMatchCount(_ otherCount: Int) -> Self {
+        let countDifference = otherCount - self.count
+        guard countDifference >= 0, let packIdx = self.firstIndex(where: { $0.kind == .pack }) else {
+            return self
+        }
+
+        var copy = self
+        copy[packIdx] = .init(label: copy[packIdx].label, kind: .standard)
+        if countDifference > 0 {
+            copy.insert(contentsOf: Array(repeating: .unlabeled, count: countDifference), at: packIdx + 1)
+        }
+        return copy
+    }
+}
+
 #if FOUNDATION_FRAMEWORK
 private let moduleName = "Foundation"
 #else
@@ -55,25 +97,35 @@ private let moduleName = "FoundationEssentials"
 
 private struct FunctionStructure: Hashable {
     struct Argument : Hashable, ExpressibleByStringLiteral {
+        enum Kind : Hashable {
+            case standard
+            case closure
+            case pack
+        }
+        
         let label: String?
-        let isClosure: Bool
+        let kind: Kind
         
         init(stringLiteral: String) {
             label = stringLiteral
-            isClosure = false
+            kind = .standard
         }
         
-        init(label: String?, closure: Bool) {
+        init(label: String?, kind: Kind) {
             self.label = label
-            self.isClosure = closure
+            self.kind = kind
         }
         
         static func closure(labeled label: String?) -> Self {
-            Self(label: label, closure: true)
+            Self(label: label, kind: .closure)
         }
         
         static var unlabeled: Self {
-            Self(label: nil, closure: false)
+            Self(label: nil, kind: .standard)
+        }
+            
+        static func pack(labeled label: String?) -> Self {
+            Self(label: label, kind: .pack)
         }
         
         static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -85,7 +137,7 @@ private struct FunctionStructure: Hashable {
     let hasTrailingClosure: Bool
     
     var supportsTrailingClosure: Bool {
-        hasTrailingClosure || (arguments.last?.isClosure ?? false)
+        hasTrailingClosure || arguments.last?.kind == .closure
     }
     
     var signature: String {
@@ -104,13 +156,13 @@ private struct FunctionStructure: Hashable {
         
         switch (self.hasTrailingClosure, other.hasTrailingClosure) {
         case (true, true), (false, false):
-            return self.arguments == other.arguments
+            return self.arguments.argumentsEqual(other.arguments)
         case (true, false):
             guard let otherLast = other.arguments.last else { return false }
-            return self.arguments == other.arguments.dropLast() && otherLast.isClosure
+            return self.arguments.argumentsEqual(other.arguments.dropLast()) && otherLast.kind == .closure
         case (false, true):
             guard let last = self.arguments.last else { return false }
-            return self.arguments.dropLast() == other.arguments && last.isClosure
+            return self.arguments.dropLast().argumentsEqual(other.arguments) && last.kind == .closure
         }
     }
     
@@ -676,7 +728,8 @@ private class PredicateQueryRewriter: SyntaxRewriter, PredicateSyntaxRewriter {
         // Check this function against our known list to provide rich diagnostics for functions we know we don't support
         let name = TokenSyntax(.identifier(functionName), presence: .present).with(\.leadingTrivia, []).with(\.trailingTrivia, [])
         let args = argumentList.map {
-            FunctionStructure.Argument(label: $0.label?.text, closure: $0.expression.is(ClosureExprSyntax.self) || $0.expression.is(KeyPathExprSyntax.self))
+            let isClosure = $0.expression.is(ClosureExprSyntax.self) || $0.expression.is(KeyPathExprSyntax.self)
+            return FunctionStructure.Argument(label: $0.label?.text, kind: isClosure ? .closure : .standard)
         }
         let structure = FunctionStructure(name.text, arguments: args, trailingClosure: trailingClosure != nil)
         guard let knownFunc = _knownMatchingFunction(structure) else {
@@ -707,9 +760,9 @@ private class PredicateQueryRewriter: SyntaxRewriter, PredicateSyntaxRewriter {
         addArgument(base, label: nil, withComma: !argumentList.isEmpty)
         validOptionalChainingTree = oldValidOptionalChainingTree
         
-        for (sourceArg, knownArgStructure) in zip(argumentList, knownFunc.arguments) {
+        for (sourceArg, knownArgStructure) in zip(argumentList, knownFunc.arguments.expandingPackToMatchCount(argumentList.count)) {
             var expression = sourceArg.expression
-            if knownArgStructure.isClosure, let kpExpr = sourceArg.expression.as(KeyPathExprSyntax.self) {
+            if knownArgStructure.kind == .closure, let kpExpr = sourceArg.expression.as(KeyPathExprSyntax.self) {
                 guard !kpExpr.containsShorthandArgumentIdentifiers,
                       let memberAccess = kpExpr.asDirectExpression(on: DeclReferenceExprSyntax(baseName: .dollarIdentifier("$0"))),
                       let preparedMemberAccess = try? memberAccess.rewrite(with: OptionalChainRewriter()) else {

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -387,6 +387,39 @@ final class NSPredicateConversionTests: XCTestCase {
         XCTAssertEqual(converted, NSPredicate(format: "b CONTAINS[cdl] 'ABC'"))
         XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
     }
+    
+    func testNested() {
+        let predicateA = Predicate<ObjCObject> {
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.a
+                ),
+                rhs: PredicateExpressions.build_Arg(3)
+            )
+        }
+        
+        let predicateB = Predicate<ObjCObject> {
+            PredicateExpressions.build_Conjunction(
+                lhs: PredicateExpressions.build_evaluate(
+                    PredicateExpressions.build_Arg(predicateA),
+                    PredicateExpressions.build_Arg($0)
+                ),
+                rhs: PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.a
+                    ),
+                    rhs: PredicateExpressions.build_Arg(2),
+                    op: .greaterThan
+                )
+            )
+        }
+        
+        let converted = convert(predicateB)
+        XCTAssertEqual(converted, NSPredicate(format: "a == 3 AND a > 2"))
+        XCTAssertFalse(converted!.evaluate(with: ObjCObject()))
+    }
 }
 
 #endif

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -378,4 +378,39 @@ final class PredicateTests: XCTestCase {
             "\(moduleName).Predicate<Pack{\(testModuleName).PredicateTests.Object}>(variable: (Variable(#)), expression: NilCoalesce(lhs: OptionalFlatMap(wrapped: ConditionalCast(input: KeyPath(root: Variable(#), keyPath: \\Object.i), desiredType: Swift.Int), variable: Variable(#), transform: Equal(lhs: Variable(#), rhs: Value<Swift.Int>(3))), rhs: Equal(lhs: KeyPath(root: Variable(#), keyPath: \\Object.h), rhs: Value<\(moduleName).Date>(\(date.debugDescription)))))"
         )
     }
+
+    func testNested() {
+        let predicateA = Predicate<Object> {
+            PredicateExpressions.build_Equal(
+                lhs: PredicateExpressions.build_KeyPath(
+                    root: PredicateExpressions.build_Arg($0),
+                    keyPath: \.a
+                ),
+                rhs: PredicateExpressions.build_Arg(3)
+            )
+        }
+        
+        let predicateB = Predicate<Object> {
+            PredicateExpressions.build_Conjunction(
+                lhs: PredicateExpressions.build_evaluate(
+                    PredicateExpressions.build_Arg(predicateA),
+                    PredicateExpressions.build_Arg($0)
+                ),
+                rhs: PredicateExpressions.build_Comparison(
+                    lhs: PredicateExpressions.build_KeyPath(
+                        root: PredicateExpressions.build_Arg($0),
+                        keyPath: \.a
+                    ),
+                    rhs: PredicateExpressions.build_Arg(2),
+                    op: .greaterThan
+                )
+            )
+        }
+        
+        XCTAssertTrue(try predicateA.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertFalse(try predicateA.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertTrue(try predicateB.evaluate(Object(a: 3, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertFalse(try predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+        XCTAssertFalse(try predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
+    }
 }

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -380,7 +380,7 @@ final class PredicateTests: XCTestCase {
     }
 
     #if FOUNDATION_FRAMEWORK
-    func testNested() {
+    func testNested() throws {
         guard #available(FoundationPreview 0.3, *) else {
             throw XCTSkip("This test is not available on this OS version")
         }

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -379,7 +379,12 @@ final class PredicateTests: XCTestCase {
         )
     }
 
+    #if FOUNDATION_FRAMEWORK
     func testNested() {
+        guard #available(FoundationPreview 0.3, *) else {
+            throw XCTSkip("This test is not available on this OS version")
+        }
+        
         let predicateA = Predicate<Object> {
             PredicateExpressions.build_Equal(
                 lhs: PredicateExpressions.build_KeyPath(
@@ -413,4 +418,5 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
         XCTAssertFalse(try predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
     }
+    #endif
 }

--- a/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
@@ -534,6 +534,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
+    #if FOUNDATION_FRAMEWORK
     func testEvaluate() {
         AssertPredicateExpansion(
             """
@@ -581,6 +582,7 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
             """
         )
     }
+    #endif
     
     func testDiagnoseUnsupportedFunction() {
         AssertPredicateExpansion(

--- a/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
+++ b/Tests/FoundationMacrosTests/PredicateMacroFunctionCallTests.swift
@@ -534,6 +534,54 @@ final class PredicateMacroFunctionCallTests: XCTestCase {
         )
     }
     
+    func testEvaluate() {
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { input in
+                other.evaluate()
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ input in
+                PredicateExpressions.build_evaluate(
+                    PredicateExpressions.build_Arg(other)
+                )
+            })
+            """
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { input in
+                other.evaluate(input)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ input in
+                PredicateExpressions.build_evaluate(
+                    PredicateExpressions.build_Arg(other),
+                    PredicateExpressions.build_Arg(input)
+                )
+            })
+            """
+        )
+        AssertPredicateExpansion(
+            """
+            #Predicate<String> { input in
+                other.evaluate(input, input)
+            }
+            """,
+            """
+            \(foundationModuleName).Predicate<String>({ input in
+                PredicateExpressions.build_evaluate(
+                    PredicateExpressions.build_Arg(other),
+                    PredicateExpressions.build_Arg(input),
+                    PredicateExpressions.build_Arg(input)
+                )
+            })
+            """
+        )
+    }
+    
     func testDiagnoseUnsupportedFunction() {
         AssertPredicateExpansion(
             """


### PR DESCRIPTION
This PR adds support for combining predicates together to form compound predicates. Predicates can be combined like the following:

```swift
let predicateA: Predicate<String>
let predicateB: Predicate<Int>

let predicateC = #Predicate<String, Int> {
    predicateA.evaluate($0) && predicateB.evaluate($1)
}
```

This creates a compound `predicateC` which only evaluates to true when `predicateA` evaluates to true given the first input, and `predicateB` evaluates to true given the second input.