### PR TITLE
Remove `_foundation_essentials_feature_enabled` guard in FOUNDATION_FRAMEWORK

### DIFF
--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -37,15 +37,7 @@ extension StringProtocol {
     /// strings of the same lengths as the originals.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public var capitalized: String {
-#if FOUNDATION_FRAMEWORK
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._capitalized()
-        }
-
-        return _ns.capitalized
-#else
-        return String(self)._capitalized()
-#endif
+        String(self)._capitalized()
     }
 
 #if FOUNDATION_FRAMEWORK
@@ -54,17 +46,11 @@ extension StringProtocol {
     /// given options.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public func rangeOfCharacter(from aSet: CharacterSet, options mask: String.CompareOptions = [], range aRange: Range<Index>? = nil) -> Range<Index>? {
-        if _foundation_essentials_feature_enabled() {
-            var subStr = Substring(self)
-            if let aRange {
-                subStr = subStr[aRange]
-            }
-            return subStr._rangeOfCharacter(from: aSet, options: mask)
+        var subStr = Substring(self)
+        if let aRange {
+            subStr = subStr[aRange]
         }
-
-        return aSet.withUnsafeImmutableStorage {
-            return _optionalRange(_ns._rangeOfCharacter(from: $0, options: mask, range: _toRelativeNSRange(aRange ?? startIndex..<endIndex)))
-        }
+        return subStr._rangeOfCharacter(from: aSet, options: mask)
     }
 #endif // FOUNDATION_FRAMEWORK
 
@@ -117,22 +103,20 @@ extension StringProtocol {
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public func components<T : StringProtocol>(separatedBy separator: T) -> [String] {
 #if FOUNDATION_FRAMEWORK
-        if _foundation_essentials_feature_enabled() {
-            if let contiguousSubstring = _asContiguousUTF8Substring(from: startIndex..<endIndex) {
-                let options: String.CompareOptions
-                if separator == "\n" {
-                    // 106365366: Some clients intend to separate strings whose line separator is "\r\n" with "\n".
-                    // Maintain compatibility with `.literal` so that "\n" can match that in "\r\n" on the unicode scalar level.
-                    options = [.literal]
-                } else {
-                    options = []
-                }
+        if let contiguousSubstring = _asContiguousUTF8Substring(from: startIndex..<endIndex) {
+            let options: String.CompareOptions
+            if separator == "\n" {
+                // 106365366: Some clients intend to separate strings whose line separator is "\r\n" with "\n".
+                // Maintain compatibility with `.literal` so that "\n" can match that in "\r\n" on the unicode scalar level.
+                options = [.literal]
+            } else {
+                options = []
+            }
 
-                do {
-                    return try contiguousSubstring._components(separatedBy: Substring(separator), options: options)
-                } catch {
-                    // Otherwise, inputs were unsupported - fallthrough to NSString implementation for compatibility
-                }
+            do {
+                return try contiguousSubstring._components(separatedBy: Substring(separator), options: options)
+            } catch {
+                // Otherwise, inputs were unsupported - fallthrough to NSString implementation for compatibility
             }
         }
 

--- a/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
+++ b/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
@@ -23,15 +23,10 @@ extension StringProtocol {
     /// using the current locale.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public var localizedCapitalized: String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._capitalized(with: .current)
-        }
-#endif
-        return _ns.localizedCapitalized
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.localizedCapitalized
 #else
-        return String(self)._capitalized(with: .current)
+        String(self)._capitalized(with: .current)
 #endif
     }
 
@@ -39,15 +34,10 @@ extension StringProtocol {
     /// using the specified locale.
     @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
     public func capitalized(with locale: Locale?) -> String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._capitalized(with: locale)
-        }
-#endif
-        return _ns.capitalized(with: locale)
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.capitalized(with: locale)
 #else
-        return String(self)._capitalized(with: locale)
+        String(self)._capitalized(with: locale)
 #endif
     }
 
@@ -55,16 +45,10 @@ extension StringProtocol {
     /// locale.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public var localizedLowercase: String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._lowercased(with: .current)
-        }
-#endif
-
-        return _ns.localizedLowercase
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.localizedLowercase
 #else
-        return String(self)._lowercased(with: .current)
+        String(self)._lowercased(with: .current)
 #endif
     }
 
@@ -74,15 +58,10 @@ extension StringProtocol {
     /// locale.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public func lowercased(with locale: Locale?) -> String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._lowercased(with: locale)
-        }
-#endif
-        return _ns.lowercased(with: locale)
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.lowercased(with: locale)
 #else
-        return String(self)._lowercased(with: locale)
+        String(self)._lowercased(with: locale)
 #endif
     }
 
@@ -90,16 +69,10 @@ extension StringProtocol {
     /// locale.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public var localizedUppercase: String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._uppercased(with: .current)
-        }
-#endif
-
-        return _ns.localizedUppercase
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.localizedUppercase
 #else
-        return String(self)._uppercased(with: .current)
+        String(self)._uppercased(with: .current)
 #endif
     }
 
@@ -108,16 +81,10 @@ extension StringProtocol {
     /// locale.
     @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
     public func uppercased(with locale: Locale?) -> String {
-#if FOUNDATION_FRAMEWORK
-#if canImport(FoundationICU)
-        if _foundation_essentials_feature_enabled() {
-            return String(self)._uppercased(with: locale)
-        }
-#endif
-
-        return _ns.uppercased(with: locale)
+#if FOUNDATION_FRAMEWORK && !canImport(FoundationICU)
+        _ns.uppercased(with: locale)
 #else
-        return String(self)._uppercased(with: locale)
+        String(self)._uppercased(with: locale)
 #endif
     }
 }


### PR DESCRIPTION
Enable the code paths guarded behind the feature flag unconditionally now that the feature flag has been enabled for quite a while now.