### PR TITLE
Rename the UUID functions so they do not conflict with other definitions

### DIFF
--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -27,7 +27,7 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
     public init() {
         withUnsafeMutablePointer(to: &uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
-                uuid_generate_random($0)
+                _foundation_uuid_generate_random($0)
             }
         }
     }
@@ -49,7 +49,7 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
     public init?(uuidString string: __shared String) {
         let res = withUnsafeMutablePointer(to: &uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
-                return uuid_parse(string, $0)
+                return _foundation_uuid_parse(string, $0)
             }
         }
         if res != 0 {
@@ -68,7 +68,7 @@ public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
         return withUUIDBytes { valBuffer in
             withUnsafeMutablePointer(to: &bytes) { strPtr in
                 strPtr.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<uuid_string_t>.size) { str in
-                    uuid_unparse_upper(valBuffer.baseAddress!, str)
+                    _foundation_uuid_unparse_upper(valBuffer.baseAddress!, str)
                     return String(cString: str)
                 }
             }

--- a/Sources/_CShims/include/uuid.h
+++ b/Sources/_CShims/include/uuid.h
@@ -61,23 +61,23 @@ typedef __darwin_uuid_string_t    uuid_string_t;
 extern "C" {
 #endif
 
-INTERNAL void uuid_clear(uuid_t uu);
+INTERNAL void _foundation_uuid_clear(uuid_t uu);
 
-INTERNAL int uuid_compare(const uuid_t uu1, const uuid_t uu2);
+INTERNAL int _foundation_uuid_compare(const uuid_t uu1, const uuid_t uu2);
 
-INTERNAL void uuid_copy(uuid_t dst, const uuid_t src);
+INTERNAL void _foundation_uuid_copy(uuid_t dst, const uuid_t src);
 
-INTERNAL void uuid_generate(uuid_t out);
-INTERNAL void uuid_generate_random(uuid_t out);
-INTERNAL void uuid_generate_time(uuid_t out);
+INTERNAL void _foundation_uuid_generate(uuid_t out);
+INTERNAL void _foundation_uuid_generate_random(uuid_t out);
+INTERNAL void _foundation_uuid_generate_time(uuid_t out);
 
-INTERNAL int uuid_is_null(const uuid_t uu);
+INTERNAL int _foundation_uuid_is_null(const uuid_t uu);
 
-INTERNAL int uuid_parse(const uuid_string_t in, uuid_t uu);
+INTERNAL int _foundation_uuid_parse(const uuid_string_t in, uuid_t uu);
 
-INTERNAL void uuid_unparse(const uuid_t uu, uuid_string_t out);
-INTERNAL void uuid_unparse_lower(const uuid_t uu, uuid_string_t out);
-INTERNAL void uuid_unparse_upper(const uuid_t uu, uuid_string_t out);
+INTERNAL void _foundation_uuid_unparse(const uuid_t uu, uuid_string_t out);
+INTERNAL void _foundation_uuid_unparse_lower(const uuid_t uu, uuid_string_t out);
+INTERNAL void _foundation_uuid_unparse_upper(const uuid_t uu, uuid_string_t out);
 
 #ifdef __cplusplus
 }

--- a/Sources/_CShims/uuid.c
+++ b/Sources/_CShims/uuid.c
@@ -146,25 +146,25 @@ read_time(void)
 }
 
 void
-uuid_clear(uuid_t uu)
+_foundation_uuid_clear(uuid_t uu)
 {
     memset(uu, 0, sizeof(uuid_t));
 }
 
 int
-uuid_compare(const uuid_t uu1, const uuid_t uu2)
+_foundation_uuid_compare(const uuid_t uu1, const uuid_t uu2)
 {
     return memcmp(uu1, uu2, sizeof(uuid_t));
 }
 
 void
-uuid_copy(uuid_t dst, const uuid_t src)
+_foundation_uuid_copy(uuid_t dst, const uuid_t src)
 {
     memcpy(dst, src, sizeof(uuid_t));
 }
 
 void
-uuid_generate_random(uuid_t out)
+_foundation_uuid_generate_random(uuid_t out)
 {
     read_random(out, sizeof(uuid_t));
 
@@ -173,7 +173,7 @@ uuid_generate_random(uuid_t out)
 }
 
 void
-uuid_generate_time(uuid_t out)
+_foundation_uuid_generate_time(uuid_t out)
 {
     uint64_t time;
 
@@ -195,19 +195,19 @@ uuid_generate_time(uuid_t out)
 }
 
 void
-uuid_generate(uuid_t out)
+_foundation_uuid_generate(uuid_t out)
 {
-    uuid_generate_random(out);
+    _foundation_uuid_generate_random(out);
 }
 
 int
-uuid_is_null(const uuid_t uu)
+_foundation_uuid_is_null(const uuid_t uu)
 {
     return !memcmp(uu, UUID_NULL, sizeof(uuid_t));
 }
 
 int
-uuid_parse(const uuid_string_t in, uuid_t uu)
+_foundation_uuid_parse(const uuid_string_t in, uuid_t uu)
 {
     int n = 0;
 
@@ -227,7 +227,7 @@ uuid_parse(const uuid_string_t in, uuid_t uu)
 }
 
 void
-uuid_unparse_lower(const uuid_t uu, uuid_string_t out)
+_foundation_uuid_unparse_lower(const uuid_t uu, uuid_string_t out)
 {
     snprintf(out,
         sizeof(uuid_string_t),
@@ -244,7 +244,7 @@ uuid_unparse_lower(const uuid_t uu, uuid_string_t out)
 }
 
 void
-uuid_unparse_upper(const uuid_t uu, uuid_string_t out)
+_foundation_uuid_unparse_upper(const uuid_t uu, uuid_string_t out)
 {
     snprintf(out,
         sizeof(uuid_string_t),
@@ -261,7 +261,7 @@ uuid_unparse_upper(const uuid_t uu, uuid_string_t out)
 }
 
 void
-uuid_unparse(const uuid_t uu, uuid_string_t out)
+_foundation_uuid_unparse(const uuid_t uu, uuid_string_t out)
 {
-    uuid_unparse_upper(uu, out);
+    _foundation_uuid_unparse_upper(uu, out);
 }


### PR DESCRIPTION
Since we export the `uuid` functions from the library, we should prefix them with something so they don't conflict with the (commonly used) names from another UUID library.