### PR TITLE
Improved big-number formatting

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -152,9 +152,9 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
             return false
         }
 
-        func _format(_ value: ICUNumberFormatter.Value) -> AttributedString {
+        public func format(_ value: Int64) -> AttributedString {
             let unit: Unit = allowedUnits.contains(.kb) ? .kilobyte : .byte
-            if spellsOutZero && value.isZero {
+            if spellsOutZero && value == .zero {
                 let numberFormatter = ICUByteCountNumberFormatter.create(for: "measure-unit/digital-\(unit.name)\(unit == .byte ? " unit-width-full-name" : "")", locale: locale)
                 guard var attributedFormat = numberFormatter?.attributedFormat(.integer(.zero), unit: unit) else {
                     // fallback to English if ICU formatting fails
@@ -192,7 +192,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
                 maxSizes = Self.maxBinarySizes
             }
 
-            let absValue = abs(value.doubleValue)
+            let absValue = abs(Double(value))
             let bestUnit: Unit = {
                 var bestUnit = allowedUnits.smallestUnit
                 for (idx, size) in maxSizes.enumerated() {
@@ -209,7 +209,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
             }()
 
             let denominator = decimal ? bestUnit.decimalSize : bestUnit.binarySize
-            let unitValue = value.doubleValue/Double(denominator)
+            let unitValue = Double(value)/Double(denominator)
 
             let precisionSkeleton: String
             switch bestUnit {
@@ -231,7 +231,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
                 let localizedParens = localizedParens(locale: locale)
                 attributedString.append(AttributedString(localizedParens.0))
 
-                var attributedBytes = byteFormatter!.attributedFormat(value, unit: .byte)
+                var attributedBytes = byteFormatter!.attributedFormat(.integer(value), unit: .byte)
                 for (value, range) in attributedBytes.runs[\.byteCount] where value == .value {
                     attributedBytes[range].byteCount = .actualByteCount
                 }
@@ -242,13 +242,7 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
 
             return attributedString
         }
-
-
-        public func format(_ value: Int64) -> AttributedString {
-            _format(.integer(value))
-        }
     }
-
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryFloatingPoint+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryFloatingPoint+FormatStyle.swift
@@ -19,7 +19,7 @@ extension BinaryFloatingPoint {
 
     /// Format `self` with `FloatingPointFormatStyle()`.
     public func formatted() -> String {
-        FloatingPointFormatStyle().format(Double(self))
+        FloatingPointFormatStyle().format(self)
     }
 
     /// Format `self` with the given format.

--- a/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/BinaryInteger+FormatStyle.swift
@@ -25,7 +25,7 @@ extension BinaryInteger {
 
     /// Format `self` using `IntegerFormatStyle()`
     public func formatted() -> String {
-        IntegerFormatStyle().format(Int(self))
+        IntegerFormatStyle().format(self)
     }
 
     /// Format `self` with the given format.

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -68,6 +68,7 @@ internal class ICUNumberFormatterBase {
         case integer(Int64)
         case floatingPoint(Double)
         case decimal(Decimal)
+        case numericStringRepresentation(String)
 
         var isZero: Bool {
             switch self {
@@ -77,6 +78,8 @@ internal class ICUNumberFormatterBase {
                 return num == 0
             case .decimal(let num):
                 return num == 0
+            case .numericStringRepresentation(let num):
+                return num == "0"
             }
         }
 
@@ -88,6 +91,8 @@ internal class ICUNumberFormatterBase {
                 return num
             case .decimal(let num):
                 return num.doubleValue
+            case .numericStringRepresentation(let num):
+                return Double(num)!
             }
         }
 
@@ -96,6 +101,7 @@ internal class ICUNumberFormatterBase {
             case .integer(let i): return String(i)
             case .floatingPoint(let d): return String(d)
             case .decimal(let d): return d.description
+            case .numericStringRepresentation(let i): return i
             }
         }
     }
@@ -137,6 +143,8 @@ internal class ICUNumberFormatterBase {
         case .floatingPoint(let v):
             result = try? FormatResult(formatter: uformatter, value: v)
         case .decimal(let v):
+            result = try? FormatResult(formatter: uformatter, value: v)
+        case .numericStringRepresentation(let v):
             result = try? FormatResult(formatter: uformatter, value: v)
         }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -79,7 +79,7 @@ internal class ICUNumberFormatterBase {
             case .decimal(let num):
                 return num == 0
             case .numericStringRepresentation(let num):
-                return num == "0"
+                return Double(num)!.isZero
             }
         }
 

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -70,32 +70,6 @@ internal class ICUNumberFormatterBase {
         case decimal(Decimal)
         case numericStringRepresentation(String)
 
-        var isZero: Bool {
-            switch self {
-            case .integer(let num):
-                return num == 0
-            case .floatingPoint(let num):
-                return num == 0
-            case .decimal(let num):
-                return num == 0
-            case .numericStringRepresentation(let num):
-                return Double(num)!.isZero
-            }
-        }
-
-        var doubleValue: Double {
-            switch self {
-            case .integer(let num):
-                return Double(num)
-            case .floatingPoint(let num):
-                return num
-            case .decimal(let num):
-                return num.doubleValue
-            case .numericStringRepresentation(let num):
-                return Double(num)!
-            }
-        }
-
         var fallbackDescription: String {
             switch self {
             case .integer(let i): return String(i)

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -218,8 +218,6 @@ extension IntegerFormatStyle : FormatStyle {
             // Formatting Int64 is the fastest option -- try that first.
             if let i = Int64(exactly: value) {
                 str = nf.format(i)
-            } else if let decimal = Decimal(exactly: value) {
-                str = nf.format(decimal)
             } else {
                 str = nf.format(value.numericStringRepresentation)
             }
@@ -250,8 +248,6 @@ extension IntegerFormatStyle.Percent : FormatStyle {
             // Formatting Int64 is the fastest option -- try that first.
             if let i = Int64(exactly: value) {
                 str = nf.format(i)
-            } else if let decimal = Decimal(exactly: value) {
-                str = nf.format(decimal)
             } else {
                 str = nf.format(value.numericStringRepresentation)
             }
@@ -282,8 +278,6 @@ extension IntegerFormatStyle.Currency : FormatStyle {
             // Formatting Int64 is the fastest option -- try that first.
             if let i = Int64(exactly: value) {
                 str = nf.format(i)
-            } else if let decimal = Decimal(exactly: value) {
-                str = nf.format(decimal)
             } else {
                 str = nf.format(value.numericStringRepresentation)
             }
@@ -511,8 +505,6 @@ extension IntegerFormatStyle {
             let numberValue: ICUNumberFormatterBase.Value
             if let i = Int64(exactly: value) {
                 numberValue = .integer(i)
-            } else if let decimal = Decimal(exactly: value) {
-                numberValue = .decimal(decimal)
             } else {
                 numberValue = .numericStringRepresentation(value.numericStringRepresentation)
             }

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerFormatStyle.swift
@@ -514,7 +514,7 @@ extension IntegerFormatStyle {
             } else if let decimal = Decimal(exactly: value) {
                 numberValue = .decimal(decimal)
             } else {
-                numberValue = .integer(Int64(clamping: value))
+                numberValue = .numericStringRepresentation(value.numericStringRepresentation)
             }
 
             switch style {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -1948,11 +1948,11 @@ extension NumberFormatStyleTests {
         XCTAssertEqual(parseableWrapperFunc(GenericWrapper<Double>(), style: .number), parseableWrapperFunc(GenericWrapper<Double>(), style: FloatingPointFormatStyle.number))
     }
 }
+#endif
 
-// MARK: - Decimal Tests
-// TODO: Reenable once Decimal has been moved: https://github.com/apple/swift-foundation/issues/43
+// MARK: - Big Integer Tests
+
 extension NumberFormatStyleTests {
-
 
     func testIntegerFormatStyleBigNumberNoCrash() throws {
         let uint64Style: IntegerFormatStyle<UInt64> = .init(locale: enUSLocale)
@@ -1966,7 +1966,6 @@ extension NumberFormatStyleTests {
         let uint64Currency: IntegerFormatStyle<UInt64>.Currency = .init(code: "USD", locale: enUSLocale)
         XCTAssertEqual(uint64Currency.format(UInt64.max), "$18,446,744,073,709,551,615.00")
         XCTAssertEqual(UInt64.max.formatted(.currency(code: "USD").locale(enUSLocale)), "$18,446,744,073,709,551,615.00")
-
 
         let uint64StyleAttributed: IntegerFormatStyle<UInt64>.Attributed = IntegerFormatStyle<UInt64>(locale: enUSLocale).attributed
         XCTAssertEqual(String(uint64StyleAttributed.format(UInt64.max).characters), "18,446,744,073,709,551,615")
@@ -1999,4 +1998,3 @@ extension NumberFormatStyleTests {
         XCTAssertEqual(Int64.min.formatted(.currency(code: "USD").locale(enUSLocale)), "-$9,223,372,036,854,775,808.00")
     }
 }
-#endif


### PR DESCRIPTION
Howdy! I've made some changes to improve your big-number formatting.

### Changes

- Removed trapping conversion to Int in BinaryInteger/formatted().
  - IntegerFormatStyle can format big integers since ([#262](https://github.com/apple/swift-foundation/pull/262)).
- Removed rounding conversion to Double in BinaryFloatingPoint/formatted()
  - This method now does whatever FloatingPointFormatStyle/format(\_:) does.
- Reenabled "Decimal Tests" in NumberFormatStyleTests.swift.
  - The normal styles worked as-is, but the attributed one needed some love.
- Added a "numeric string representation" case to ICUNumberFormatterBase.Value.
  - IntegerFormatStyle.Attributed now uses this value rather than Int64(clamping:).
- Removed conversions to Decimal in each integer format style ([#186](https://github.com/apple/swift-foundation/issues/186)).
  - IntegerFormatStyle, [...].Attributed, [...].Currency, [...].Percent
- Removed isZero and doubleValue from ICUNumberFormatterBase.Value.
  - This makes it easier to accommodate non-numeric payloads, e.g. String.
  - Both were used in ByteCountFormatStyle, which now queries FormatInput.
- Added internal \_format(\_:doubleValue:) method to ByteCountFormatStyle.
  - Parameterized function body for use with values convertible to Double.
  - Prior method was removed because it relied on [...].Value/doubleValue.

### Comments

 [RESOLVED] I was not sure what to do with ICUNumberFormatterBase.Value's isZero and doubleValue – please share your thoughts. I solved it :tm: by force unwrapping Double.init(\_:). The force unwrap should never fail, assuming the numeric string representation is well-formed, but large values may result in ± Double.infinity. It is not a problem for isZero, but I do not know the semantics of doubleValue.

### Alternatives

 [OUTDATED] You can add some thing like fallbackInteger(any BinaryInteger) instead of numericStringRepresentation(String). Perhaps it makes sense if you don't want to check isZero through Double.