### PR TITLE
Add RangeExpressionContains to the standard PredicateCodableConfiguration

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -352,6 +352,7 @@ extension PredicateCodableConfiguration {
         // Foundation-defined PredicateExpression types
         configuration.allowPartialType(PredicateExpressions.Arithmetic<PredicateExpressions.Value<Int>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.Arithmetic")
         configuration.allowPartialType(PredicateExpressions.ClosedRange<PredicateExpressions.Value<Int>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.ClosedRange")
+        configuration.allowPartialType(PredicateExpressions.RangeExpressionContains<PredicateExpressions.Value<Range<Int>>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.RangeExpressionContains")
         configuration.allowPartialType(PredicateExpressions.CollectionContainsCollection<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<[Int]>>.self, identifier: "PredicateExpressions.CollectionContainsCollection")
         configuration.allowPartialType(PredicateExpressions.CollectionIndexSubscript<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<Int>>.self, identifier: "PredicateExpressions.CollectionIndexSubscript")
         configuration.allowPartialType(PredicateExpressions.CollectionRangeSubscript<PredicateExpressions.Value<[Int]>, PredicateExpressions.Value<Range<Int>>>.self, identifier: "PredicateExpressions.CollectionRangeSubscript")

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -331,6 +331,12 @@ final class PredicateCodableTests: XCTestCase {
         }
         decoded4 = try _encodeDecode(predicate4)
         XCTAssertEqual(try decoded4.evaluate(["A": 1, "B": 2, "C": 3]), try predicate4.evaluate(["A": 1, "B": 2, "C": 3]))
+        
+        let predicate5 = #Predicate<Int> {
+            (0 ..< 4).contains($0)
+        }
+        let decoded5 = try _encodeDecode(predicate5)
+        XCTAssertEqual(try decoded5.evaluate(2), try predicate5.evaluate(2))
     }
     
     func testMalformedData() {


### PR DESCRIPTION
It looks like we missed an expression type in the standard configuration. This adds it to allow for encoding/decoding with predicates that contain these expressions without requiring it to be manually allowed.

Resolves #344 