### PR TITLE
[Gregorian Calendar] Implement `dateComponents(_:from:to:)`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -150,6 +150,13 @@ enum ResolvedDateComponents {
 
 }
 
+
+/// Internal-use error for indicating unexpected situations when finding dates.
+enum GregorianCalendarError : Error {
+    case overflow(Calendar.Component, Date /* failing start date */, Date /* failing end date */)
+    case notAdvancing(Date /* next */, Date /* previous */)
+}
+
 /// This class is a placeholder and work-in-progress to provide an implementation of the Gregorian calendar.
 internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable {
     
@@ -2515,9 +2522,167 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         }
     }
 
-    
+    // MARK: Differences
+
+    // Calendar::fieldDifference
+    func difference(inComponent component: Calendar.Component, from start: Date, to end: Date) throws -> (difference: Int, newStart: Date) {
+        guard end != start else {
+            return (0, start)
+        }
+
+        switch component {
+        case .calendar, .timeZone, .isLeapMonth:
+            preconditionFailure("Invalid arguments")
+
+        case .era:
+            // Special handling since `add` below doesn't work with `era`
+            let currEra = dateComponent(.era, from: start)
+            let goalEra = dateComponent(.era, from: end)
+
+            return (goalEra - currEra, start)
+        case .nanosecond:
+            let diffInNano = end.timeIntervalSince(start).remainder(dividingBy: 1) * 1.0e+9
+            let diff = diffInNano < Double(Int32.max) ? Int(diffInNano) : Int(Int32.max)
+            let advanced = add(component, to: start, amount: diff, inTimeZone: timeZone)
+            return (diff, advanced)
+
+        case .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear:
+            // continue to below
+            break
+        }
+
+        let forward = end > start
+        var max = forward ? 1 : -1
+        var min = 0
+        while true {
+            let ms = add(component, to: start, amount: max, inTimeZone: timeZone)
+            guard forward ? (ms > start) : (ms < start) else {
+                throw GregorianCalendarError.notAdvancing(start, ms)
+            }
+
+            if ms == end {
+                return (max, ms)
+            } else if (forward && ms > end) || (!forward && ms < end) {
+                break
+            } else {
+                min = max
+                max <<= 1
+                guard forward ? max >= 0 : max < 0 else {
+                    throw GregorianCalendarError.overflow(component, start, end)
+                }
+            }
+        }
+
+        // Binary search
+        while (forward && (max - min) > 1) || (!forward && (min - max > 1)) {
+            let t = min + (max - min) / 2
+
+            let ms = add(component, to: start, amount: t, inTimeZone: timeZone)
+            if ms == end {
+                return (t, ms)
+            } else if (forward && ms > end) || (!forward && ms < end) {
+                max = t
+            } else {
+                min = t
+            }
+        }
+
+        let advanced = add(component, to: start, amount: min, inTimeZone: timeZone)
+
+        return (min, advanced)
+    }
+
     func dateComponents(_ components: Calendar.ComponentSet, from start: Date, to end: Date) -> DateComponents {
-        fatalError()
+        let cappedStart = start.capped
+        let cappedEnd = end.capped
+
+        let subseconds = cappedStart.timeIntervalSinceReferenceDate.remainder(dividingBy: 1)
+
+        var curr = cappedStart  - subseconds
+        let goal = cappedEnd - subseconds
+        func orderedComponents(_ components: Calendar.ComponentSet) -> [Calendar.Component] {
+            var comps: [Calendar.Component] = []
+            if components.contains(.era) {
+                comps.append(.era)
+            }
+            if components.contains(.year) {
+                comps.append(.year)
+            }
+            if components.contains(.yearForWeekOfYear) {
+                comps.append(.yearForWeekOfYear)
+            }
+            if components.contains(.quarter) {
+                comps.append(.quarter)
+            }
+            if components.contains(.month) {
+                comps.append(.month)
+            }
+            if components.contains(.weekOfYear) {
+                comps.append(.weekOfYear)
+            }
+            if components.contains(.weekOfMonth) {
+                comps.append(.weekOfMonth)
+            }
+            if components.contains(.day) {
+                comps.append(.day)
+            }
+            if components.contains(.weekday) {
+                comps.append(.weekday)
+            }
+            if components.contains(.weekdayOrdinal) {
+                comps.append(.weekdayOrdinal)
+            }
+            if components.contains(.hour) {
+                comps.append(.hour)
+            }
+            if components.contains(.minute) {
+                comps.append(.minute)
+            }
+            if components.contains(.second) {
+                comps.append(.second)
+            }
+
+            if components.contains(.nanosecond) {
+                comps.append(.nanosecond)
+            }
+
+            return comps
+        }
+
+        var dc = DateComponents()
+
+        for component in orderedComponents(components) {
+            switch component {
+            case .era, .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .weekOfYear, .yearForWeekOfYear, .weekOfMonth, .nanosecond:
+                do {
+                    let (diff, newStart) = try difference(inComponent: component, from: curr, to: goal)
+                    dc.setValue(diff, for: component)
+                    curr = newStart
+                } catch let error as GregorianCalendarError {
+#if FOUNDATION_FRAMEWORK
+                    switch error {
+
+                    case .overflow(_, _, _):
+                        Logger(Calendar.log).error("Overflowing in dateComponents(from:start:end:). start: \(start.timeIntervalSinceReferenceDate, privacy: .public) end: \(end.timeIntervalSinceReferenceDate, privacy: .public) component: \(component, privacy: .public)")
+                    case .notAdvancing(_, _):
+                        Logger(Calendar.log).error("Not advancing in dateComponents(from:start:end:). start: \(start.timeIntervalSinceReferenceDate, privacy: .public) end: \(end.timeIntervalSinceReferenceDate, privacy: .public) component: \(component, privacy: .public)")
+                    }
+#endif
+                    dc.setValue(0, for: component)
+                } catch {
+                    preconditionFailure("Unknown error: \(error)")
+                }
+
+            case .timeZone, .isLeapMonth, .calendar:
+                // No leap month support needed here, since these are quantities, not values
+                break
+            case .quarter:
+                // Currently unsupported so always return 0
+                dc.quarter = 0
+            }
+        }
+
+        return dc
     }
     
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -2546,7 +2546,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
             let advanced = add(component, to: start, amount: diff, inTimeZone: timeZone)
             return (diff, advanced)
 
