### PR TITLE
Predicate to NSPredicate conversion should support captured URLs

### DIFF
--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -134,7 +134,7 @@ private func _expressionCompatibleValue(for value: Any) throws -> Any? {
     case Optional<Any>.none:
         return nil
     // Handle supported value types
-    case is String, is UUID, is Date, is Data:
+    case is String, is UUID, is Date, is Data, is URL:
         return value
     // Handle supported numeric types
     case is Int, is Int8, is Int16, is Int32, is Int64,

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -29,6 +29,7 @@ final class NSPredicateConversionTests: XCTestCase {
         @objc var j: String?
         @objc var k: UUID
         @objc var l: Data
+        @objc var m: URL
         var nonObjCKeypath: Int
         
         override init() {
@@ -43,6 +44,7 @@ final class NSPredicateConversionTests: XCTestCase {
             j = nil
             k = UUID()
             l = Data([1, 2, 3])
+            m = URL(string: "http://apple.com")!
             nonObjCKeypath = 8
             super.init()
         }
@@ -330,6 +332,16 @@ final class NSPredicateConversionTests: XCTestCase {
         }
         let converted = convert(predicate)
         XCTAssertEqual(converted, NSPredicate(format: "l == %@", data as NSData))
+        XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
+    }
+    
+    func testURL() {
+        let url = URL(string: "http://apple.com")!
+        let predicate = #Predicate<ObjCObject> {
+            $0.m == url
+        }
+        let converted = convert(predicate)
+        XCTAssertEqual(converted, NSPredicate(format: "m == %@", url as NSURL))
         XCTAssertTrue(converted!.evaluate(with: ObjCObject()))
     }
     


### PR DESCRIPTION
`NSPredicate` supports embedded URLs when passing the `NSPredicate` to CoreData, so we should ensure that when converting a `Predicate` to an `NSPredicate` it successfully embeds captured URLs