### PR TITLE
Fix an Off-By-One Error in String's File System Representation

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -83,11 +83,9 @@ extension String {
     
     #if canImport(Darwin) || FOUNDATION_FRAMEWORK
     fileprivate func _fileSystemRepresentation(into buffer: UnsafeMutableBufferPointer<CChar>) -> Bool {
-        let result = buffer.withMemoryRebound(to: UInt8.self) { uintBuffer in
-            let newBuffer = UnsafeMutableBufferPointer(start: uintBuffer.baseAddress, count: uintBuffer.count - 1)
-            return _decomposed(.hfsPlus, into: newBuffer, nullTerminated: true)
+        let result = buffer.withMemoryRebound(to: UInt8.self) { rebound in
+            _decomposed(.hfsPlus, into: rebound, nullTerminated: true)
         }
-        
         return result != nil
     }
     #endif

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -360,6 +360,18 @@ final class StringTests : XCTestCase {
             XCTAssertNotNil($0)
             assertCString($0!, equals: original)
         }
+        
+#if canImport(Darwin) || FOUNDATION_FRAMEWORK
+        // A string of length PATH_MAX-1 should perfectly fit in the buffer (with the null byte)
+        Array(repeating: "A", count: Int(PATH_MAX) - 1).joined().withFileSystemRepresentation { ptr in
+            XCTAssertNotNil(ptr)
+        }
+        
+        // This will not fit in the buffer with the null byte
+        Array(repeating: "A", count: Int(PATH_MAX)).joined().withFileSystemRepresentation { ptr in
+            XCTAssertNil(ptr)
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
String's file system representation uses a buffer of size `PATH_MAX`, so strings up to size `PATH_MAX - 1` should fit (to leave room for the null byte). However, due to an off by one error, we accidentally failed for strings of exactly length `PATH_MAX - 1`.