-        case .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear:
+        case .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .dayOfYear:
             // continue to below
             break
         }
@@ -2653,7 +2653,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
         for component in orderedComponents(components) {
             switch component {
-            case .era, .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .weekOfYear, .yearForWeekOfYear, .weekOfMonth, .nanosecond:
+            case .era, .year, .month, .day, .dayOfYear, .hour, .minute, .second, .weekday, .weekdayOrdinal, .weekOfYear, .yearForWeekOfYear, .weekOfMonth, .nanosecond:
                 do {
                     let (diff, newStart) = try difference(inComponent: component, from: curr, to: goal)
                     dc.setValue(diff, for: component)

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -3141,6 +3141,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: 60)
         test(.weekOfYear, expected: 60)
         test(.yearForWeekOfYear, expected: 1)
+        test(.dayOfYear, expected: 425)
 
         // leap to non leap
         start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
@@ -3155,6 +3156,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: 52)
         test(.weekOfYear, expected: 52)
         test(.yearForWeekOfYear, expected: 1)
+        test(.dayOfYear, expected: 366)
 
         // within leap
         start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
@@ -3169,6 +3171,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: 8)
         test(.weekOfYear, expected: 8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: 59)
 
         start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
         end = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
@@ -3182,6 +3185,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: 8)
         test(.weekOfYear, expected: 8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: 60)
 
         // within non leap
         start = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
@@ -3196,6 +3200,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: 8)
         test(.weekOfYear, expected: 8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: 59)
 
         // Backwards
         // non leap to leap
@@ -3211,6 +3216,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: -60)
         test(.weekOfYear, expected: -60)
         test(.yearForWeekOfYear, expected: -1)
+        test(.dayOfYear, expected: -425)
 
         // leap to non leap
         start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
@@ -3225,6 +3231,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: -52)
         test(.weekOfYear, expected: -52)
         test(.yearForWeekOfYear, expected: -1)
+        test(.dayOfYear, expected: -365)
 
         // within leap
         start = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
@@ -3239,6 +3246,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: -8)
         test(.weekOfYear, expected: -8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: -60)
 
         start = Date(timeIntervalSince1970: 825580800.0) // 1996-02-29
         end = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
