### PR TITLE
Add some benchmarks for Calendar and Locale

### DIFF
--- a/Benchmarks/Benchmarks/Calendar/Calendar.swift
+++ b/Benchmarks/Benchmarks/Calendar/Calendar.swift
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import func Benchmark.blackHole
+import FoundationEssentials
+import FoundationInternationalization
+
+let benchmarks = {
+    Benchmark.defaultConfiguration.maxIterations = 1_000
+    Benchmark.defaultConfiguration.maxDuration = .seconds(3)
+    Benchmark.defaultConfiguration.scalingFactor = .kilo
+    //    Benchmark.defaultConfiguration.metrics = .arc + [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // use ARC to see traffic
+    //  Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // skip ARC as it has some overhead
+    Benchmark.defaultConfiguration.metrics = .all // Use all metrics to easily see which ones are of interest for this benchmark suite
+    
+    let thanksgivingComponents = DateComponents(month: 11, weekday: 5, weekOfMonth: 4)
+    let cal = Calendar(identifier: .gregorian)
+    let thanksgivingStart = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
+    
+    Benchmark("nextThousandThanksgivings") { benchmark in
+        var count = 1000
+        cal.enumerateDates(startingAfter: thanksgivingStart, matching: thanksgivingComponents, matchingPolicy: .nextTime) { result, exactMatch, stop in
+            count -= 1
+            if count == 0 {
+                stop = true
+            }
+        }
+    }
+    
+    let reference = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
+    
+    Benchmark("allocationsForFixedCalendars", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            // Fixed calendar
+            let cal = Calendar(identifier: .gregorian)
+            let date = cal.date(byAdding: .day, value: 1, to: reference)
+            assert(date != nil)
+        }
+    }
+    
+    Benchmark("allocationsForCurrentCalendar", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            // Current calendar
+            let cal = Calendar.current
+            let date = cal.date(byAdding: .day, value: 1, to: reference)
+            assert(date != nil)
+        }
+    }
+    
+    Benchmark("allocationsForAutoupdatingCurrentCalendar", configuration: .init(scalingFactor: .mega)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            // Autoupdating current calendar
+            let cal = Calendar.autoupdatingCurrent
+            let date = cal.date(byAdding: .day, value: 1, to: reference)
+            assert(date != nil)
+        }
+    }
+    
+    Benchmark("copyOnWritePerformance", configuration: .init(scalingFactor: .mega)) { benchmark in
+        var cal = Calendar(identifier: .gregorian)
+        for i in benchmark.scaledIterations {
+            cal.firstWeekday = i % 2
+            assert(cal.firstWeekday == i % 2)
+        }
+    }
+    
+    Benchmark("copyOnWritePerformanceNoDiff", configuration: .init(scalingFactor: .mega)) { benchmark in
+        var cal = Calendar(identifier: .gregorian)
+        let tz = TimeZone(secondsFromGMT: 1800)!
+        for _ in benchmark.scaledIterations {
+            cal.timeZone = tz
+        }
+    }
+    
+    Benchmark("allocationsForFixedLocale", configuration: .init(scalingFactor: .mega)) { benchmark in
+        // Fixed locale
+        for _ in benchmark.scaledIterations {
+            let loc = Locale(identifier: "en_US")
+            let identifier = loc.identifier
+            assert(identifier == "en_US")
+        }
+    }
+    
+    Benchmark("allocationsForCurrentLocale", configuration: .init(scalingFactor: .mega)) { benchmark in
+        // Current locale
+        for _ in benchmark.scaledIterations {
+            let loc = Locale.current
+            let identifier = loc.identifier
+            assert(identifier == "en_US")
+        }
+    }
+    
+    Benchmark("allocationsForAutoupdatingCurrentLocale", configuration: .init(scalingFactor: .mega)) { benchmark in
+        // Autoupdating current locale
+        for _ in benchmark.scaledIterations {
+            let loc = Locale.autoupdatingCurrent
+            let identifier = loc.identifier
+            assert(identifier == "en_US")
+        }
+    }
+        
+    Benchmark("identifierFromComponents", configuration: .init(scalingFactor: .mega)) { benchmark in
+        let c1 = ["kCFLocaleLanguageCodeKey" : "en"]
+        let c2 = ["kCFLocaleLanguageCodeKey" : "zh",
+                  "kCFLocaleScriptCodeKey" : "Hans",
+                  "kCFLocaleCountryCodeKey" : "TW"]
+        let c3 = ["kCFLocaleLanguageCodeKey" : "es",
+                  "kCFLocaleScriptCodeKey" : "",
+                  "kCFLocaleCountryCodeKey" : "409"]
+        
+        for _ in benchmark.scaledIterations {
+            let id1 = Locale.identifier(fromComponents: c1)
+            let id2 = Locale.identifier(fromComponents: c2)
+            let id3 = Locale.identifier(fromComponents: c3)
+            assert(id1.isEmpty == false)
+            assert(id2.isEmpty == false)
+            assert(id3.isEmpty == false)
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -21,5 +21,17 @@ let package = Package(
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
         ),
+        .executableTarget(
+            name: "CalendarBenchmarks",
+            dependencies: [
+                .product(name: "FoundationEssentials", package: "swift-foundation-local"),
+                .product(name: "FoundationInternationalization", package: "swift-foundation-local"),
+                .product(name: "Benchmark", package: "package-benchmark"),
+            ],
+            path: "Benchmarks/Calendar",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
     ]
 )


### PR DESCRIPTION
Using our nice new benchmarking suite (#291), add some basic benchmarks for Calendar and Locale. We can expand this with more tests over time of course.