### PR TITLE
Improve performance of UUID equality

### DIFF
--- a/Benchmarks/Benchmarks/Essentials/Essentials.swift
+++ b/Benchmarks/Benchmarks/Essentials/Essentials.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import func Benchmark.blackHole
+import FoundationEssentials
+
+let benchmarks = {
+    Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
+    Benchmark.defaultConfiguration.maxDuration = .seconds(3)
+    Benchmark.defaultConfiguration.scalingFactor = .kilo
+    Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .throughput] // use ARC to see traffic
+    
+    // MARK: UUID
+    
+    Benchmark("UUIDEqual", configuration: .init(scalingFactor: .mega)) { benchmark in
+        let u1 = UUID()
+        let u2 = UUID()
+        for _ in benchmark.scaledIterations {
+            assert(u1 != u2)
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -33,5 +33,16 @@ let package = Package(
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
         ),
+        .executableTarget(
+            name: "EssentialsBenchmarks",
+            dependencies: [
+                .product(name: "FoundationEssentials", package: "swift-foundation-local"),
+                .product(name: "Benchmark", package: "package-benchmark"),
+            ],
+            path: "Benchmarks/Essentials",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
     ]
 )

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -90,22 +90,13 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
     }
 
     public static func ==(lhs: UUID, rhs: UUID) -> Bool {
-        return lhs.uuid.0 == rhs.uuid.0 &&
-            lhs.uuid.1 == rhs.uuid.1 &&
-            lhs.uuid.2 == rhs.uuid.2 &&
-            lhs.uuid.3 == rhs.uuid.3 &&
-            lhs.uuid.4 == rhs.uuid.4 &&
-            lhs.uuid.5 == rhs.uuid.5 &&
-            lhs.uuid.6 == rhs.uuid.6 &&
-            lhs.uuid.7 == rhs.uuid.7 &&
-            lhs.uuid.8 == rhs.uuid.8 &&
-            lhs.uuid.9 == rhs.uuid.9 &&
-            lhs.uuid.10 == rhs.uuid.10 &&
-            lhs.uuid.11 == rhs.uuid.11 &&
-            lhs.uuid.12 == rhs.uuid.12 &&
-            lhs.uuid.13 == rhs.uuid.13 &&
-            lhs.uuid.14 == rhs.uuid.14 &&
-            lhs.uuid.15 == rhs.uuid.15
+        withUnsafeBytes(of: lhs) { lhsPtr in
+            withUnsafeBytes(of: rhs) { rhsPtr in
+                let lhsTuple = lhsPtr.loadUnaligned(as: (UInt64, UInt64).self)
+                let rhsTuple = rhsPtr.loadUnaligned(as: (UInt64, UInt64).self)
+                return (lhsTuple.0 ^ rhsTuple.0) | (lhsTuple.1 ^ rhsTuple.1) == 0
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Improves the performance of UUID equality. Also, restores desired behavior (for security reasons) of doing the comparison in constant time.