@@ -3252,6 +3260,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: -8)
         test(.weekOfYear, expected: -8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: -59)
 
         // within non leap
         start = Date(timeIntervalSince1970: 794044800.0) // 1995-03-01
@@ -3266,6 +3275,7 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfMonth, expected: -8)
         test(.weekOfYear, expected: -8)
         test(.yearForWeekOfYear, expected: 0)
+        test(.dayOfYear, expected: -59)
 
         // Time
 

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -3003,5 +3003,409 @@ final class GregorianCalendarTests : XCTestCase {
         test(.weekOfYear, in: .month, for: date, expected: 1..<6)
         test(.day, in: .weekOfMonth, for: date, expected: 1..<7)
     }
+
+    // MARK: - Difference
+
+    func testDateComponentsFromStartToEnd() {
+        let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
+        var start: Date!
+        var end: Date!
+        func test(_ components: Calendar.ComponentSet, expected: DateComponents, file: StaticString = #file, line: UInt = #line) {
+            let actual = calendar.dateComponents(components, from: start, to: end)
+            XCTAssertEqual(actual, expected, file: file, line: line)
+        }
+
+        // non leap to leap
+        start = Date(timeIntervalSince1970: 788918400.0) // 1995-01-01
+        end = Date(timeIntervalSince1970: 825638400.0) // 1996-03-01
+        test([.year, .day, .month], expected: .init(year: 1, month: 2, day: 0))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 1, month: 2, weekday: 0, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 8, yearForWeekOfYear: 1))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 1, month: 2, weekday: 0, weekdayOrdinal: 0))
+
+        // leap to non leap
+        // positive year, negative month
+        start = Date(timeIntervalSince1970: 823132800.0) // 1996-02-01
+        end = Date(timeIntervalSince1970: 852076800.0) // 1997-01-01
+        test([.year, .day, .month], expected: .init(year: 0, month: 11, day: 0))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 11, weekday: 0, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 47, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 11, weekday: 0, weekdayOrdinal: 0))
+
+        // within leap
+        // positive month, positive day
+        start = Date(timeIntervalSince1970: 822960000.0) // 1996-01-30
+        end = Date(timeIntervalSince1970: 825552000.0) // 1996-02-29
+        test([.year, .day, .month], expected: .init(year: 0, month: 1, day: 0))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 1, weekday: 0, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 4, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 1, weekday: 0, weekdayOrdinal: 0))
+
+        // positive month, negative day
+        start = Date(timeIntervalSince1970: 823046400.0) // 1996-01-31
+        end = Date(timeIntervalSince1970: 825638400.0) // 1996-03-01
+        test([.year, .day, .month], expected: .init(year: 0, month: 1, day: 1))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 1, weekday: 1, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 4, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 1, weekday: 1, weekdayOrdinal: 0))
+
+        // within non leap
+        // positive month, positive day
+        start = Date(timeIntervalSince1970: 788918400.0) // 1995-01-01
+        end = Date(timeIntervalSince1970: 794361600.0) // 1995-03-05
+        test([.year, .day, .month], expected: .init(year: 0, month: 2, day: 4))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 2, weekday: 4, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 9, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 2, weekday: 4, weekdayOrdinal: 0))
+
+        // positive month, negative day
+        start = Date(timeIntervalSince1970: 791510400.0) // 1995-01-31
+        end = Date(timeIntervalSince1970: 794361600.0) // 1995-03-05
+        test([.year, .day, .month], expected: .init(year: 0, month: 1, day: 5))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 1, weekday: 5, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 4, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 1, weekday: 5, weekdayOrdinal: 0))
+
+        // ---------
+        // Backwards
+        start = Date(timeIntervalSince1970: 852076800.0) // 1997-01-01
+        end = Date(timeIntervalSince1970: 851817600.0) // 1996-12-29
+        test([.year, .day, .month], expected: .init(year: 0, month: 0, day: -3))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 0, weekday: -3, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: 0, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 0, weekday: -3, weekdayOrdinal: 0))
+
+        // leap to non leap
+        // negative year, positive month
+        start = Date(timeIntervalSince1970: 825638400.0) // 1996-03-01
+        end = Date(timeIntervalSince1970: 817776000.0) // 1995-12-01
+        test([.year, .day, .month], expected: .init(year: 0, month: -3, day: 0))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: -3, weekday: 0, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: -13, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: -3, weekday: 0, weekdayOrdinal: 0))
+
+        // within leap
+        // negative month, negative day
+        start = Date(timeIntervalSince1970: 825984000.0) // 1996-03-05
+        end = Date(timeIntervalSince1970: 820454400.0) // 1996-01-01
+        test([.year, .day, .month], expected: .init(year: 0, month: -2, day: -4))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: -2, weekday: -4, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: -9, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: -2, weekday: -4, weekdayOrdinal: 0))
+
+        // negative month, positive day
+        start = Date(timeIntervalSince1970: 825552000.0) // 1996-02-29
+        end = Date(timeIntervalSince1970: 823046400.0) // 1996-01-31
+        test([.year, .day, .month], expected: .init(year: 0, month: 0, day: -29))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 0, weekday: -1, weekOfMonth: -4))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: -4, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 0, weekday: -29, weekdayOrdinal: 0))
+
+        // within non leap
+        // negative month, negative day
+        start = Date(timeIntervalSince1970: 794361600.0) // 1995-03-05
+        end = Date(timeIntervalSince1970: 788918400.0) // 1995-01-01
+        test([.year, .day, .month], expected: .init(year: 0, month: -2, day: -4))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: -2, weekday: -4, weekOfMonth: 0))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: -9, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: -2, weekday: -4, weekdayOrdinal: 0))
+
+        // negative month, positive day
+        start = Date(timeIntervalSince1970: 793929600.0) // 1995-02-28
+        end = Date(timeIntervalSince1970: 791510400.0) // 1995-01-31
+        test([.year, .day, .month], expected: .init(year: 0, month: 0, day: -28))
+        test([.weekday, .year, .month, .weekOfMonth], expected: .init(year: 0, month: 0, weekday: 0, weekOfMonth: -4))
+        test([.yearForWeekOfYear, .weekOfYear], expected: .init(weekOfYear: -4, yearForWeekOfYear: 0))
+        test([.weekday, .year, .month, .weekdayOrdinal], expected: .init(year: 0, month: 0, weekday: -28, weekdayOrdinal: 0))
+    }
+
+    func testDifference() {
+        let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -28800)!, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
+        var start: Date!
+        var end: Date!
+        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #file, line: UInt = #line) {
+            let (actualDiff, _) = try! calendar.difference(inComponent: component, from: start, to: end)
+            XCTAssertEqual(actualDiff, expected, file: file, line: line)
+        }
+
+        // non leap to leap
+        start = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
+        end = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
+        test(.era, expected: 0)
+        test(.year, expected: 1)
+        test(.month, expected: 14)
+        test(.day, expected: 425)
+        test(.hour, expected: 10200)
+        test(.weekday, expected: 425)
+        test(.weekdayOrdinal, expected: 60)
+        test(.weekOfMonth, expected: 60)
+        test(.weekOfYear, expected: 60)
+        test(.yearForWeekOfYear, expected: 1)
+
+        // leap to non leap
+        start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        end = Date(timeIntervalSince1970: 852105600.0) // 1997-01-01
+        test(.era, expected: 0)
+        test(.year, expected: 1)
+        test(.month, expected: 12)
+        test(.day, expected: 366)
+        test(.hour, expected: 8784)
+        test(.weekday, expected: 366)
+        test(.weekdayOrdinal, expected: 52)
+        test(.weekOfMonth, expected: 52)
+        test(.weekOfYear, expected: 52)
+        test(.yearForWeekOfYear, expected: 1)
+
+        // within leap
+        start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        end = Date(timeIntervalSince1970: 825580800.0) // 1996-02-29
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: 1)
+        test(.day, expected: 59)
+        test(.hour, expected: 1416)
+        test(.weekday, expected: 59)
+        test(.weekdayOrdinal, expected: 8)
+        test(.weekOfMonth, expected: 8)
+        test(.weekOfYear, expected: 8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        end = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: 2)
+        test(.day, expected: 60)
+        test(.hour, expected: 1440)
+        test(.weekday, expected: 60)
+        test(.weekdayOrdinal, expected: 8)
+        test(.weekOfMonth, expected: 8)
+        test(.weekOfYear, expected: 8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        // within non leap
+        start = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
+        end = Date(timeIntervalSince1970: 794044800.0) // 1995-03-01
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: 2)
+        test(.day, expected: 59)
+        test(.hour, expected: 1416)
+        test(.weekday, expected: 59)
+        test(.weekdayOrdinal, expected: 8)
+        test(.weekOfMonth, expected: 8)
+        test(.weekOfYear, expected: 8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        // Backwards
+        // non leap to leap
+        start = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
+        end = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
+        test(.era, expected: 0)
+        test(.year, expected: -1)
+        test(.month, expected: -14)
+        test(.day, expected: -425)
+        test(.hour, expected: -10200)
+        test(.weekday, expected: -425)
+        test(.weekdayOrdinal, expected: -60)
+        test(.weekOfMonth, expected: -60)
+        test(.weekOfYear, expected: -60)
+        test(.yearForWeekOfYear, expected: -1)
+
+        // leap to non leap
+        start = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        end = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
+        test(.era, expected: 0)
+        test(.year, expected: -1)
+        test(.month, expected: -12)
+        test(.day, expected: -365)
+        test(.hour, expected: -8760)
+        test(.weekday, expected: -365)
+        test(.weekdayOrdinal, expected: -52)
+        test(.weekOfMonth, expected: -52)
+        test(.weekOfYear, expected: -52)
+        test(.yearForWeekOfYear, expected: -1)
+
+        // within leap
+        start = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01
+        end = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: -2)
+        test(.day, expected: -60)
+        test(.hour, expected: -1440)
+        test(.weekday, expected: -60)
+        test(.weekdayOrdinal, expected: -8)
+        test(.weekOfMonth, expected: -8)
+        test(.weekOfYear, expected: -8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825580800.0) // 1996-02-29
+        end = Date(timeIntervalSince1970: 820483200.0) // 1996-01-01
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: -1)
+        test(.day, expected: -59)
+        test(.hour, expected: -1416)
+        test(.weekday, expected: -59)
+        test(.weekdayOrdinal, expected: -8)
+        test(.weekOfMonth, expected: -8)
+        test(.weekOfYear, expected: -8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        // within non leap
+        start = Date(timeIntervalSince1970: 794044800.0) // 1995-03-01
+        end = Date(timeIntervalSince1970: 788947200.0) // 1995-01-01
+        test(.era, expected: 0)
+        test(.year, expected: 0)
+        test(.month, expected: -2)
+        test(.day, expected: -59)
+        test(.hour, expected: -1416)
+        test(.weekday, expected: -59)
+        test(.weekdayOrdinal, expected: -8)
+        test(.weekOfMonth, expected: -8)
+        test(.weekOfYear, expected: -8)
+        test(.yearForWeekOfYear, expected: 0)
+
+        // Time
+
+        start = Date(timeIntervalSince1970: 820479600.0) // 1995-12-31 23:00:00
+        end = Date(timeIntervalSince1970: 825667200.0) // 1996-03-01 00:00:00
+        test(.hour, expected: 1441)
+        test(.minute, expected: 86460)
+        test(.second, expected: 5187600)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 852105540.0) // 1996-12-31 23:59:00
+        end = Date(timeIntervalSince1970: 857203205.0) // 1997-03-01 00:00:05
+        test(.hour, expected: 1416)
+        test(.minute, expected: 84961)
+        test(.second, expected: 5097665)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
+        end = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
+        test(.hour, expected: 0)
+        test(.minute, expected: 1)
+        test(.second, expected: 85)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
+        end = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
+        test(.hour, expected: 24)
+        test(.minute, expected: 1441)
+        test(.second, expected: 86485)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 794044710.0) // 1995-02-28 23:58:30
+        end = Date(timeIntervalSince1970: 794044805.0) // 1995-03-01 00:00:05
+        test(.hour, expected: 0)
+        test(.minute, expected: 1)
+        test(.second, expected: 95)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 857203205.0) // 1997-03-01 00:00:05
+        end = Date(timeIntervalSince1970: 852105520.0) // 1996-12-31 23:58:40
+        test(.hour, expected: -1416)
+        test(.minute, expected: -84961)
+        test(.second, expected: -5097685)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
+        end = Date(timeIntervalSince1970: 820483120.0) // 1995-12-31 23:58:40
+        test(.hour, expected: -1440)
+        test(.minute, expected: -86401)
+        test(.second, expected: -5184085)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
+        end = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
+        test(.hour, expected: -24)
+        test(.minute, expected: -1441)
+        test(.second, expected: -86485)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
+        end = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
+        test(.hour, expected: 0)
+        test(.minute, expected: -1)
+        test(.second, expected: -85)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
+        end = Date(timeIntervalSince1970: 820569520.0) // 1996-01-01 23:58:40
+        test(.hour, expected: -1392)
+        test(.minute, expected: -83521)
+        test(.second, expected: -5011285)
+        test(.nanosecond, expected: 0)
+
+        start = Date(timeIntervalSince1970: 794044805.0) // 1995-03-01 00:00:05
+        end = Date(timeIntervalSince1970: 794044710.0) // 1995-02-28 23:58:30
+        test(.hour, expected: 0)
+        test(.minute, expected: -1)
+        test(.second, expected: -95)
+        test(.nanosecond, expected: 0)
+    }
+
+    func testDifference_DST() {
+        let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
+
+        var start: Date!
+        var end: Date!
+        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #file, line: UInt = #line) {
+            let (actualDiff, _) = try! calendar.difference(inComponent: component, from: start, to: end)
+            XCTAssertEqual(actualDiff, expected, file: file, line: line)
+        }
+
+        start = Date(timeIntervalSince1970: 828867787.0) // 1996-04-07T01:03:07-0800
+        end = Date(timeIntervalSince1970: 828871387.0) // 1996-04-07T03:03:07-0700
+        test(.hour, expected: 1)
+        test(.minute, expected: 60)
+        test(.second, expected: 3600)
+
+        start = Date(timeIntervalSince1970: 828867787.0) // 1996-04-07T01:03:07-0800
+        end = Date(timeIntervalSince1970: 828874987.0) // 1996-04-07T04:03:07-0700
+        test(.hour, expected: 2)
+        test(.minute, expected: 120)
+        test(.second, expected: 7200)
+
+        start = Date(timeIntervalSince1970: 846403387.0) // 1996-10-27T01:03:07-0700
+        end = Date(timeIntervalSince1970: 846406987.0) // 1996-10-27T01:03:07-0800
+        test(.hour, expected: 1)
+        test(.minute, expected: 60)
+        test(.second, expected: 3600)
+
+        start = Date(timeIntervalSince1970: 846403387.0) // 1996-10-27T01:03:07-0700
+        end = Date(timeIntervalSince1970: 846410587.0) // 1996-10-27T02:03:07-0800
+        test(.hour, expected: 2)
+        test(.minute, expected: 120)
+        test(.second, expected: 7200)
+
+        // backwards
+
+        start = Date(timeIntervalSince1970: 828871387.0) // 1996-04-07T03:03:07-0700
+        end = Date(timeIntervalSince1970: 828867787.0) // 1996-04-07T01:03:07-0800
+        test(.hour, expected: -1)
+        test(.minute, expected: -60)
+        test(.second, expected: -3600)
+
+        start = Date(timeIntervalSince1970: 828874987.0) // 1996-04-07T04:03:07-0700
+        end = Date(timeIntervalSince1970: 828867787.0) // 1996-04-07T01:03:07-0800
+        test(.hour, expected: -2)
+        test(.minute, expected: -120)
+        test(.second, expected: -7200)
+
+        start = Date(timeIntervalSince1970: 846406987.0) // 1996-10-27T01:03:07-0800
+        end = Date(timeIntervalSince1970: 846403387.0) // 1996-10-27T01:03:07-0700
+        test(.hour, expected: -1)
+        test(.minute, expected: -60)
+        test(.second, expected: -3600)
+
+        start = Date(timeIntervalSince1970: 846410587.0) // 1996-10-27T02:03:07-0800
+        end = Date(timeIntervalSince1970: 846403387.0) // 1996-10-27T01:03:07-0700
+        test(.hour, expected: -2)
+        test(.minute, expected: -120)
+        test(.second, expected: -7200)
+    }
 }
 


### PR DESCRIPTION
Implementation follows that of Calendar_ICU and ICU's Calendar::fieldDifference.

Like many calendar algorithms, we get the difference by iterative search: We start advancing from `start` until we reach or pass `end`, striding using the queried component. If we land on `end` exactly, return the striding count as-is. If we pass `end`, do a binary search to find the optimal stride.
