### PR TITLE
File system representations should not be limited to PATH_MAX

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -88,11 +88,16 @@ extension String {
         }
         return result != nil
     }
+    
+    private var maxFileSystemRepresentationSize: Int {
+        // TODO: Likely an over estimate and slow for non-UTF16 strings, we should investigate to see if it can be smaller and computed more quickly, especially if we know the string is ASCII
+        self.utf16.count * 9 + 1
+    }
     #endif
     
     package func withFileSystemRepresentation<R>(_ block: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
         #if canImport(Darwin) || FOUNDATION_FRAMEWORK
-        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(PATH_MAX)) { buffer in
+        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: maxFileSystemRepresentationSize) { buffer in
             guard _fileSystemRepresentation(into: buffer) else {
                 return try block(nil)
             }
@@ -107,7 +112,7 @@ extension String {
     
     package func withMutableFileSystemRepresentation<R>(_ block: (UnsafeMutablePointer<CChar>?) throws -> R) rethrows -> R {
         #if canImport(Darwin) || FOUNDATION_FRAMEWORK
-        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(PATH_MAX)) { buffer in
+        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: maxFileSystemRepresentationSize) { buffer in
             guard _fileSystemRepresentation(into: buffer) else {
                 return try block(nil)
             }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -362,14 +362,13 @@ final class StringTests : XCTestCase {
         }
         
 #if canImport(Darwin) || FOUNDATION_FRAMEWORK
-        // A string of length PATH_MAX-1 should perfectly fit in the buffer (with the null byte)
+        // The buffer should dynamically grow and not be limited to a size of PATH_MAX
         Array(repeating: "A", count: Int(PATH_MAX) - 1).joined().withFileSystemRepresentation { ptr in
             XCTAssertNotNil(ptr)
         }
         
-        // This will not fit in the buffer with the null byte
         Array(repeating: "A", count: Int(PATH_MAX)).joined().withFileSystemRepresentation { ptr in
-            XCTAssertNil(ptr)
+            XCTAssertNotNil(ptr)
         }
 #endif
     }


### PR DESCRIPTION
There are certain strings that historically use the file system representation that aren't strictly paths (such as environment values and arguments to a launched process). Since these can exceed the size of `PATH_MAX`, we should use a variable size for the buffer rather than a fixed `PATH_MAX` size