### PR TITLE
Provide manual name override for local swift-foundation in the benchmark package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ Package.resolved
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 
@@ -93,4 +93,3 @@ iOSInjectionProject/
 .*.sw?
 
 .DS_Store
-/.swiftpm

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -6,14 +6,14 @@ let package = Package(
     name: "benchmarks",
     platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")], // Should match parent project
     dependencies: [
-        .package(path: "../"),
+        .package(name: "swift-foundation-local", path: "../"),
         .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1"),
     ],
     targets: [
         .executableTarget(
             name: "PredicateBenchmarks",
             dependencies: [
-                .product(name: "FoundationEssentials", package: "swift-foundation"),
+                .product(name: "FoundationEssentials", package: "swift-foundation-local"),
                 .product(name: "Benchmark", package: "package-benchmark"),
             ],
             path: "Benchmarks/Predicates",


### PR DESCRIPTION
The benchmark package relies on the package at `../` for the `FoundationEssentials` module. By default the package name is inferred to be the directory name, so the dependency on `"swift-foundation"` works if your directory is named `swift-foundation` but fails to resolve the package if your directory is named differently. This adds a manual override for the package name to ensure the name of the directory doesn't influence whether you can build benchmarks

While I'm at it, I added `Benchmarks/.swiftpm` to the `.gitignore` in addition to `/.swiftpm`