### PR TITLE
Upgrade SwiftFoudationICU to 0.0.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             revision: "d8003787efafa82f9805594bc51100be29ac6903"), // on release/1.1
         .package(
             url: "https://github.com/apple/swift-foundation-icu",
-            exact: "0.0.4"),
+            exact: "0.0.5"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
             from: "509.0.2")

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ macOS Ventura 13.3.1 is the minimum supported version.
 - Download the latest Xcode from the App Store
 - Download and install the Swift 5.9 toolchain for Xcode from [swift.org](https://www.swift.org/download)
 - Launch Xcode and select the downloaded 5.9 toolchains via *Xcode > Toolchains*
-- Open `Package.swift` and select *Debug > Test*
+- Open `Package.swift` and select *Product > Test*
 
 ### Linux
 - Download the latest [Swift 5.9 docker image](https://hub.docker.com/r/swiftlang/swift/tags?name=5.9) and follow instructions to attach


### PR DESCRIPTION
Upgrade `SwiftFoundationICU` to `0.0.5` to workaround the build failure.

---
Also fixed the instruction in the `README`