### PR TITLE
Fix inconsistent identifier handling in Locale.Collation

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale+Components.swift
+++ b/Sources/FoundationEssentials/Locale/Locale+Components.swift
@@ -354,7 +354,7 @@ extension Locale {
                 _identifier
             }
             set {
-                _normalizedIdentifier = newValue.capitalized
+                _normalizedIdentifier = newValue.lowercased()
                 _identifier = newValue
             }
         }
@@ -392,7 +392,7 @@ extension Locale {
         public init(from decoder: Decoder) throws {
             do {
                 _identifier = try decoder.singleValueContainer().decode(String.self)
-                _normalizedIdentifier = _identifier.capitalized
+                _normalizedIdentifier = _identifier.lowercased()
             } catch {
                 // backward compatibility: we used to encode both _identifier and _normalizedIdentifier. Fall back to this if there's not a matched single value container
                 let container = try decoder.container(keyedBy: CodingKeys.self)


### PR DESCRIPTION
As best I can determine, the normalization for `Locale.Collation`'s identifier should be `.lowercased()` across the board, not `.capitalized`, so the setter for `identifier` and the `Decodable` logic are updated accordingly (rather than making the opposite change to `.init(identifier:)`). This was not caught by tests because the only test which should have ended up invoking the competing code paths on the same object is testing round tripping through the "legacy" encoding, which results in sidestepping the conflicting behavior, as seen [here](https://github.com/gwynne/swift-foundation/blob/main/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift#L411-L423) and [here](https://github.com/gwynne/swift-foundation/blob/main/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift#L334-L351).

I haven't added a new test for this particular concern because doing so would imply adding similar tests for all the various components, not just `Collation`, for which I'm not really certain of the best approach.