### PR TITLE
Fix out of order result check in ICUPatternGenerator

### DIFF
--- a/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
+++ b/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
@@ -38,8 +38,8 @@ final class ICUPatternGenerator {
 
     func _patternForSkeleton(_ skeleton: String) -> String {
         var status = U_ZERO_ERROR
-        try! status.checkSuccess()
         let clonedPatternGenerator = udatpg_clone(upatternGenerator, &status)
+        try! status.checkSuccess()
         defer {
              udatpg_close(clonedPatternGenerator)
         }


### PR DESCRIPTION
Simple, straightforward fix - check for success _after_ attempting the operation rather than before it. I can't imagine `udatpg_clone()` fails even remotely often enough for this to ever get noticed under normal conditions (nor can I think of a meaningful unit test, given that a failure trips a fatal error).