### PR TITLE
AttributedString --> NSAS conversion is expensive due to dictionary merging and setting empty attribute dictionaries

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -36,12 +36,10 @@ import Darwin
 fileprivate struct ScopeDescription : Sendable {
     var attributes: [String : any AttributedStringKey.Type] = [:]
     var markdownAttributes: [String : any MarkdownDecodableAttributedStringKey.Type] = [:]
-    var subscopes: [any AttributeScope.Type] = []
     
     mutating func merge(_ other: Self) {
         attributes.merge(other.attributes, uniquingKeysWith: { current, new in new })
         markdownAttributes.merge(other.markdownAttributes, uniquingKeysWith: { current, new in new })
-        subscopes.append(contentsOf: other.subscopes)
     }
 }
 
@@ -183,7 +181,7 @@ internal extension AttributeScope {
                     desc.markdownAttributes[markdownAttribute.markdownName] = markdownAttribute
                 }
             case let scope as any AttributeScope.Type:
-                desc.subscopes.append(scope)
+                desc.merge(scope.scopeDescription)
             default: break
             }
         }
@@ -195,17 +193,11 @@ internal extension AttributeScope {
     }
     
     static func attributeKeyTypes() -> [String : any AttributedStringKey.Type] {
-        let description = Self.scopeDescription
-        return description.subscopes.reduce(description.attributes) {
-            $0.merging($1.attributeKeyTypes(), uniquingKeysWith: { current, new in new })
-        }
+        Self.scopeDescription.attributes
     }
     
     static func markdownKeyTypes() -> [String : any MarkdownDecodableAttributedStringKey.Type] {
-        let description = Self.scopeDescription
-        return description.subscopes.reduce(description.markdownAttributes) {
-            $0.merging($1.markdownKeyTypes(), uniquingKeysWith: { current, new in new })
-        }
+        Self.scopeDescription.markdownAttributes
     }
 }
 

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -207,9 +207,13 @@ extension NSAttributedString {
         for run in attrStr._guts.runs {
             let stringEnd = attrStr._guts.string.utf8.index(stringStart, offsetBy: run.length)
             let utf16Length = attrStr._guts.string.utf16.distance(from: stringStart, to: stringEnd)
-            let range = NSRange(location: nsStartIndex, length: utf16Length)
-            let attributes = try Dictionary(AttributeContainer(run.attributes), attributeTable: attributeTable, options: options)
-            result.setAttributes(attributes, range: range)
+            if !run.attributes.isEmpty {
+                let range = NSRange(location: nsStartIndex, length: utf16Length)
+                let attributes = try Dictionary(AttributeContainer(run.attributes), attributeTable: attributeTable, options: options)
+                if !attributes.isEmpty {
+                    result.setAttributes(attributes, range: range)
+                }
+            }
             nsStartIndex += utf16Length
             stringStart = stringEnd
         }


### PR DESCRIPTION
This is a small patch that improves the performance of `AttributedString` to `NSAttributedString` conversion. First, dynamically merging the descriptions of each attribute scope can be expensive, so we now only do that once and cache the result rather than combining scopes dynamically for each request. Additionally, setting an empty attribute dictionary over a run can also be expensive, so we now ensure that we only set attributes for a range of the created NSAS if we have attributes to set (since we know that the string starts with no attributes)