### PR TITLE
Calendar.date(_: , matchesComponents: ) does not check for leap months correctly

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1242,20 +1242,13 @@ public struct Calendar : Hashable, Equatable, Sendable {
             return components.value(for: u) != nil
         }
 
-        if actualUnits.isEmpty {
-            // Try leap month
-            if components.isLeapMonth != nil {
-                let monthComponents = _dateComponents(.month, from: date)
-                // Apparently, enough that it's set and we don't check the actual value
-                return monthComponents.isLeapMonth != nil
-            }
-        }
-
         var comp = dateComponents(actualUnits, from: date)
         var tempComp = components
 
-        if comp.isLeapMonth != nil && components.isLeapMonth != nil {
-            tempComp.isLeapMonth = comp.isLeapMonth
+        if components.isLeapMonth != nil {
+            // `isLeapMonth` isn't part of `actualUnits`, so we have to retrieve
+            // it separately
+            comp.isLeapMonth = _dateComponents(.month, from: date).isLeapMonth
         }
 
         // Apply an epsilon to comparison of nanosecond values

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -547,6 +547,26 @@ final class CalendarTests : XCTestCase {
         XCTAssertTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
         XCTAssertFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
     }
+    
+    func test_leapMonthProperty() throws {
+        let c = Calendar(identifier: .chinese)
+        /// 2023-02-20 08:00:00 +0000 -- non-leap month in the Chinese calendar
+        let d1 = Date(timeIntervalSinceReferenceDate: 698572800.0)
+        /// 2023-03-22 07:00:00 +0000 -- leap month in the Chinese calendar
+        let d2 = Date(timeIntervalSinceReferenceDate: 701161200.0)
+        
+        var components = DateComponents()
+        components.isLeapMonth = true
+        XCTAssertFalse(c.date(d1, matchesComponents: components))
+        XCTAssertTrue(c.date(d2, matchesComponents: components))
+        components.isLeapMonth = false
+        XCTAssertTrue(c.date(d1, matchesComponents: components))
+        XCTAssertFalse(c.date(d2, matchesComponents: components))
+        components.day = 1
+        components.isLeapMonth = true
+        XCTAssertFalse(c.date(d1, matchesComponents: components))
+        XCTAssertTrue(c.date(d2, matchesComponents: components))
+    }
 
     func test_addingDeprecatedWeek() throws {
         let date = try Date("2024-02-24 01:00:00 UTC", strategy: .iso8601.dateTimeSeparator(.space))


### PR DESCRIPTION
When checking if a date matches components, we were checking whether isLeapMonth has been set, but were not reading its actual value. This meant that this method would sometimes return wrong results in calendars that have leap months.