### PR TITLE
Guard against UTF8 buffers from large strings in NSString filesystem representation

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -269,8 +269,8 @@ extension NSString {
                 }
             }
             
-            let next = buffer.initialize(fromContentsOf: utf8Buffer)
-            guard next < buffer.endIndex else {
+            var (leftoverIterator, next) = buffer.initialize(from: utf8Buffer)
+            guard leftoverIterator.next() == nil && next < buffer.endIndex else {
                 return false
             }
             buffer[next] = 0


### PR DESCRIPTION
When we have an all-ASCII NSString and we need to get it's filesystem representation we just copy the string's UTF-8 buffer into our new buffer. However, the function used crashes if the destination buffer does not have enough room for the source buffer. To avoid the crash, we now use initialize(from:) instead which returns an iterator that we can use to validate there were no extra un-copied bytes.