### PR TITLE
String.lastPathComponent should return last non-empty component

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -117,13 +117,18 @@ extension String {
         }
         
         if lastSlash == index(before: endIndex) {
-            // This is a trailing slash. Ignore it.
-            let beforeLastSlash = self[startIndex..<lastSlash].lastIndex { $0 == "/" }
-            if let beforeLastSlash {
-                return String(self[index(after: beforeLastSlash)..<lastSlash])
+            // This is a trailing slash. Ignore it and all slashes that directly precede it.
+            let lastNonSlash = self[startIndex..<lastSlash].lastIndex { $0 != "/" }
+            guard let lastNonSlash else {
+                // String is all slashes, return a bare slash.
+                return "/"
+            }
+            let slashBeforeLastComponent = self[startIndex..<lastNonSlash].lastIndex { $0 == "/" }
+            if let slashBeforeLastComponent {
+                return String(self[index(after: slashBeforeLastComponent)...lastNonSlash])
             } else {
-                // No other slash. Return string minus that slash.
-                return String(self[startIndex..<lastSlash])
+                // No other slash. Return string up to the last non-slash character.
+                return String(self[startIndex...lastNonSlash])
             }
         } else {
             return String(self[index(after: lastSlash)..<endIndex])

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -373,6 +373,32 @@ final class StringTests : XCTestCase {
         }
 #endif
     }
+
+    func testLastPathComponent() {
+        XCTAssertEqual("".lastPathComponent, "")
+        XCTAssertEqual("a".lastPathComponent, "a")
+        XCTAssertEqual("/a".lastPathComponent, "a")
+        XCTAssertEqual("a/".lastPathComponent, "a")
+        XCTAssertEqual("/a/".lastPathComponent, "a")
+
+        XCTAssertEqual("a/b".lastPathComponent, "b")
+        XCTAssertEqual("/a/b".lastPathComponent, "b")
+        XCTAssertEqual("a/b/".lastPathComponent, "b")
+        XCTAssertEqual("/a/b/".lastPathComponent, "b")
+
+        XCTAssertEqual("a//".lastPathComponent, "a")
+        XCTAssertEqual("a////".lastPathComponent, "a")
+        XCTAssertEqual("/a//".lastPathComponent, "a")
+        XCTAssertEqual("/a////".lastPathComponent, "a")
+        XCTAssertEqual("//a//".lastPathComponent, "a")
+        XCTAssertEqual("/a/b//".lastPathComponent, "b")
+        XCTAssertEqual("//a//b////".lastPathComponent, "b")
+
+        XCTAssertEqual("/".lastPathComponent, "/")
+        XCTAssertEqual("//".lastPathComponent, "/")
+        XCTAssertEqual("/////".lastPathComponent, "/")
+        XCTAssertEqual("/./..//./..//".lastPathComponent, "..")
+    }
 }
 
 


### PR DESCRIPTION
Updated `String.lastPathComponent` to match current Darwin behavior by returning the last non-empty component, e.g.

```
"hello///".lastPathComponent == "hello"
"//hello/there//".lastPathComponent == "there"
"///".lastPathComponent == "/"
```