### PR TITLE
Port FileManager to swift-foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,9 @@ let package = Package(
             "FoundationMacros",
             .product(name: "_RopeModule", package: "swift-collections"),
           ],
+          cSettings: [
+            .define("_GNU_SOURCE", .when(platforms: [.linux]))
+          ],
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
             .enableExperimentalFeature("AccessLevelOnImport")

--- a/Sources/FoundationEssentials/CocoaError.swift
+++ b/Sources/FoundationEssentials/CocoaError.swift
@@ -282,4 +282,6 @@ internal let NSUnderlyingErrorKey = "NSUnderlyingErrorKey"
 internal let NSUserStringVariantErrorKey = "NSUserStringVariantErrorKey"
 internal let NSFilePathErrorKey = "NSFilePathErrorKey"
 internal let NSURLErrorKey = "NSURLErrorKey"
+internal let NSSourceFilePathErrorKey = "NSSourceFilePathErrorKey"
+internal let NSDestinationFilePathErrorKey = "NSDestinationFilePathErrorKey"
 #endif

--- a/Sources/FoundationEssentials/Data/Data+Stub.swift
+++ b/Sources/FoundationEssentials/Data/Data+Stub.swift
@@ -70,11 +70,6 @@ extension Data {
     }
 }
 
-internal struct FileAttributeKey: RawRepresentable, Equatable, Hashable {
-    typealias RawValue = String
-    let rawValue: String
-}
-
 // Placeholder for Progress
 internal final class Progress {
     var completedUnitCount: Int64

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -1,0 +1,228 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+internal struct _FileManagerImpl {
+    weak var _manager: FileManager?
+    weak var delegate: FileManagerDelegate?
+    
+    var fileManager: FileManager {
+        guard let _manager else {
+            fatalError("_FileManagerImpl called without a valid reference to a FileManager")
+        }
+        return _manager
+    }
+    
+    var safeDelegate: FileManagerDelegate? {
+#if FOUNDATION_FRAMEWORK
+        fileManager._safeDelegate() as? FileManagerDelegate
+#else
+        self.delegate
+#endif
+    }
+    
+    init() {}
+    
+    #if FOUNDATION_FRAMEWORK
+    func displayName(atPath path: String) -> String {
+        // We lie to filePath:directoryHint: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.
+        let url = URL(filePath: path, directoryHint: .notDirectory)
+        
+        if let storedName = try? url.resourceValues(forKeys: [.localizedNameKey]).localizedName {
+            return storedName
+        }
+        
+        return path.lastPathComponent.replacing(":", with: "/")
+    }
+    #endif
+    
+    func contents(atPath path: String) -> Data? {
+        try? Data(contentsOfFile: path)
+    }
+    
+    func contentsEqual(
+        atPath path: String,
+        andPath other: String
+    ) -> Bool {
+        func _openFD(_ path: UnsafePointer<CChar>) -> Int32? {
+            var statBuf = stat()
+            let fd = open(path, 0, 0)
+            guard fd >= 0 else { return nil }
+            if fstat(fd, &statBuf) < 0 || statBuf.st_mode & S_IFMT == S_IFDIR {
+                close(fd)
+                return nil
+            }
+            return fd
+        }
+        
+        // compares contents in efficient manner
+        // note that symlinks are not traversed!
+        guard let myInfo = fileManager._fileStat(path), let otherInfo = fileManager._fileStat(other) else {
+            return false
+        }
+        
+        /* check for being hard links */
+        if myInfo.st_dev == otherInfo.st_dev && myInfo.st_ino == otherInfo.st_ino {
+            return true
+        }
+        
+        /* check for being same type */
+        if myInfo.st_mode & S_IFMT != otherInfo.st_mode & S_IFMT {
+            return false
+        }
+        
+        if myInfo.isSpecial {
+            return myInfo.st_rdev == otherInfo.st_rdev // different inodes aiming at same device
+        }
+        
+        if myInfo.isRegular {
+            if myInfo.st_size != otherInfo.st_size {
+                return false
+            }
+            return fileManager.withFileSystemRepresentation(for: path) { pathPtr in
+                guard let pathPtr, let fd1 = _openFD(pathPtr) else { return false }
+                defer { close(fd1) }
+                return fileManager.withFileSystemRepresentation(for: other) { otherPtr in
+                    guard let otherPtr, let fd2 = _openFD(otherPtr) else { return false }
+                    defer { close(fd2) }
+                    #if canImport(Darwin)
+                    _ = fcntl(fd1, F_NOCACHE, 1)
+                    _ = fcntl(fd2, F_NOCACHE, 1)
+                    #endif
+                    let quantum = 8 * 1024
+                    return withUnsafeTemporaryAllocation(of: CChar.self, capacity: quantum) { buf1 in
+                        buf1.initialize(repeating: 0)
+                        defer { buf1.deinitialize() }
+                        return withUnsafeTemporaryAllocation(of: CChar.self, capacity: quantum) { buf2 in
+                            buf2.initialize(repeating: 0)
+                            defer { buf2.deinitialize() }
+                            var readBytes = 0
+                            while true {
+                                readBytes = read(fd1, buf1.baseAddress!, quantum)
+                                guard readBytes > 0 else { break }
+                                if read(fd2, buf2.baseAddress!, quantum) != readBytes {
+                                    return false
+                                }
+                                if !buf1.elementsEqual(buf2) {
+                                    return false
+                                }
+                            }
+                            if readBytes < -1 { return false }
+                            return true
+                        }
+                    }
+                }
+            }
+        } else if myInfo.isSymbolicLink {
+            return (try? fileManager.destinationOfSymbolicLink(atPath: path) == fileManager.destinationOfSymbolicLink(atPath: other)) ?? false
+        } else if myInfo.isDirectory {
+            guard let myContents = try? fileManager.contentsOfDirectory(atPath: path),
+                  let otherContents = try? Set(fileManager.contentsOfDirectory(atPath: other)),
+                  myContents.count == otherContents.count else { return false }
+            for item in myContents {
+                guard otherContents.contains(item) else { return false }
+                let myItemPath = "\(path)/\(item)"
+                let otherItemPath = "\(other)/\(item)"
+                // Ok to call to self here because it's the same function
+                if !self.contentsEqual(atPath: myItemPath, andPath: otherItemPath) {
+                    return false
+                }
+            }
+            return true
+        }
+        
+        fatalError("Unknown file type 0x\(String(myInfo.st_mode, radix: 16)) for file \(path)")
+    }
+    
+    func fileSystemRepresentation(withPath path: String) -> UnsafePointer<CChar>? {
+        path.withFileSystemRepresentation { ptr -> UnsafePointer<CChar>? in
+            guard let ptr else {
+                return nil
+            }
+            
+            let len = strlen(ptr) + 1
+            let newPtr = UnsafeMutablePointer<CChar>.allocate(capacity: len)
+            memcpy(newPtr, ptr, len)
+            return UnsafePointer(newPtr)
+        }
+    }
+    
+    // SPI
+    func getFileSystemRepresentation(_ buffer: UnsafeMutablePointer<CChar>, maxLength: UInt, with path: String) -> Bool {
+        guard !path.isEmpty else {
+            return false
+        }
+        return path.withFileSystemRepresentation { ptr in
+            guard let ptr else {
+                return false
+            }
+            let lengthOfData = strlen(ptr) + 1
+            guard lengthOfData <= maxLength else {
+                return false
+            }
+            
+            memcpy(buffer, ptr, lengthOfData)
+            return true
+        }
+    }
+    
+    func string(
+        withFileSystemRepresentation str: UnsafePointer<CChar>,
+        length len: Int
+    ) -> String {
+        UnsafeBufferPointer(start: str, count: len).withMemoryRebound(to: UInt8.self) { buffer in
+            String(decoding: buffer, as: UTF8.self)
+        }
+    }
+}
+
+extension FileManager {
+    #if FOUNDATION_FRAMEWORK
+    @nonobjc
+    func withFileSystemRepresentation<R>(for path: String, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
+        var selfType: Any.Type { Self.self }
+        if selfType != FileManager.self {
+            // Subclasses can override getFileSystemRepresentation. Continue to call into that function to preserve subclassing behavior
+            return try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
+               guard self.getFileSystemRepresentation(buffer.baseAddress!, maxLength: FileManager.MAX_PATH_SIZE, withPath: path) else {
+                   return try body(nil)
+               }
+               return try body(buffer.baseAddress)
+            }
+        }
+        // We don't have a subclass, so we can call this directly to avoid the temp allocation + copy
+        return try path.withFileSystemRepresentation(body)
+    }
+    #endif
+    
+    @nonobjc
+    func _fileStat(_ path: String) -> stat? {
+        let result = self.withFileSystemRepresentation(for: path) { rep -> stat? in
+            var s = stat()
+            guard let rep, lstat(rep, &s) == 0 else {
+                return nil
+            }
+            return s
+        }
+        
+        guard let result else { return nil }
+        return result
+    }
+    
+    @nonobjc
+    static var MAX_PATH_SIZE: Int { 1026 }
+}

--- a/Sources/FoundationEssentials/FileManager/FileManager+Bridge.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Bridge.swift
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+@_implementationOnly import Foundation_Private.NSFileManager
+
+@objc(_NSFileManagerBridge)
+@objcMembers
+final class _NSFileManagerBridge : NSObject {
+    private let _impl: _FileManagerImpl
+    
+    @objc(initWithFileManager:)
+    init(implementing manager: FileManager) {
+        var impl = _FileManagerImpl()
+        impl._manager = manager
+        self._impl = impl
+        super.init()
+    }
+    
+    func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        _impl.urls(for: directory, in: domainMask)
+    }
+
+    func url(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
+        try _impl.url(for: directory, in: domain, appropriateFor: url, create: shouldCreate)
+    }
+    
+    func getRelationship(_ outRelationship: UnsafeMutablePointer<FileManager.URLRelationship>, ofDirectoryAt directoryURL: URL, toItemAt otherURL: URL) throws {
+        try _impl.getRelationship(outRelationship, ofDirectoryAt: directoryURL, toItemAt: otherURL)
+    }
+
+    func getRelationship(_ outRelationship: UnsafeMutablePointer<FileManager.URLRelationship>, of directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask, toItemAt url: URL) throws {
+        try _impl.getRelationship(outRelationship, of: directory, in: domainMask, toItemAt: url)
+    }
+
+    func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
+        try _impl.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
+    }
+
+    func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws {
+        try _impl.createSymbolicLink(at: url, withDestinationURL: destURL)
+    }
+
+    func setAttributes(_ attributes: [FileAttributeKey : Any], ofItemAtPath path: String) throws {
+        try _impl.setAttributes(attributes, ofItemAtPath: path)
+    }
+
+    func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
+        try _impl.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes)
+    }
+
+    func contentsOfDirectory(atPath path: String) throws -> [String] {
+        try _impl.contentsOfDirectory(atPath: path)
+    }
+
+    func subpathsOfDirectory(atPath path: String) throws -> [String] {
+        try _impl.subpathsOfDirectory(atPath: path)
+    }
+
+    func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
+        try _impl.attributesOfItem(atPath: path)
+    }
+
+    func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+        try _impl.attributesOfFileSystem(forPath: path)
+    }
+
+    func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+        try _impl.createSymbolicLink(atPath: path, withDestinationPath: destPath)
+    }
+
+    func destinationOfSymbolicLink(atPath path: String) throws -> String {
+        try _impl.destinationOfSymbolicLink(atPath: path)
+    }
+
+    func copyItem(atPath srcPath: String, toPath dstPath: String, options: NSFileManagerCopyOptions) throws {
+        try _impl.copyItem(atPath: srcPath, toPath: dstPath, options: options)
+    }
+
+    func moveItem(atPath srcPath: String, toPath dstPath: String, options: NSFileManagerMoveOptions) throws {
+        try _impl.moveItem(atPath: srcPath, toPath: dstPath, options: options)
+    }
+
+    func linkItem(atPath srcPath: String, toPath dstPath: String) throws {
+        try _impl.linkItem(atPath: srcPath, toPath: dstPath)
+    }
+
+    func removeItem(atPath path: String) throws {
+        try _impl.removeItem(atPath: path)
+    }
+
+    func copyItem(at srcURL: URL, to dstURL: URL, options: NSFileManagerCopyOptions) throws {
+        try _impl.copyItem(at: srcURL, to: dstURL, options: options)
+    }
+
+    func moveItem(at srcURL: URL, to dstURL: URL, options: NSFileManagerMoveOptions) throws {
+        try _impl.moveItem(at: srcURL, to: dstURL, options: options)
+    }
+
+    func linkItem(at srcURL: URL, to dstURL: URL) throws {
+        try _impl.linkItem(at: srcURL, to: dstURL)
+    }
+
+    func removeItem(at URL: URL) throws {
+        try _impl.removeItem(at: URL)
+    }
+
+    var currentDirectoryPath: String? {
+        _impl.currentDirectoryPath
+    }
+
+    func changeCurrentDirectoryPath(_ path: String) -> Bool {
+        _impl.changeCurrentDirectoryPath(path)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        _impl.fileExists(atPath: path)
+    }
+
+    func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        var dir = false
+        guard _impl.fileExists(atPath: path, isDirectory: &dir) else {
+            return false
+        }
+        if let isDirectory {
+            isDirectory.pointee = ObjCBool(dir)
+        }
+        return true
+    }
+
+    func isReadableFile(atPath path: String) -> Bool {
+        _impl.isReadableFile(atPath: path)
+    }
+
+    func isWritableFile(atPath path: String) -> Bool {
+        _impl.isWritableFile(atPath: path)
+    }
+
+    func isExecutableFile(atPath path: String) -> Bool {
+        _impl.isExecutableFile(atPath: path)
+    }
+
+    func isDeletableFile(atPath path: String) -> Bool {
+        _impl.isDeletableFile(atPath: path)
+    }
+
+    func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+        _impl.contentsEqual(atPath: path1, andPath: path2)
+    }
+
+    func displayName(atPath path: String) -> String {
+        _impl.displayName(atPath: path)
+    }
+    
+    func contents(atPath path: String) -> Data? {
+        _impl.contents(atPath: path)
+    }
+
+    func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
+        _impl.createFile(atPath: path, contents: data, attributes: attr)
+    }
+
+    func string(withFileSystemRepresentation str: UnsafePointer<CChar>, length len: Int) -> String {
+        _impl.string(withFileSystemRepresentation: str, length: len)
+    }
+    
+    func withFileSystemRepresentation<R>(for path: String, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
+        try path.withFileSystemRepresentation(body)
+    }
+
+    var homeDirectoryForCurrentUser: URL {
+        _impl.homeDirectoryForCurrentUser
+    }
+
+    var temporaryDirectory: URL {
+        _impl.temporaryDirectory
+    }
+    
+    func homeDirectory(forUser userName: String?) -> URL? {
+        _impl.homeDirectory(forUser: userName)
+    }
+}
+
+#endif

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -1,0 +1,398 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import containermanager
+@_implementationOnly import _ForSwiftFoundation
+@_implementationOnly import _CShims
+@_implementationOnly import os
+#endif
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+package import _CShims
+#endif
+
+#if FOUNDATION_FRAMEWORK
+var _shouldLog: Bool = {
+    UserDefaults.standard.bool(forKey: "NSLogSpecialFolderRecreation")
+}()
+func _LogSpecialFolderRecreation(_ fileManager: FileManager, _ path: String) {
+    if _shouldLog && !fileManager.fileExists(atPath: path) {
+        Logger().info("*** Application: \(Bundle.main.bundleIdentifier ?? "(null)") just recreated special folder: \(path)")
+    }
+}
+#endif
+
+extension _FileManagerImpl {
+    var homeDirectoryForCurrentUser: URL {
+        URL(filePath: String.homeDirectoryPath(), directoryHint: .isDirectory)
+    }
+    
+    func homeDirectory(forUser userName: String?) -> URL? {
+        URL(filePath:  String.homeDirectoryPath(forUser: userName), directoryHint: .isDirectory)
+    }
+    
+    var temporaryDirectory: URL {
+        URL(filePath: String.temporaryDirectoryPath, directoryHint: .isDirectory)
+    }
+    
+    #if FOUNDATION_FRAMEWORK
+    func url(
+        for directory: FileManager.SearchPathDirectory,
+        in domain: FileManager.SearchPathDomainMask,
+        appropriateFor url: URL?,
+        create shouldCreate: Bool
+    ) throws -> URL {
+        #if os(macOS) || os(iOS)
+        if let url, directory == .trashDirectory {
+            return try fileManager._URLForTrashingItem(at: url, create: shouldCreate)
+        }
+        #endif
+        if let url, domain == .userDomainMask, directory == .itemReplacementDirectory {
+            // The only place we need to do this is for certain operations, namely the replacing item API.
+            return try fileManager._URLForReplacingItem(at: url)
+        }
+        var domain = domain
+        if domain == .systemDomainMask {
+            domain = ._partitionedSystemDomainMask
+        }
+        let paths = Array(_SearchPaths(for: directory, in: domain, expandTilde: true))
+        guard let path = domain == ._partitionedSystemDomainMask ? paths.last : paths.first else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        
+        if shouldCreate {
+            #if FOUNDATION_FRAMEWORK
+            _LogSpecialFolderRecreation(fileManager, path)
+            #endif
+            var isUserDomain = domain == .userDomainMask
+            #if os(macOS)
+            isUserDomain = isUserDomain || domain == ._sharedUserDomainMask
+            #endif
+            var attrDictionary: [FileAttributeKey : Any] = [:]
+            if isUserDomain {
+                attrDictionary[.posixPermissions] = 0o700
+            } else if domain == ._partitionedSystemDomainMask {
+                attrDictionary[.posixPermissions] = 0o755
+                attrDictionary[.ownerAccountID] = 0 // root
+                attrDictionary[.groupOwnerAccountID] = 80 // admin
+            }
+            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: attrDictionary)
+        }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+    
+    func urls(
+        for directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask
+    ) -> [URL] {
+        _SearchPaths(for: directory, in: domainMask, expandTilde: true).map {
+            URL(fileURLWithPath: $0, isDirectory: true)
+        }
+    }
+    
+    func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? {
+        groupIdentifier.withCString {
+            guard let path = container_create_or_lookup_app_group_path_by_app_group_identifier($0, nil)  else {
+                return nil
+            }
+            
+            defer { path.deallocate() }
+            return URL(fileURLWithFileSystemRepresentation: path, isDirectory: true, relativeTo: nil)
+        }
+    }
+#endif
+    
+    func contentsOfDirectory(atPath path: String) throws -> [String] {
+        #if os(macOS)
+        // CFURLEnumerator/CarbonCore does not operate on /dev paths
+        if !path.standardizingPath.starts(with: "/dev") {
+            guard fileManager.fileExists(atPath: path) else {
+                throw CocoaError.errorWithFilePath(path, osStatus: -43 /*fnfErr*/, reading: true, variant: "Folder")
+            }
+            
+            #if FOUNDATION_FRAMEWORK
+            // Use CFURLEnumerator in Foundation framework, otherwise fallback to POSIX sequence below
+            var err: NSError?
+            guard let result = _NSDirectoryContentsFromCFURLEnumeratorError(URL(fileURLWithPath: path, isDirectory: true), nil, 0, true, &err) else {
+                throw err!
+            }
+            return result
+            #endif
+        }
+        #endif
+        var result: [String] = []
+        let iterator = _POSIXDirectoryContentsSequence(path: path, appendSlashForDirectory: false).makeIterator()
+        if let error = iterator.error {
+            throw error
+        } else {
+            while let item = iterator.next() {
+                result.append(item.fileName)
+            }
+        }
+        return result
+    }
+    
+    func subpathsOfDirectory(atPath path: String) throws -> [String] {
+        return try path.withFileSystemRepresentation { fileSystemRep in
+            guard let fileSystemRep else {
+                throw CocoaError.errorWithFilePath(.fileNoSuchFile, path)
+            }
+            
+            let subpaths = _FTSSequence(fileSystemRep, FTS_PHYSICAL | FTS_NOCHDIR | FTS_NOSTAT).subpaths
+            var realFirstPath: String?
+            
+            var results: [String] = []
+            for item in subpaths {
+                var subpath: String
+                switch item {
+                case .error(let errNum, let p):
+                    throw CocoaError.errorWithFilePath(p, errno: errNum, reading: true)
+                case .entry(let path):
+                    subpath = path
+                }
+                
+                guard let realFirstPath else {
+                    realFirstPath = subpath
+                    continue
+                }
+                
+                let trueSubpath = subpath.trimmingPrefix(realFirstPath)
+                if trueSubpath.first == "/" {
+                    results.append(String(trueSubpath.dropFirst()))
+                } else if !trueSubpath.isEmpty {
+                    results.append(String(trueSubpath))
+                }
+            }
+            return results
+        }
+    }
+    
+    #if FOUNDATION_FRAMEWORK
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey : Any]? = nil
+    ) throws {
+        guard url.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileWriteUnsupportedScheme, url)
+        }
+        
+        let path = url.path
+        guard !path.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, url)
+        }
+        
+        try createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes)
+    }
+    #endif
+    
+    func createDirectory(
+        atPath path: String,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey : Any]? = nil
+    ) throws {
+        try fileManager.withFileSystemRepresentation(for: path) { pathPtr in
+            guard let pathPtr else {
+                throw CocoaError.errorWithFilePath(.fileWriteUnknown, path)
+            }
+            
+            guard createIntermediates else {
+                guard mkdir(pathPtr, 0o777) == 0 else {
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                }
+                if let attributes {
+                    try? fileManager.setAttributes(attributes, ofItemAtPath: path)
+                }
+                return
+            }
+            
+            #if FOUNDATION_FRAMEWORK
+            var firstDirectoryPtr: UnsafePointer<CChar>?
+            defer { firstDirectoryPtr?.deallocate() }
+            let result = _mkpath_np(pathPtr, S_IRWXU | S_IRWXG | S_IRWXO, &firstDirectoryPtr)
+            
+            guard result == 0 else {
+                guard result != EEXIST else { return }
+                var errNum = result
+                var errPath = path
+                if result == ENOTDIR {
+                    // _mkpath_np reports ENOTDIR when any component in the path is a regular file. We need to do two things to ensure binary compatibility: 1) find that file -- we have to report it in the error, and 2) special-case the last component. For whatever reason, we've always reported EEXIST for this case. This requires some extra stat'ing.
+                    var currentDirectory = path
+                    var isLastComponent = true
+                    // This shouldn't happen unless there are file system races going on, but stop iterating when we reach "/".
+                    while currentDirectory.count > 1 {
+                        if fileManager.fileExists(atPath: currentDirectory) {
+                            errPath = currentDirectory
+                            if isLastComponent {
+                                errNum = EEXIST
+                            }
+                            break
+                        }
+                        currentDirectory = currentDirectory.deletingLastPathComponent()
+                        isLastComponent = false
+                    }
+                }
+                throw CocoaError.errorWithFilePath(errPath, errno: errNum, reading: false)
+            }
+            
+            guard let attributes else {
+                return // Nothing left to do
+            }
+            
+            // The directory was successfully created. To keep binary compatibility, we need to post-process the newly created directories and set attributes.
+            // We're relying on the knowledge that _mkpath_np does not change any of the parent path components of firstDirectory. Otherwise, I think we'd have to canonicalize paths or check for IDs, which would probably require more file system calls than is worthwhile.
+            var currentDirectory = firstDirectoryPtr.flatMap(String.init(cString:)) ?? path
+            
+            // Start with the first newly created directory.
+            try? fileManager.setAttributes(attributes, ofItemAtPath: currentDirectory)// Not returning error to preserve binary compatibility.
+            
+            // Now append each subsequent path component.
+            let fullComponents = path.pathComponents
+            let currentComponents = currentDirectory.pathComponents
+            for component in fullComponents[currentComponents.count...] {
+                currentDirectory = currentDirectory.appendingPathComponent(component)
+                try? fileManager.setAttributes(attributes, ofItemAtPath: currentDirectory) // Not returning error to preserve binary compatibility.
+            }
+            #else
+            func _create(path: String, leafFile: Bool = true) throws {
+                var isDir = false
+                guard !fileManager.fileExists(atPath: path, isDirectory: &isDir) else {
+                    if !isDir && leafFile {
+                        throw CocoaError.errorWithFilePath(path, errno: EEXIST, reading: false)
+                    }
+                    return
+                }
+                let parent = path.deletingLastPathComponent()
+                if !parent.isEmpty {
+                    try _create(path: parent, leafFile: false)
+                }
+                try fileManager.withFileSystemRepresentation(for: path) { pathFsRep in
+                    guard let pathFsRep else {
+                        throw CocoaError.errorWithFilePath(.fileWriteInvalidFileName, path)
+                    }
+                    guard mkdir(pathFsRep, 0o777) == 0 else {
+                        let posixErrno = errno
+                        if posixErrno == EEXIST && fileManager.fileExists(atPath: path, isDirectory: &isDir) && isDir {
+                            // Continue; if there is an existing file and it is a directory, that is still a success.
+                            // There can be an existing file if another thread or process concurrently creates the
+                            // same file.
+                            return
+                        } else {
+                            throw CocoaError.errorWithFilePath(path, errno: posixErrno, reading: false)
+                        }
+                    }
+                    if let attr = attributes {
+                        try? fileManager.setAttributes(attr, ofItemAtPath: path)
+                    }
+                }
+            }
+            try _create(path: path)
+            #endif
+        }
+    }
+    
+    #if FOUNDATION_FRAMEWORK
+    func getRelationship(
+        _ outRelationship: UnsafeMutablePointer<FileManager.URLRelationship>,
+        ofDirectoryAt directoryURL: URL,
+        toItemAt otherURL: URL
+    ) throws {
+        // Get url's resource identifier, volume identifier, and make sure it is a directory
+        let dirValues = try directoryURL.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey, .isDirectoryKey])
+        
+        guard dirValues.isDirectory! else {
+            outRelationship.pointee = .other
+            return
+        }
+        
+        // Get other's resource identifier and make sure it is not the same resource as otherURL
+        let otherValues = try otherURL.resourceValues(forKeys: [.fileIdentifierKey, .fileResourceIdentifierKey, .volumeIdentifierKey])
+        guard !otherValues.fileResourceIdentifier!.isEqual(dirValues.fileResourceIdentifier!) else {
+            outRelationship.pointee = .same
+            return
+        }
+        
+        guard otherValues.volumeIdentifier!.isEqual(dirValues.volumeIdentifier!) else {
+            outRelationship.pointee = .other
+            return
+        }
+        
+        // Start looking through the parent chain up to the volume root for a parent that is equal to 'url'. Stop when the current URL reaches the volume root
+        var currentURL = otherURL
+        while try !currentURL.resourceValues(forKeys: [.isVolumeKey]).isVolume! {
+            // Get url's parentURL
+            let parentURL = try currentURL.resourceValues(forKeys: [.parentDirectoryURLKey]).parentDirectory!
+            
+            let parentResourceID = try parentURL.resourceValues(forKeys: [.fileResourceIdentifierKey]).fileResourceIdentifier!
+            
+            if parentResourceID.isEqual(dirValues.fileResourceIdentifier!) {
+                outRelationship.pointee = .contains
+                return
+            }
+            
+            currentURL = parentURL
+        }
+        
+        outRelationship.pointee = .other
+        return
+    }
+    
+    func getRelationship(
+        _ outRelationship: UnsafeMutablePointer<FileManager.URLRelationship>,
+        of directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask,
+        toItemAt url: URL
+    ) throws {
+        // Figure out the standard directory, then call the other API
+        let directoryURL = try fileManager.url(
+            for: directory,
+            in: domainMask,
+            appropriateFor: domainMask.isEmpty ? url : nil,
+            create: false)
+        return try fileManager.getRelationship(
+            outRelationship,
+            ofDirectoryAt: directoryURL,
+            toItemAt: url)
+    }
+#endif
+    
+    func changeCurrentDirectoryPath(_ path: String) -> Bool {
+        fileManager.withFileSystemRepresentation(for: path) { rep in
+            guard let rep else { return false }
+#if os(Windows)
+            return SetCurrentDirectoryW(rep)
+#else
+            return chdir(rep) == 0
+#endif
+        }
+    }
+    
+    var currentDirectoryPath: String? {
+        withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
+#if !os(Windows)
+            guard getcwd(buffer.baseAddress!, FileManager.MAX_PATH_SIZE) != nil else {
+                return nil
+            }
+#else
+            guard GetCurrentDirectoryW(FileManager.MAX_PATH_SIZE, buffer.baseAddress!) >= 0 else {
+                return nil
+            }
+#endif
+            
+            return fileManager.string(withFileSystemRepresentation: buffer.baseAddress!, length: strlen(buffer.baseAddress!))
+        }
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -1,0 +1,682 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import Foundation_Private.NSFileManager
+#endif
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+package import _CShims
+#endif
+
+extension Date {
+    fileprivate init(seconds: TimeInterval, nanoSeconds: TimeInterval) {
+        self.init(timeIntervalSinceReferenceDate: seconds - Self.timeIntervalBetween1970AndReferenceDate + nanoSeconds / 1_000_000_000.0 )
+    }
+}
+
+private func _nameFor(uid: uid_t) -> String? {
+    guard let pwd = getpwuid(uid), let name = pwd.pointee.pw_name else {
+        return nil
+    }
+    return String(cString: name)
+}
+
+private func _nameFor(gid: gid_t) -> String? {
+    guard let pwd = getgrgid(gid), let name = pwd.pointee.gr_name else {
+        return nil
+    }
+    return String(cString: name)
+}
+
+extension mode_t {
+    fileprivate var fileType: FileAttributeType {
+        switch self & S_IFMT {
+        case S_IFCHR: .typeCharacterSpecial
+        case S_IFDIR: .typeDirectory
+        case S_IFBLK: .typeBlockSpecial
+        case S_IFREG: .typeRegular
+        case S_IFLNK: .typeSymbolicLink
+        case S_IFSOCK: .typeSocket
+        default: .typeUnknown
+        }
+    }
+}
+
+func _readFileAttributePrimitive<T: BinaryInteger>(_ value: Any?, as type: T.Type) -> T? {
+    guard let value else { return nil }
+    #if FOUNDATION_FRAMEWORK
+    if let nsNumber = value as? NSNumber, let result = nsNumber as? T {
+        return result
+    }
+    #endif
+    
+    if let binInt = value as? (any BinaryInteger), let result = T(exactly: binInt) {
+        return result
+    }
+    return nil
+}
+
+func _readFileAttributePrimitive(_ value: Any?, as type: Bool.Type) -> Bool? {
+    guard let value else { return nil }
+    #if FOUNDATION_FRAMEWORK
+    if let nsNumber = value as? NSNumber, let result = nsNumber as? Bool {
+        return result
+    }
+    #endif
+    
+    if let binInt = value as? (any BinaryInteger), let result = Int(exactly: binInt) {
+        switch result {
+        case 0: return false
+        case 1: return true
+        default: return nil
+        }
+    }
+    return nil
+}
+
+func _writeFileAttributePrimitive<T: BinaryInteger, U: BinaryInteger>(_ value: T, as type: U.Type) -> Any {
+    #if FOUNDATION_FRAMEWORK
+    if let int = Int64(exactly: value) {
+        NSNumber(value: int)
+    } else {
+        NSNumber(value: UInt64(value))
+    }
+    #else
+    U(value)
+    #endif
+}
+
+func _writeFileAttributePrimitive(_ value: Bool) -> Any {
+    #if FOUNDATION_FRAMEWORK
+    NSNumber(value: value)
+    #else
+    value
+    #endif
+}
+
+extension stat {
+    var modificationDate: Date {
+        #if canImport(Darwin)
+        Date(seconds: TimeInterval(st_mtimespec.tv_sec), nanoSeconds: TimeInterval(st_mtimespec.tv_nsec))
+        #else
+        Date(seconds: TimeInterval(st_mtim.tv_sec), nanoSeconds: TimeInterval(st_mtim.tv_nsec))
+        #endif
+    }
+    
+    var creationDate: Date {
+        #if canImport(Darwin)
+        Date(seconds: TimeInterval(st_ctimespec.tv_sec), nanoSeconds: TimeInterval(st_ctimespec.tv_nsec))
+        #else
+        Date(seconds: TimeInterval(st_ctim.tv_sec), nanoSeconds: TimeInterval(st_ctim.tv_nsec))
+        #endif
+    }
+    
+    fileprivate var fileAttributes: [FileAttributeKey : Any] {
+        let fileType = st_mode.fileType
+        var result: [FileAttributeKey : Any] = [
+            .size : _writeFileAttributePrimitive(st_size, as: UInt.self),
+            .modificationDate : modificationDate,
+            .creationDate : creationDate,
+            .posixPermissions : _writeFileAttributePrimitive(st_mode & 0o7777, as: UInt.self),
+            .referenceCount : _writeFileAttributePrimitive(st_nlink, as: UInt.self),
+            .systemNumber : _writeFileAttributePrimitive(st_dev, as: UInt.self),
+            .systemFileNumber : _writeFileAttributePrimitive(st_ino, as: UInt64.self),
+            .type : fileType,
+            .ownerAccountID : _writeFileAttributePrimitive(st_uid, as: UInt.self),
+            .groupOwnerAccountID : _writeFileAttributePrimitive(st_gid, as: UInt.self)
+        ]
+        if let userName = _nameFor(uid: st_uid) {
+            result[.ownerAccountName] = userName
+        }
+        if let groupName = _nameFor(gid: st_gid) {
+            result[.groupOwnerAccountName] = groupName
+        }
+        if fileType == .typeBlockSpecial || fileType == .typeCharacterSpecial {
+            result[.deviceIdentifier] = _writeFileAttributePrimitive(st_rdev, as: UInt.self)
+        }
+        #if canImport(Darwin)
+        if (st_flags & UInt32(UF_IMMUTABLE)) != 0 || (st_flags & UInt32(SF_IMMUTABLE)) != 0 {
+            result[.immutable] = _writeFileAttributePrimitive(true)
+        }
+        if (st_flags & UInt32(UF_APPEND)) != 0 || (st_flags & UInt32(SF_APPEND)) != 0 {
+            result[.appendOnly] = _writeFileAttributePrimitive(true)
+        }
+        #endif
+        return result
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+extension FileProtectionType {
+    var intValue: Int32? {
+        switch self {
+        case .complete: PROTECTION_CLASS_A
+        case .init(rawValue: "NSFileProtectionWriteOnly"), .completeUnlessOpen: PROTECTION_CLASS_B
+        case .init(rawValue: "NSFileProtectionCompleteUntilUserAuthentication"), .completeUntilFirstUserAuthentication: PROTECTION_CLASS_C
+        case .none: PROTECTION_CLASS_D
+        #if !os(macOS)
+        case .completeWhenUserInactive: PROTECTION_CLASS_CX
+        #endif
+        default: nil
+        }
+    }
+    
+    init?(intValue value: Int32) {
+        switch value {
+        case PROTECTION_CLASS_A: self = .complete
+        case PROTECTION_CLASS_B: self = .completeUnlessOpen
+        case PROTECTION_CLASS_C: self = .completeUntilFirstUserAuthentication
+        case PROTECTION_CLASS_D: self = .none
+        #if !os(macOS)
+        case PROTECTION_CLASS_CX: self = .completeWhenUserInactive
+        #endif
+        default: return nil
+        }
+    }
+}
+#endif
+
+extension FileAttributeKey {
+    fileprivate static var _extendedAttributes: Self { Self("NSFileExtendedAttributes") }
+}
+
+extension _FileManagerImpl {
+    func createFile(
+        atPath path: String,
+        contents data: Data?,
+        attributes attr: [FileAttributeKey : Any]? = nil
+    ) -> Bool {
+        #if (os(iOS) || os(watchOS) || os(tvOS)) && FOUNDATION_FRAMEWORK
+        // Creating a file with a specific file protection class must have that class specified at open() time. Special-case NSFileProtectionKey here so that we can pass it as an NSDataWritingOption instead. 21998573.
+        var opts = Data.WritingOptions.atomic
+        var attr = attr
+        if let protection = attr?[.protectionKey] as? String {
+            let option: Data.WritingOptions? = switch FileProtectionType(rawValue: protection) {
+            case .none: .noFileProtection
+            case .complete: .completeFileProtection
+            case .completeUnlessOpen: .completeFileProtectionUnlessOpen
+            case .completeUntilFirstUserAuthentication: .completeFileProtectionUntilFirstUserAuthentication
+            case .completeWhenUserInactive: .completeFileProtectionWhenUserInactive
+            default: nil
+            }
+            if let option {
+                opts.insert(option)
+            }
+            attr?[.protectionKey] = nil
+        }
+        #else
+        let opts = Data.WritingOptions.atomic
+        #endif
+        
+        do {
+            try (data ?? .init()).write(to: URL(fileURLWithPath: path), options: opts)
+        } catch {
+            return false
+        }
+        if let attr {
+            try? fileManager.setAttributes(attr, ofItemAtPath: path)
+        }
+        return true
+    }
+    
+    func removeItem(at url: URL) throws {
+        guard url.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, url)
+        }
+        
+        let path = url.path
+        guard !path.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, url)
+        }
+        
+        try removeItem(atPath: path)
+    }
+    
+    func removeItem(atPath path: String) throws {
+        try _FileOperations.removeFile(path, with: fileManager)
+    }
+    
+    func copyItem(
+        at srcURL: URL,
+        to dstURL: URL,
+        options: NSFileManagerCopyOptions
+    ) throws {
+        guard srcURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, srcURL)
+        }
+        guard dstURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, dstURL)
+        }
+        
+        let srcPath = srcURL.path
+        guard !srcPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, srcURL)
+        }
+        let dstPath = dstURL.path
+        guard !dstPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, dstURL)
+        }
+        
+        try copyItem(atPath: srcPath, toPath: dstPath, options: options)
+    }
+    
+    func copyItem(
+        atPath srcPath: String,
+        toPath dstPath: String,
+        options: NSFileManagerCopyOptions
+    ) throws {
+        try _FileOperations.copyFile(srcPath, to: dstPath, with: fileManager, options: options)
+    }
+    
+    func moveItem(
+        at srcURL: URL,
+        to dstURL: URL,
+        options: NSFileManagerMoveOptions
+    ) throws {
+        guard srcURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, srcURL)
+        }
+        guard dstURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, dstURL)
+        }
+        
+        let srcPath = srcURL.path
+        guard !srcPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, srcURL)
+        }
+        let dstPath = dstURL.path
+        guard !dstPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, dstURL)
+        }
+        
+        try moveItem(atPath: srcPath, toPath: dstPath, options: options)
+    }
+    
+    func moveItem(
+        atPath srcPath: String,
+        toPath dstPath: String,
+        options: NSFileManagerMoveOptions
+    ) throws {
+        try _FileOperations.moveFile(
+            URL(fileURLWithPath: srcPath),
+            to: URL(fileURLWithPath: dstPath),
+            with: fileManager,
+            options: options
+        )
+    }
+    
+    private func _fileExists(_ path: String) -> (exists: Bool, isDirectory: Bool) {
+        path.withFileSystemRepresentation { rep -> (Bool, Bool) in
+            guard let rep else {
+                return (false, false)
+            }
+            
+            var fileInfo = stat()
+            guard stat(rep, &fileInfo) == 0 else {
+                return (false, false)
+            }
+            let isDir = (fileInfo.st_mode & S_IFMT) == S_IFDIR
+            return (true, isDir)
+        }
+    }
+    
+    func fileExists(atPath path: String) -> Bool {
+        _fileExists(path).exists
+    }
+    
+    func fileExists(
+        atPath path: String,
+        isDirectory: inout Bool
+    ) -> Bool {
+        let result = _fileExists(path)
+        guard result.exists else { return false }
+        isDirectory = result.isDirectory
+        return true
+    }
+    
+    private func _fileAccessibleForMode(_ path: String, _ mode: Int32) -> Bool {
+        path.withFileSystemRepresentation { ptr in
+            guard let ptr else { return false }
+            return access(ptr, mode) == 0
+        }
+    }
+    
+    func isReadableFile(atPath path: String) -> Bool {
+        _fileAccessibleForMode(path, R_OK)
+    }
+    
+    func isWritableFile(atPath path: String) -> Bool {
+        _fileAccessibleForMode(path, W_OK)
+    }
+    
+    func isExecutableFile(atPath path: String) -> Bool {
+        _fileAccessibleForMode(path, X_OK)
+    }
+    
+    func isDeletableFile(atPath path: String) -> Bool {
+        var parent = path.deletingLastPathComponent()
+        if parent.isEmpty {
+            parent = fileManager.currentDirectoryPath
+        }
+        
+        guard fileManager.isWritableFile(atPath: parent),
+              let dirInfo = fileManager._fileStat(parent) else {
+            return false
+        }
+        
+        if ((dirInfo.st_mode & S_ISVTX) != 0) && fileManager.fileExists(atPath: path) {
+            // its sticky so verify that we own the file
+            // otherwise we answer YES on the principle that if
+            // we create files we can delete them
+            
+            guard let fileInfo = fileManager._fileStat(path) else {
+                return false
+            }
+            return fileInfo.st_uid == getuid();
+        } else {
+            return true
+        }
+    }
+    
+    private func _extendedAttribute(_ key: UnsafePointer<CChar>, at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> Data {
+        #if canImport(Darwin)
+        var size = getxattr(path, key, nil, 0, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
+        #else
+        var size = followSymlinks ? getxattr(path, key, nil, 0) : lgetxattr(path, key, nil, 0)
+        #endif
+        guard size > 0 else {
+            throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: true)
+        }
+        // Deallocated below in the Data deallocator
+        let buffer = malloc(size)!
+        #if canImport(Darwin)
+        size = getxattr(path, key, buffer, size, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
+        #else
+        size = followSymlinks ? getxattr(path, key, buffer, size) : lgetxattr(path, key, buffer, size)
+        #endif
+        guard size > 0 else {
+            free(buffer)
+            throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: true)
+        }
+        return Data(bytesNoCopy: buffer, count: size, deallocator: .free)
+    }
+    
+    private func _extendedAttributes(at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> [String : Data]? {
+        #if canImport(Darwin)
+        var size = listxattr(path, nil, 0, 0)
+        #else
+        var size = listxattr(path, nil, 0)
+        #endif
+        guard size > 0 else { return nil }
+        let keyList = UnsafeMutableBufferPointer<CChar>.allocate(capacity: size)
+        defer { keyList.deallocate() }
+        #if canImport(Darwin)
+        size = listxattr(path, keyList.baseAddress!, size, 0)
+        #else
+        size = listxattr(path, keyList.baseAddress!, size)
+        #endif
+        guard size > 0 else { return nil }
+        
+        var extendedAttrs: [String : Data] = [:]
+        var current = keyList.baseAddress!
+        let end = keyList.baseAddress!.advanced(by: keyList.count)
+        while current < end {
+            let currentKey = String(cString: current)
+            defer { current = current.advanced(by: currentKey.utf8.count) + 1 /* pass null byte */ }
+            
+            #if canImport(Darwin)
+            if currentKey == XATTR_RESOURCEFORK_NAME || currentKey == XATTR_FINDERINFO_NAME || currentKey == "system.Security" {
+                continue
+            }
+            #endif
+            
+            extendedAttrs[currentKey] = try _extendedAttribute(current, at: path, followSymlinks: false)
+        }
+        return extendedAttrs
+    }
+    
+    func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
+        try fileManager.withFileSystemRepresentation(for: path) { fsRep in
+            guard let fsRep else {
+                throw CocoaError.errorWithFilePath(.fileReadUnknown, path)
+            }
+            
+            var statAtPath = stat()
+            guard lstat(fsRep, &statAtPath) == 0 else {
+                throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+            }
+            
+            var attributes = statAtPath.fileAttributes
+            try? Self._catInfo(for: URL(filePath: path, directoryHint: .isDirectory), statInfo: statAtPath, into: &attributes)
+            
+            if let extendedAttrs = try? _extendedAttributes(at: fsRep, followSymlinks: false) {
+                attributes[._extendedAttributes] = extendedAttrs
+            }
+            
+            #if !targetEnvironment(simulator) && FOUNDATION_FRAMEWORK
+            if statAtPath.isRegular || statAtPath.isDirectory {
+                if let protectionClass = Self._fileProtectionValueForPath(fsRep), let pType = FileProtectionType(intValue: protectionClass) {
+                    attributes[.protectionKey] = pType
+                } else {
+                    attributes[.protectionKey] = nil
+                }
+            }
+            #endif
+            return attributes
+        }
+    }
+    
+    func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+        try fileManager.withFileSystemRepresentation(for: path) { rep in
+            guard let rep else {
+                throw CocoaError.errorWithFilePath(.fileReadUnknown, path)
+            }
+            
+            #if canImport(Darwin)
+            var result = statfs()
+            let statfsReturnValue = statfs(rep, &result)
+            #else
+            var result = statvfs()
+            let statfsReturnValue = statvfs(rep, &result)
+            #endif
+            guard statfsReturnValue == 0 else {
+                throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+            }
+            
+            #if canImport(Darwin)
+            let fsNumber = result.f_fsid.val.0
+            let blockSize = UInt64(result.f_bsize)
+            #else
+            let fsNumber = result.f_fsid
+            let blockSize = UInt(result.f_frsize)
+            #endif
+            var totalSizeBytes = result.f_blocks * blockSize
+            var availSizeBytes = result.f_bavail * blockSize
+            var totalFiles = result.f_files
+            var availFiles = result.f_ffree
+            
+            
+            #if canImport(Darwin)
+            func QCMD(_ cmd: Int32, _ type: Int32) -> Int32 {
+                (cmd << SUBCMDSHIFT) | (type & SUBCMDMASK)
+            }
+            
+            func _quotactl<T>(_ path: UnsafePointer<CChar>, _ cmd: Int32, _ type: Int32, _ uid: uid_t, init: T) -> T? {
+                var res = `init`
+                let success = withUnsafeMutableBytes(of: &res) { buffer in
+                    quotactl(path, QCMD(cmd, type), Int32(uid), buffer.baseAddress!) == 0
+                }
+                return success ? res : nil
+            }
+            
+            withUnsafeBytes(of: &result.f_mntonname) { mntonnameBuffer in
+                let mntonname = mntonnameBuffer.baseAddress!.assumingMemoryBound(to: CChar.self)
+                // If a quota is enabled, get quota info
+                let userID = geteuid()
+                if let isQuotaOn = _quotactl(mntonname, Q_QUOTASTAT, USRQUOTA, userID, init: 0),
+                   isQuotaOn != 0,
+                   let quotaInfo = _quotactl(mntonname, Q_GETQUOTA, USRQUOTA, userID, init: dqblk()) {
+                    // For each value (total/available bytes, total/available files) report the smaller of the quota hard limit and the statfs value.
+                    if quotaInfo.dqb_bhardlimit > 0 {
+                        totalSizeBytes = min(quotaInfo.dqb_bhardlimit, totalSizeBytes)
+                        availSizeBytes = min(quotaInfo.dqb_bhardlimit - quotaInfo.dqb_curbytes, availSizeBytes)
+                    }
+                    if (quotaInfo.dqb_ihardlimit > 0) {
+                        totalFiles = min(UInt64(quotaInfo.dqb_ihardlimit), totalFiles)
+                        availFiles = min(UInt64(quotaInfo.dqb_ihardlimit - quotaInfo.dqb_curinodes), availFiles)
+                    }
+                }
+            }
+            #endif
+            
+            return [
+                .systemSize : _writeFileAttributePrimitive(totalSizeBytes, as: UInt64.self),
+                .systemFreeSize : _writeFileAttributePrimitive(availSizeBytes, as: UInt64.self),
+                .systemNodes : _writeFileAttributePrimitive(totalFiles, as: UInt64.self),
+                .systemFreeNodes : _writeFileAttributePrimitive(availFiles, as: UInt64.self),
+                .systemNumber : _writeFileAttributePrimitive(fsNumber, as: Int.self)
+            ]
+        }
+    }
+    
+    func setAttributes(
+        _ attributes: [FileAttributeKey : Any],
+        ofItemAtPath path: String
+    ) throws {
+        try fileManager.withFileSystemRepresentation(for: path) { fileSystemRepresentation in
+            guard let fileSystemRepresentation else {
+                throw CocoaError.errorWithFilePath(.fileWriteUnknown, path)
+            }
+            
+            let mode = _readFileAttributePrimitive(attributes[.posixPermissions], as: UInt.self)
+            let immutable = _readFileAttributePrimitive(attributes[.immutable], as: Bool.self)
+            let appendOnly = _readFileAttributePrimitive(attributes[.appendOnly], as: Bool.self)
+            // Use Result instead of throwing var to avoid compiler hang (rdar://119035093)
+            lazy var statAtPath: Result<stat, CocoaError> = {
+                var result = stat()
+                if lstat(fileSystemRepresentation, &result) != 0 {
+                    return .failure(CocoaError.errorWithFilePath(path, errno: errno, reading: false))
+                }
+                return .success(result)
+            }()
+            
+            // Set the flags first if we could be clearing the immutable bit. Set them last if we could be setting the immutable bit.
+            var setFlags: (() throws -> Void)?
+            if (immutable != nil || appendOnly != nil) {
+                #if canImport(Darwin)
+                setFlags = {
+                    var flags = try statAtPath.get().st_flags
+                    if let appendOnly {
+                        if appendOnly {
+                            flags |= UInt32(UF_APPEND)
+                        } else {
+                            flags &= ~UInt32(UF_APPEND)
+                        }
+                    }
+                    if let immutable {
+                        if immutable {
+                            flags |= UInt32(UF_IMMUTABLE)
+                        } else {
+                            flags &= ~UInt32(UF_IMMUTABLE)
+                        }
+                    }
+                    
+                    if chflags(fileSystemRepresentation, flags) != 0 {
+                        throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                    }
+                }
+                
+                if !(immutable ?? false) {
+                    try setFlags?()
+                    setFlags = nil
+                }
+                #else
+                // Setting these flags is not supported on this platform
+                throw CocoaError.errorWithFilePath(.featureUnsupported, path)
+                #endif
+            }
+            
+            // Like the immutable flag, if write permissions are being set, do it first. If they are being unset, do it last.
+            var setMode: (() throws -> Void)?
+            if let mode {
+                setMode = {
+                    if chmod(fileSystemRepresentation, mode_t(mode)) != 0 {
+                        throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                    }
+                }
+                
+                if mode_t(mode) & S_IWUSR != 0 {
+                    try setMode?()
+                    setMode = nil
+                }
+            }
+            
+            let user = attributes[.ownerAccountName] as? String
+            let userID = _readFileAttributePrimitive(attributes[.ownerAccountID], as: UInt.self)
+            let group = attributes[.groupOwnerAccountName] as? String
+            let groupID = _readFileAttributePrimitive(attributes[.groupOwnerAccountID], as: UInt.self)
+            
+            if user != nil || userID != nil || group != nil || groupID != nil {
+                // Bias toward userID & groupID - try to prevent round trips to getpwnam if possible.
+                var leaveUnchanged: UInt32 { UInt32(bitPattern: -1) }
+                let rawUserID = userID.flatMap(uid_t.init) ?? user.flatMap(Self._userAccountNameToNumber) ?? leaveUnchanged
+                let rawGroupID = groupID.flatMap(gid_t.init) ?? group.flatMap(Self._groupAccountNameToNumber) ?? leaveUnchanged
+                if chown(fileSystemRepresentation, rawUserID, rawGroupID) != 0 {
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                }
+            }
+            
+            try Self._setCatInfoAttributes(attributes, path: path)
+            
+            if let extendedAttrs = attributes[.init("NSFileExtendedAttributes")] as? [String : Data] {
+                try Self._setAttributes(extendedAttrs, at: fileSystemRepresentation, followSymLinks: false)
+            }
+            
+            if let date = attributes[.modificationDate] as? Date {
+                var timevals = (timeval(), timeval())
+                let (isecs, fsecs) = modf(date.timeIntervalSince1970)
+                timevals.0.tv_sec = time_t(isecs)
+                timevals.0.tv_usec = suseconds_t(round(fsecs * 1000000.0))
+                timevals.1 = timevals.0
+                try withUnsafePointer(to: timevals) {
+                    try $0.withMemoryRebound(to: timeval.self, capacity: 2) {
+                        if utimes(fileSystemRepresentation, $0) != 0 {
+                            throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                        }
+                    }
+                }
+            }
+            
+            // Remove write permissions if it has been requested. This must be done before setting the immutable bit.
+            try setMode?()
+            
+            // Set flags now, if we postponed it until now.
+            try setFlags?()
+            
+            #if !targetEnvironment(simulator) && FOUNDATION_FRAMEWORK
+            // Set per-file protection class on embedded.
+            let fileProtection = attributes[.protectionKey] as? FileProtectionType
+            if let fileProtection, let fileProtectionClass = fileProtection.intValue {
+                // Only set protection class on regular files and directories.
+                if try statAtPath.get().isRegular || statAtPath.get().isDirectory {
+                    // Finally, set the class.
+                    try Self._setFileProtectionValueForPath(path, fileSystemRepresentation, newValue: fileProtectionClass)
+                }
+            }
+            #endif
+        }
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -547,7 +547,7 @@ extension _FileManagerImpl {
                 .systemFreeSize : _writeFileAttributePrimitive(availSizeBytes, as: UInt64.self),
                 .systemNodes : _writeFileAttributePrimitive(totalFiles, as: UInt64.self),
                 .systemFreeNodes : _writeFileAttributePrimitive(availFiles, as: UInt64.self),
-                .systemNumber : _writeFileAttributePrimitive(fsNumber, as: Int.self)
+                .systemNumber : _writeFileAttributePrimitive(fsNumber, as: UInt.self)
             ]
         }
     }

--- a/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
@@ -1,0 +1,237 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import Foundation_Private.NSFileManager
+@_implementationOnly import Foundation_Private.NSPathUtilities
+@_implementationOnly import DarwinPrivate.dirhelper
+@_implementationOnly import DarwinPrivate.sysdir
+@_implementationOnly import _ForSwiftFoundation
+#endif
+
+#if canImport(Darwin)
+import Darwin.sysdir
+
+extension FileManager.SearchPathDirectory {
+    #if FOUNDATION_FRAMEWORK
+    fileprivate static var _homeDirectory: Self {
+        Self(rawValue: NSSearchPathDirectory_Private.homeDirectory.rawValue)!
+    }
+    #endif
+}
+
+extension FileManager.SearchPathDomainMask {
+    #if FOUNDATION_FRAMEWORK
+    #if os(macOS)
+    static var _sharedUserDomainMask: Self {
+        Self(rawValue: NSSearchPathDomainMask_Private.sharedUserDomainMask.rawValue)
+    }
+    #endif
+    
+    static var _partitionedSystemDomainMask: Self {
+        Self(rawValue: NSSearchPathDomainMask_Private.partitionedSystemDomainMask.rawValue)
+    }
+    #endif
+    
+    fileprivate var firstMask: Self? {
+        guard !self.isEmpty else { return nil }
+        return Self(rawValue: 1 << self.rawValue.trailingZeroBitCount)
+    }
+}
+
+private func foundation_sysdir_start_search_path_enumeration(_ directory: UInt, _ domainMask: UInt) -> sysdir_search_path_enumeration_state {
+    #if FOUNDATION_FRAMEWORK
+    sysdir_start_search_path_enumeration_private(
+        sysdir_search_path_directory_t(UInt32(directory)),
+        sysdir_search_path_domain_private_mask_t(rawValue: UInt32(domainMask))
+    )
+    #else
+    sysdir_start_search_path_enumeration(
+        sysdir_search_path_directory_t(UInt32(directory)),
+        sysdir_search_path_domain_mask_t(rawValue: UInt32(domainMask))
+    )
+    #endif
+}
+
+private struct _SearchPathsSequence: Sequence {
+    let directory: FileManager.SearchPathDirectory
+    let domainMask: FileManager.SearchPathDomainMask
+    
+    final class Iterator: IteratorProtocol {
+        let directory: FileManager.SearchPathDirectory
+        let domainMask: FileManager.SearchPathDomainMask
+        
+        private enum State {
+            case sysdir(sysdir_search_path_enumeration_state)
+            #if os(macOS) && FOUNDATION_FRAMEWORK
+            case special(FileManager.SearchPathDomainMask)
+            #endif
+        }
+        private var state: State
+        
+        init(directory: FileManager.SearchPathDirectory, domainMask: FileManager.SearchPathDomainMask) {
+            self.directory = directory
+            self.domainMask = domainMask
+            
+            switch directory {
+            #if os(macOS) && FOUNDATION_FRAMEWORK
+            case .trashDirectory:
+                state = .special(domainMask.union([.userDomainMask, .localDomainMask]))
+            case ._homeDirectory, .applicationScriptsDirectory:
+                state = .special(domainMask.union(.userDomainMask))
+            #endif
+                
+            default:
+                state = .sysdir(foundation_sysdir_start_search_path_enumeration(directory.rawValue, domainMask.rawValue))
+            }
+        }
+        
+        func next() -> String? {
+            switch state {
+            case .sysdir(let sysdirState):
+                return withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
+                    let newState = sysdir_get_next_search_path_enumeration(sysdirState, buffer.baseAddress!)
+                    state = .sysdir(newState)
+                    if newState != 0 {
+                        return FileManager.default.string(withFileSystemRepresentation: buffer.baseAddress!, length: strlen(buffer.baseAddress!))
+                    } else {
+                        return nil
+                    }
+                }
+            #if os(macOS) && FOUNDATION_FRAMEWORK
+            case .special(var mask):
+                defer { state = .special(mask) }
+                while let currentMask = mask.firstMask {
+                    mask.remove(currentMask)
+                    if let result = _specialFind(directory, in: currentMask) {
+                        return result
+                    }
+                }
+                return nil
+            #endif
+            }
+        }
+        
+        #if os(macOS) && FOUNDATION_FRAMEWORK
+        private func _specialFindReturn(_ buffer: UnsafeMutableBufferPointer<CChar>) -> String? {
+            guard buffer.baseAddress!.pointee != 0 else { return nil }
+            
+            // strip trailing slashes because NSPathUtilities doesn't return paths with trailing slashes.
+            let len = strlen(buffer.baseAddress!)
+            let lastNonSlash = buffer.prefix(upTo: len).lastIndex {
+                $0 != 0x2F // Slash Character
+            }
+            return FileManager.default.string(withFileSystemRepresentation: buffer.baseAddress!, length: lastNonSlash ?? len)
+        }
+        
+        private func _specialFind(_ directory: FileManager.SearchPathDirectory, in mask: FileManager.SearchPathDomainMask) -> String? {
+            withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { cpath in
+                switch (directory, mask)  {
+                case (.trashDirectory, .userDomainMask):
+                    // get the trash relative to the home directory without checking to see if the directory exists
+                    return String.homeDirectoryPath().withFileSystemRepresentation { homePathPtr -> String? in
+                        guard let homePathPtr else { return nil }
+                        if __user_relative_dirname(geteuid(), DIRHELPER_RELATIVE_TRASH, homePathPtr, cpath.baseAddress!, FileManager.MAX_PATH_SIZE) != nil {
+                            var buff = stat()
+                            if lstat(cpath.baseAddress!, &buff) == 0 {
+                                return _specialFindReturn(cpath)?.abbreviatingWithTildeInPath
+                            }
+                        }
+                        return nil
+                    }
+                    
+                case (.trashDirectory, .localDomainMask):
+                    // get the trash on the boot volume without checking to see if the directory exists
+                    if __user_relative_dirname(geteuid(), DIRHELPER_RELATIVE_TRASH, "/", cpath.baseAddress!, FileManager.MAX_PATH_SIZE) != nil {
+                        var buff = stat()
+                        if lstat(cpath.baseAddress!, &buff) == 0 {
+                            return _specialFindReturn(cpath)
+                        }
+                    }
+                    return nil
+                    
+                case (.applicationScriptsDirectory, .userDomainMask):
+                    guard let id = _NSCodeSigningIdentifierForCurrentProcess() else {
+                        return nil
+                    }
+                    return "\("~".replacingTildeWithRealHomeDirectory)/Library/Application Scripts/\(id)"
+                    
+                case (._homeDirectory, .userDomainMask):
+                    return "~"
+                    
+                default:
+                    return nil
+                }
+            }
+        }
+        #endif
+    }
+    
+    func makeIterator() -> Iterator {
+        Iterator(directory: directory, domainMask: domainMask)
+    }
+}
+
+#if os(macOS) && FOUNDATION_FRAMEWORK
+extension String {
+    fileprivate var replacingTildeWithRealHomeDirectory: String {
+        guard self == "~" || self.hasPrefix("~/") else {
+            return self
+        }
+        var bufSize = sysconf(_SC_GETPW_R_SIZE_MAX)
+        if bufSize == -1 {
+            bufSize = 4096 // A generous guess.
+        }
+        return withUnsafeTemporaryAllocation(of: CChar.self, capacity: bufSize) { pwBuff in
+            var pw: UnsafeMutablePointer<passwd>?
+            var pwd = passwd()
+            let euid = geteuid()
+            let trueUid = euid == 0 ? getuid() : euid
+            guard getpwuid_r(trueUid, &pwd, pwBuff.baseAddress!, bufSize, &pw) == 0, let pw else {
+                return self
+            }
+            return String(cString: pw.pointee.pw_dir).appendingPathComponent(String(self.dropFirst()))
+        }
+    }
+}
+#endif
+
+func _SearchPaths(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> some Sequence<String> {
+    let basic = _SearchPathsSequence(directory: directory, domainMask: domain).lazy.map {
+        if expandTilde {
+            return $0.expandingTildeInPath
+        } else {
+            return $0
+        }
+    }
+    
+    #if os(macOS) && FOUNDATION_FRAMEWORK
+    // NSSharedUserDomainMask is basically just a wrapper around NSUserDomainMask.
+    let compatibleSharedUserDomainMask = domain != .allDomainsMask && (domain.rawValue & 16) != 0
+    if domain.contains(._sharedUserDomainMask) || compatibleSharedUserDomainMask {
+        var result = Array(basic)
+        for path in _SearchPathsSequence(directory: directory, domainMask: .userDomainMask) {
+            let expandedPath = expandTilde ? path.replacingTildeWithRealHomeDirectory : path
+            // Avoid duplicates, which would occur with (NSUserDomainMask | NSSharedUserDomainMask) in non-sandboxed apps.
+            if !result.contains(expandedPath) {
+                // Insert this path after NSUserDomainMask and before any of the more general paths.
+                let insertionIndex = domain.contains(.userDomainMask) ? 1 : 0
+                result.insert(expandedPath, at: insertionIndex)
+            }
+        }
+        return result
+    }
+    #endif
+    return Array(basic)
+}
+
+#endif

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+extension _FileManagerImpl {
+    func createSymbolicLink(
+        at url: URL,
+        withDestinationURL destURL: URL
+    ) throws {
+        guard url.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, url)
+        }
+        
+        // If there's no scheme, then this is probably a relative URL.
+        if destURL.scheme != nil && !destURL.isFileURL {
+            throw CocoaError.errorWithFilePath(.fileWriteUnsupportedScheme, destURL)
+        }
+        
+        let path = url.path
+        let destPath = destURL.path
+        guard !path.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, url)
+        }
+        guard !destPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, destURL)
+        }
+        
+        try createSymbolicLink(atPath: path, withDestinationPath: destPath)
+    }
+    
+    func createSymbolicLink(
+        atPath path: String,
+        withDestinationPath destPath: String
+    ) throws {
+        try fileManager.withFileSystemRepresentation(for: path) { srcRep in
+            guard let srcRep else {
+                throw CocoaError.errorWithFilePath(.fileReadUnknown, path)
+            }
+            
+            try fileManager.withFileSystemRepresentation(for: destPath) { destRep in
+                guard let destRep else {
+                    throw CocoaError.errorWithFilePath(.fileReadUnknown, destPath)
+                }
+                
+                if symlink(destRep, srcRep) != 0 {
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+                }
+            }
+        }
+    }
+    
+    func linkItem(
+        at srcURL: URL,
+        to dstURL: URL
+    ) throws {
+        guard srcURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileReadUnsupportedScheme, srcURL)
+        }
+        
+        guard dstURL.isFileURL else {
+            throw CocoaError.errorWithFilePath(.fileWriteUnsupportedScheme, dstURL)
+        }
+        
+        let srcPath = srcURL.path
+        let dstPath = dstURL.path
+        guard !srcPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, srcURL)
+        }
+        guard !dstPath.isEmpty else {
+            throw CocoaError.errorWithFilePath(.fileNoSuchFile, dstURL)
+        }
+        
+        try linkItem(atPath: srcPath, toPath: dstPath)
+    }
+    
+    func linkItem(
+        atPath srcPath: String,
+        toPath dstPath: String
+    ) throws {
+        try _FileOperations.linkFile(srcPath, to: dstPath, with: fileManager)
+    }
+    
+    func destinationOfSymbolicLink(atPath path: String) throws -> String {
+        try fileManager.withFileSystemRepresentation(for: path) { rep in
+            guard let rep else {
+                throw CocoaError.errorWithFilePath(.fileReadUnknown, path)
+            }
+            
+            return try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
+                let charsReturned = readlink(rep, buffer.baseAddress!, FileManager.MAX_PATH_SIZE)
+                guard charsReturned >= 0 else {
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+                }
+                
+                return fileManager.string(withFileSystemRepresentation: buffer.baseAddress!, length: charsReturned)
+            }
+        }
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -1,0 +1,359 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import XPCPrivate
+@_implementationOnly import _ForSwiftFoundation
+@_implementationOnly import Foundation_Private.NSFileManager
+@_implementationOnly import DarwinPrivate
+
+#if os(macOS)
+@_implementationOnly import QuarantinePrivate
+#endif
+#endif
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+package import _CShims
+#endif
+
+extension CocoaError {
+#if !FOUNDATION_FRAMEWORK
+    static var NSURLErrorKey: String { "NSURL" }
+    static var NSFilePathErrorKey: String { "NSFilePath"}
+#endif
+    
+    static func errorWithFilePath(_ code: CocoaError.Code, _ path: String) -> CocoaError {
+        CocoaError(code, userInfo: [NSFilePathErrorKey : path])
+    }
+    
+    private static func filePathCocoaCode(from errno: Int32, reading: Bool) -> CocoaError.Code {
+        if reading {
+            switch errno {
+            case EFBIG: .fileReadTooLarge
+            case ENOENT: .fileReadNoSuchFile
+            case EPERM, EACCES: .fileReadNoPermission
+            case ENAMETOOLONG: .fileReadInvalidFileName
+            default: .fileReadUnknown
+            }
+        } else {
+            switch errno {
+            case ENOENT: .fileNoSuchFile
+            case EPERM, EACCES: .fileWriteNoPermission
+            case ENAMETOOLONG: .fileWriteInvalidFileName
+            case EDQUOT, ENOSPC: .fileWriteOutOfSpace
+            case EROFS: .fileWriteVolumeReadOnly
+            case EEXIST: .fileWriteFileExists
+            default: .fileWriteUnknown
+            }
+        }
+    }
+    
+    static func errorWithFilePath(_ path: String, errno: Int32, reading: Bool, variant: String? = nil, extra: [String : AnyHashable] = [:]) -> CocoaError {
+        guard let code = POSIXError.Code(rawValue: errno) else {
+            fatalError("Invalid posix errno \(errno)")
+        }
+        var userInfo: [String : AnyHashable] = [
+            NSUnderlyingErrorKey : POSIXError(code),
+            NSFilePathErrorKey : path
+        ].merging(extra) { _, new in
+            new
+        }
+        if let variant {
+            userInfo["NSUserStringVariant"] = [variant]
+        }
+        return CocoaError(Self.filePathCocoaCode(from: errno, reading: reading), userInfo: userInfo)
+    }
+    
+    static func errorWithFilePath(_ code: CocoaError.Code, _ url: URL) -> CocoaError {
+        CocoaError(code, userInfo: [NSURLErrorKey : url])
+    }
+    
+    static func errorWithFilePath(_ url: URL, errno: Int32, reading: Bool, variant: String? = nil, extra: [String : AnyHashable] = [:]) -> CocoaError {
+        var userInfo: [String : AnyHashable] = [
+            NSUnderlyingErrorKey : POSIXError(.init(rawValue: errno)!),
+            NSURLErrorKey : url
+        ].merging(extra) { _, new in
+            new
+        }
+        if let variant {
+            userInfo["NSUserStringVariant"] = [variant]
+        }
+        return CocoaError(Self.filePathCocoaCode(from: errno, reading: reading), userInfo: userInfo)
+    }
+    
+    static func errorWithFilePath(_ path: String? = nil, osStatus: Int, reading: Bool, variant: String? = nil) -> CocoaError {
+        // Do more or less what _NSErrorWithFilePathAndErrno() does, except for OSStatus values
+        let errorCode: CocoaError.Code = switch (reading, osStatus) {
+        case (true, -43 /*fnfErr*/), (true, -120 /*dirNFErr*/): .fileReadNoSuchFile
+        case (true, -5000 /*afpAccessDenied*/): .fileReadNoPermission
+        case (true, _): .fileReadUnknown
+        case (false, -34 /*dskFulErr*/), (false, -1425 /*errFSQuotaExceeded*/): .fileWriteOutOfSpace
+        case (false, -45 /*fLckdErr*/), (false, -5000 /*afpAccessDenied*/): .fileWriteNoPermission
+        case (false, _): .fileWriteUnknown
+        }
+        #if FOUNDATION_FRAMEWORK
+        var userInfo: [String : AnyHashable] = [
+            NSUnderlyingErrorKey : NSError(domain: NSOSStatusErrorDomain, code: osStatus)
+        ]
+        #else
+        var userInfo: [String : AnyHashable] = [:]
+        #endif
+        if let path {
+            userInfo[NSFilePathErrorKey] = path
+        }
+        if let variant {
+            userInfo[NSUserStringVariantErrorKey] = [variant]
+        }
+        return CocoaError(errorCode, userInfo: userInfo)
+    }
+}
+
+extension stat {
+    var isDirectory: Bool {
+        (self.st_mode & S_IFMT) == S_IFDIR
+    }
+    
+    var isRegular: Bool {
+        (self.st_mode & S_IFMT) == S_IFREG
+    }
+    
+    var isSymbolicLink: Bool {
+        (self.st_mode & S_IFMT) == S_IFLNK
+    }
+    
+    var isSpecial: Bool {
+        let type = self.st_mode & S_IFMT
+        return type == S_IFBLK || type == S_IFCHR
+    }
+}
+
+#if FOUNDATION_FRAMEWORK && os(macOS)
+extension URLResourceKey {
+    static var _finderInfoKey: Self { URLResourceKey("_NSURLFinderInfoKey") }
+}
+#endif
+
+extension _FileManagerImpl {
+    #if os(macOS) && FOUNDATION_FRAMEWORK
+    private struct _HFSFinderInfo {
+        var fileInfo: FndrFileInfo
+        var extendedFileInfo: FndrExtendedFileInfo
+    }
+    #endif
+    
+    static func _catInfo(for url: URL, statInfo: stat, into attributes: inout [FileAttributeKey : Any]) throws {
+        #if FOUNDATION_FRAMEWORK
+        // Get the info we care about for the file (creatorCode, fileTypeCode, extensionHidden, creationDate, fileBusy) and set validFields for each of them.
+        #if os(macOS)
+        let keys: Set<URLResourceKey> = [.hasHiddenExtensionKey, .creationDateKey, ._finderInfoKey]
+        #else
+        let keys: Set<URLResourceKey> = [.hasHiddenExtensionKey, .creationDateKey]
+        #endif
+        let values = try url.resourceValues(forKeys: keys)
+        #if os(macOS)
+        if let finderInfoData = values.allValues[._finderInfoKey] as? Data {
+            let finderInfo = finderInfoData.withUnsafeBytes({ $0.load(as: _HFSFinderInfo.self) })
+            // Record the creator and file type of a file.
+            if statInfo.isRegular {
+                attributes[.hfsCreatorCode] = _writeFileAttributePrimitive(finderInfo.fileInfo.fdCreator, as: UInt.self)
+                attributes[.hfsTypeCode] = _writeFileAttributePrimitive(finderInfo.fileInfo.fdType, as: UInt.self)
+            } else if statInfo.isSymbolicLink {
+                attributes[.hfsCreatorCode] = _writeFileAttributePrimitive(kSymLinkCreator, as: UInt.self)
+                attributes[.hfsTypeCode] = _writeFileAttributePrimitive(kSymLinkFileType, as: UInt.self)
+            }
+            attributes[.busy] = _writeFileAttributePrimitive((finderInfo.extendedFileInfo.extended_flags & 0x80 /*kExtendedFlagObjectIsBusy*/) != 0)
+        }
+        #endif
+        
+        // Record whether or not the file or directory's name extension is hidden.
+        if let value = values.hasHiddenExtension {
+            attributes[.extensionHidden] = _writeFileAttributePrimitive(value)
+        }
+
+        // Record the creation date of the object.
+        attributes[.creationDate] = values.creationDate
+        #else
+        return // TODO: implement fetching cat info attributes in swift-foundation
+        #endif
+    }
+    
+    static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
+        #if !FOUNDATION_FRAMEWORK
+        let usedKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
+        guard !attributes.keys.contains(where: { usedKeys.contains($0) }) else {
+            // TODO: Implement CAT info attributes for swift-foundation
+            throw CocoaError.errorWithFilePath(.featureUnsupported, path)
+        }
+        #else
+        // -setAttributes:ofItemAtPath:error: follows symlinks (<rdar://5815920>), but the NSURL resource value API doesn't, so we have to manually resolve the symlink.
+        // We lie to fileURLWithPath:isDirectory: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.
+        var url = URL(fileURLWithPath: path.resolvingSymlinksInPath, isDirectory: false)
+        var urlAttributes: [URLResourceKey : Any] = [:]
+        #if os(macOS)
+        let creatorCode = _readFileAttributePrimitive(attributes[.hfsCreatorCode], as: UInt32.self)
+        let fileTypeCode = _readFileAttributePrimitive(attributes[.hfsTypeCode], as: UInt32.self)
+        let fileBusy = _readFileAttributePrimitive(attributes[.busy], as: Bool.self)
+        if creatorCode != nil || fileTypeCode != nil || fileBusy != nil {
+            let finderInfoData = try url.resourceValues(forKeys: [._finderInfoKey]).allValues[._finderInfoKey] as? Data
+            if var finderInfo = finderInfoData?.withUnsafeBytes({ $0.load(as: _HFSFinderInfo.self) }) {
+                if let creatorCode {
+                    finderInfo.fileInfo.fdCreator = creatorCode
+                }
+                if let fileTypeCode {
+                    finderInfo.fileInfo.fdType = fileTypeCode
+                }
+                if let fileBusy {
+                    if fileBusy {
+                        finderInfo.extendedFileInfo.extended_flags |= 0x0080 // kExtendedFlagObjectIsBusy
+                    } else {
+                        finderInfo.extendedFileInfo.extended_flags &= ~0x0080 // kExtendedFlagObjectIsBusy
+                    }
+                }
+                withUnsafeBytes(of: &finderInfo) { buffer in
+                    urlAttributes[._finderInfoKey] = Data(buffer)
+                }
+            }
+        }
+        #endif
+        
+        if let extensionHidden = attributes[.extensionHidden] {
+            urlAttributes[.hasHiddenExtensionKey] = extensionHidden
+        }
+        if let creationDate = attributes[.creationDate] {
+            urlAttributes[.creationDateKey] = creationDate
+        }
+        try url.setResourceValues(URLResourceValues(values: urlAttributes))
+        #endif
+    }
+    
+    static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
+        try value.withUnsafeBytes { buffer in
+            #if canImport(Darwin)
+            let result = setxattr(path, key, buffer.baseAddress!, buffer.count, 0, followSymLinks ? 0 : XATTR_NOFOLLOW)
+            #else
+            var result: Int32
+            if followSymLinks {
+                result = lsetxattr(path, key, buffer.baseAddress!, buffer.count, 0)
+            } else {
+                result = setxattr(path, key, buffer.baseAddress!, buffer.count, 0)
+            }
+            #endif
+            #if os(macOS) && FOUNDATION_FRAMEWORK
+            // if setxaddr failed and its a permission error for a sandbox app trying to set quaratine attribute, ignore it since its not
+            // permitted, the attribute will be put on the file by the quaratine MAC hook
+            if result == -1 && errno == EPERM && _xpc_runtime_is_app_sandboxed() && strcmp(key, "com.apple.quarantine") == 0 {
+                return
+            }
+            #endif
+            if result == -1 {
+                throw CocoaError.errorWithFilePath(String(cString: path), errno: errno, reading: false)
+            }
+        }
+    }
+    
+    static func _setAttributes(_ attributes: [String : Data], at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
+        for (key, value) in attributes {
+            try key.withCString {
+                try Self._setAttribute($0, value: value, at: path, followSymLinks: followSymLinks)
+            }
+        }
+    }
+    
+    #if FOUNDATION_FRAMEWORK
+    static func _fileProtectionValueForPath(_ fileSystemRepresentation: UnsafePointer<CChar>) -> Int32? {
+        var attrList = attrlist()
+        attrList.bitmapcount = u_short(ATTR_BIT_MAP_COUNT)
+        attrList.commonattr = attrgroup_t(ATTR_CMN_DATA_PROTECT_FLAGS)
+        typealias Buffer = (length: UInt32, class: Int32)
+        var attributesBuffer: Buffer = (0, 0)
+        let result = withUnsafeMutableBytes(of: &attributesBuffer) { buffer in
+            getattrlist(fileSystemRepresentation, &attrList, buffer.baseAddress!, buffer.count, .init(FSOPT_NOFOLLOW))
+        }
+        guard result == 0 else {
+            return nil
+        }
+        return attributesBuffer.class
+    }
+    
+    static func _setFileProtectionValueForPath(_ path: String, _ fileSystemRepresentation: UnsafePointer<CChar>, newValue: Int32) throws {
+        // It's probably better to do a single getattrlist than and open()/fcntl()/close(), so skip the work in case the value is already set correctly.
+        guard Self._fileProtectionValueForPath(fileSystemRepresentation) != newValue else {
+            return
+        }
+        
+        var fd = open(fileSystemRepresentation, O_WRONLY)
+        var dir: UnsafeMutablePointer<DIR>?
+        defer {
+            // For opendir(), the DIR structure owns the fd. Don't attempt to close it ourselves. 14323986.
+            if let dir {
+                closedir(dir)
+            } else if fd >= 0 {
+                close(fd)
+            }
+        }
+        
+        // If open() failed because the file is a directory, try again using opendir/dirfd.
+        if fd < 0 && errno == EISDIR {
+            dir = opendir(fileSystemRepresentation)
+            if let dir {
+                fd = dirfd(dir)
+            }
+        }
+        
+        if fd >= 0 {
+            if fcntl(fd, F_SETPROTECTIONCLASS, newValue) != 0 {
+                guard errno == ENOTSUP else {
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+                }
+                
+                // If we fail with ENOTSUP because the volume doesn't support file protection, then no-op.
+                var s = statfs()
+                guard fstatfs(fd, &s) != 0 || s.f_flags & UInt32(MNT_CPROTECT) == 0 else {
+                    throw CocoaError.errorWithFilePath(path, errno: ENOTSUP, reading: true)
+                }
+            }
+        } else if errno == EACCES {
+            // We don't have any alternative API for setting the protection class, so we must open() for fnctl(). If we don't have write permissions, the open() will fail with EACCES. None of the other NSFileManager attributes fail in this case, so it is unreasonable (and binary incompatible) to cause the NSFileManager methods to fail when this happens. <rdar://7796261>
+            // This results in silent failures, but we simply don't have any other alternatives. <rdar://7837261> was a request for a path-based API with similar semantics to chmod, etc., but the OS team decided not to fix it.
+            return
+        } else {
+            throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+        }
+    }
+    #endif
+    
+    static func _userAccountNameToNumber(_ name: String) -> uid_t? {
+        name.withCString { ptr in
+            getpwnam(ptr)?.pointee.pw_uid
+        }
+    }
+    
+    static func _groupAccountNameToNumber(_ name: String) -> gid_t? {
+        name.withCString { ptr in
+            getgrnam(ptr)?.pointee.gr_gid
+        }
+    }
+}
+
+extension FileManager {
+    @nonobjc
+    var safeDelegate: FileManagerDelegate? {
+#if FOUNDATION_FRAMEWORK
+        self._safeDelegate() as? FileManagerDelegate
+#else
+        self.delegate
+#endif
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -1,0 +1,353 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+package import _CShims
+#endif
+
+// MARK: Directory Iteration
+
+struct _FTSSequence: Sequence {
+    enum Element {
+        struct SwiftFTSENT {
+            fileprivate let ptr: UnsafeMutablePointer<FTSENT>
+            
+            var ftsEnt: FTSENT { ptr.pointee }
+            var name: String {
+                // FTSENT incorrectly represents the `fts_name` property so we must access it directly via the pointer rather than the pointee struct value
+                let nameOffset = MemoryLayout<FTSENT>.offset(of: \.fts_name)!
+                let len = Int(ptr.pointee.fts_namelen)
+                return UnsafeRawPointer(ptr).advanced(by: nameOffset).withMemoryRebound(to: UTF8.CodeUnit.self, capacity: len) { namePtr in
+                    String(decoding: UnsafeBufferPointer(start: namePtr, count: len), as: UTF8.self)
+                }
+            }
+            
+            init(_ ptr: UnsafeMutablePointer<FTSENT>) {
+                self.ptr = ptr
+            }
+        }
+        case entry(SwiftFTSENT)
+        case error(errno: Int32, path: String)
+    }
+    
+    final class Iterator: IteratorProtocol {
+        enum State {
+            case stream(UnsafeMutablePointer<FTS>)
+            case error(Int32, String)
+            case ended
+        }
+        var state: State
+        var path: UnsafePointer<CChar>
+        
+        #if canImport(Darwin)
+        var lastDeviceInode: dev_t = 0
+        var deviceNumbers: [dev_t] = []
+        var deviceEntryPoints: [ino_t] = []
+        var shouldFilterUnderbars = false
+        #endif
+        
+        init(_ path: UnsafePointer<CChar>, _ opts: Int32) {
+            self.path = path
+            var statBuf = stat()
+            if lstat(path, &statBuf) > 0 {
+                state = .error(errno, String(cString: path))
+                return
+            }
+            
+            state = [UnsafeMutablePointer(mutating: path), nil].withUnsafeBufferPointer{ dirList in
+                guard let stream = fts_open(dirList.baseAddress!, opts, nil) else {
+                    return .error(errno, String(cString: path))
+                }
+                return .stream(stream)
+            }
+        }
+        
+        deinit {
+            _close()
+        }
+        
+        private func _close() {
+            if case .stream(let fts) = state {
+                fts_close(fts)
+            }
+            state = .ended
+        }
+        
+        #if canImport(Darwin)
+        private func _shouldFilter(_ swiftEnt: Element.SwiftFTSENT) -> Bool {
+            let ent = swiftEnt.ftsEnt
+            let ftsName = swiftEnt.name
+            
+            // If we're being requested to iterate a directory that begins with a ._ we should do it.
+            if lastDeviceInode == 0 && ftsName.hasPrefix("._") {
+                return false
+            }
+            
+            // Instead of asking fts to stat every file just to get the fts_statp->st_dev, we can trust the already-gathered fts_dev info, which is present for at least every FTS_D and FTS_DP entry. 8740034.
+            // Don't worry. Even if someone uses FTS_SKIP, FTS always balances FTS_D with FTS_DP.
+            
+            var currentDev = deviceNumbers.last ?? 0
+            if ent.fts_info == FTS_D {
+                if deviceNumbers.last != ent.fts_dev {
+                    currentDev = ent.fts_dev
+                    deviceEntryPoints.append(ent.fts_ino)
+                    deviceNumbers.append(ent.fts_dev)
+                }
+            } else if ent.fts_info == FTS_DP {
+                if let lastEntry = deviceEntryPoints.last, lastEntry == ent.fts_ino {
+                    deviceEntryPoints.removeLast()
+                    deviceNumbers.removeLast()
+                }
+            }
+            
+            if currentDev != lastDeviceInode {
+                // We've crossed a mount point (i.e. the device is different than the last time we looked).
+                var fileSystemInfo = statfs()
+                shouldFilterUnderbars = statfs(ent.fts_path, &fileSystemInfo) == 0 && ((fileSystemInfo.f_flags & UInt32(MNT_DOVOLFS)) == 0)
+                lastDeviceInode = currentDev
+            }
+            
+            if shouldFilterUnderbars && ftsName.hasPrefix("._") {
+                // Don't report ._ files on filesystems that require them.
+                return true
+            }
+            return false
+        }
+        #else
+        private func _shouldFilter(_ swiftEnt: Element.SwiftFTSENT) -> Bool {
+            false
+        }
+        #endif
+        
+        func next() -> Element? {
+            switch state {
+            case .stream(let fts):
+                if let ent = fts_read(fts) {
+                    let swiftEnt = Element.SwiftFTSENT(ent)
+                    if _shouldFilter(swiftEnt) {
+                        return self.next()
+                    } else {
+                        return .entry(swiftEnt)
+                    }
+                } else if errno != 0 {
+                    let errNumber = errno
+                    _close()
+                    return .error(errno: errNumber, path: String(cString: path))
+                } else {
+                    _close()
+                    return nil
+                }
+            case .error(let errNum, let path):
+                state = .ended
+                return .error(errno: errNum, path: path)
+            case .ended:
+                return nil
+            }
+        }
+        
+        func skipDescendants(of entry: Element.SwiftFTSENT, skipPostProcessing: Bool = false) {
+            guard case .stream(let fts) = state else { return }
+            _ = fts_set(fts, entry.ptr, FTS_SKIP)
+            if skipPostProcessing {
+                assert(Int32(entry.ftsEnt.fts_info) == FTS_D)
+                _ = self.next() // Skip the FTS_DP entry for this directory
+            }
+        }
+    }
+    
+    let path: UnsafePointer<CChar>
+    let opts: Int32
+    
+    init(_ path: UnsafePointer<CChar>, _ opts: Int32) {
+        self.path = path
+        self.opts = opts
+    }
+    
+    func makeIterator() -> Iterator {
+        Iterator(path, opts)
+    }
+}
+
+enum SubpathElement {
+    case entry(String)
+    case error(Int32, String)
+}
+
+extension Sequence<_FTSSequence.Element> {
+    var subpaths: some Sequence<SubpathElement> {
+        self.lazy.compactMap {
+            switch $0 {
+            case .error(let error, let path): return .error(error, path)
+            case .entry(let ent):
+                switch Int32(ent.ftsEnt.fts_info) {
+                // Do the action
+                case FTS_D: fallthrough         // Directory being visited in pre-order.
+                case FTS_DEFAULT: fallthrough   // Something not defined anywhere else.
+                case FTS_F: fallthrough         // Regular file.
+                case FTS_NSOK: fallthrough      // No stat(2) information was requested, but that's OK.
+                case FTS_SL: fallthrough        // Symlink.
+                case FTS_SLNONE:                // Symlink with no target.
+                    return .entry(String(cString: ent.ftsEnt.fts_path))
+                    
+                // Error returns
+                case FTS_DNR: fallthrough   // Directory cannot be read.
+                case FTS_ERR: fallthrough   // Some error occurred, but we don't know what.
+                case FTS_NS:                // No stat(2) information is available.
+                    let path = String(cString: ent.ftsEnt.fts_path)
+                    return .error(ent.ftsEnt.fts_errno, path)
+                    
+                default: return nil
+                }
+            }
+        }
+    }
+}
+
+struct _POSIXDirectoryContentsSequence: Sequence {
+    #if canImport(Darwin)
+    typealias DirectoryEntryPtr = UnsafeMutablePointer<DIR>
+    #elseif canImport(Glibc)
+    typealias DirectoryEntryPtr = OpaquePointer
+    #endif
+    
+    final class Iterator: IteratorProtocol {
+        func next() -> Element? {
+            guard let dirp else { return nil }
+
+            // Loop until we find a value or end
+            repeat {
+                guard let dent = readdir(dirp) else {
+                    closedir(dirp)
+                    self.dirp = nil
+                    return nil
+                }
+
+                #if canImport(Darwin)
+                guard dent.pointee.d_namlen != 0 else {
+                    continue
+                }
+                #endif
+                guard dent.pointee.d_ino != 0 else {
+                    continue
+                }
+                // Use name
+                let fileName = withUnsafeBytes(of: &dent.pointee.d_name) { buf in
+                    let ptr = buf.baseAddress!.assumingMemoryBound(to: CChar.self)
+                    return String(cString: ptr)
+                }
+
+                if fileName == "." || fileName == ".." || fileName == "._" {
+                    continue
+                }
+
+                let fullFileName: String
+                if appendSlash {
+                    var isDirectory = false
+                    if dent.pointee.d_type == DT_DIR {
+                        isDirectory = true
+                    } else if dent.pointee.d_type == DT_UNKNOWN {
+                        // We need to do an additional stat on this to see if it's really a directory or not.
+                        // This path should be uncommon.
+                        var statBuf: stat = stat()
+                        let statDir = directoryPath + "/" + fileName
+                        if stat(statDir, &statBuf) == 0 {
+                            // #define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
+                            if (statBuf.st_mode & S_IFMT) == S_IFDIR {
+                                isDirectory = true
+                            }
+                        }
+                    }
+
+                    if isDirectory {
+                        fullFileName = prefix + fileName + "/"
+                    } else {
+                        fullFileName = prefix + fileName
+                    }
+                } else {
+                    fullFileName = prefix + fileName
+                }
+
+                return Element(fileName: fileName, fileNameWithPrefix: fullFileName, fileType: dent.pointee.d_type)
+            } while true
+        }
+
+        struct Element {
+            var fileName: String
+            var fileNameWithPrefix: String
+            var fileType: UInt8
+        }
+
+        private var dirp: DirectoryEntryPtr?
+        private let directoryPath: String
+        private let prefix: String
+        private let appendSlash: Bool
+        
+        var error: CocoaError?
+
+        init(path: String, appendSlashForDirectory: Bool = false, prefix: [String] = []) {
+            let dirp = path.withFileSystemRepresentation { ptr -> DirectoryEntryPtr? in
+                guard let ptr else { return nil }
+                return opendir(ptr)
+            }
+            if let dirp {
+                directoryPath = path
+                self.dirp = dirp
+                self.appendSlash = appendSlashForDirectory
+
+                // Ensure stuff to prefix list is all /-terminated
+                let prefixes: [String] = prefix.compactMap {
+                    guard let last = $0.last else {
+                        // This string is empty
+                        return nil
+                    }
+
+                    if last == "/" {
+                        return $0
+                    } else {
+                        return $0 + "/"
+                    }
+                }
+
+                self.prefix = prefixes.joined()
+            } else {
+                // It would be nice to propagate an error from here, but for now the best we can do is return nil from `next`.
+                directoryPath = ""
+                self.prefix = ""
+                appendSlash = false
+                error = CocoaError.errorWithFilePath(path, errno: errno, reading: true, variant: "Folder")
+            }
+        }
+
+        deinit {
+            if let dirp {
+                closedir(dirp)
+            }
+        }
+    }
+
+    let path: String
+    let appendSlashForDirectory: Bool
+    let prefix: [String]
+
+    init(path: String, appendSlashForDirectory: Bool, prefix: [String] = []) {
+        self.path = path
+        self.appendSlashForDirectory = appendSlashForDirectory
+        self.prefix = prefix
+    }
+
+    func makeIterator() -> Iterator {
+        Iterator(path: path, appendSlashForDirectory: appendSlashForDirectory, prefix: prefix)
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -1,0 +1,773 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@_implementationOnly import _CShims
+@_implementationOnly import _ForSwiftFoundation
+@_implementationOnly import Foundation_Private.NSFileManager
+
+#if os(macOS)
+@_implementationOnly import QuarantinePrivate
+#endif
+#else
+package import _CShims
+#endif
+
+extension CocoaError {
+    private static func fileOperationError(_ errNum: Int32, _ suspectedErroneousPath: String, sourcePath: String? = nil, destinationPath: String? = nil, variant: String? = nil) -> CocoaError {
+        // Try to be a little bit more intelligent about which path should be reported in the error. In the case of ENAMETOOLONG, we can more accurately guess which path is causing the error without racily checking the file system after the fact. This may not be perfect in the face of operations which span file systems, or on file systems that only support names/paths less than NAME_MAX or PATH_MAX, but it's better than nothing.
+        var erroneousPath = suspectedErroneousPath
+        if let sourcePath, let destinationPath, errNum == ENAMETOOLONG {
+            let lastLength = destinationPath.lastPathComponent.withFileSystemRepresentation { fsRep in
+                guard let fsRep else { return 0 }
+                return strnlen(fsRep, Int(NAME_MAX) + 1)
+            }
+            let fullLength = destinationPath.withFileSystemRepresentation { fsRep in
+                guard let fsRep else { return 0 }
+                return strnlen(fsRep, Int(PATH_MAX) + 1)
+            }
+            if lastLength > NAME_MAX || fullLength > PATH_MAX {
+                erroneousPath = destinationPath
+            } else {
+                erroneousPath = sourcePath
+            }
+        }
+        
+        var userInfo: [String : AnyHashable] = [:]
+        if let sourcePath {
+            userInfo[NSSourceFilePathErrorKey] = sourcePath
+        }
+        if let destinationPath {
+            userInfo[NSDestinationFilePathErrorKey] = destinationPath
+        }
+        return CocoaError.errorWithFilePath(erroneousPath, errno: errNum, reading: false, variant: variant, extra: userInfo)
+    }
+    
+    fileprivate static func removeFileError(_ errNum: Int32, _ path: String) -> CocoaError {
+        var err = CocoaError.fileOperationError(errNum, path, variant: "Remove")
+        if errNum == ENOTEMPTY {
+            err = CocoaError(.fileWriteNoPermission, userInfo: err.userInfo)
+        }
+        return err
+    }
+    
+    fileprivate static func moveFileError(_ errNum: Int32, _ src: URL, _ dst: URL) -> CocoaError {
+        CocoaError.fileOperationError(errNum, src.path, sourcePath: src.path, destinationPath: dst.path, variant: "Move")
+    }
+    
+    fileprivate static func linkFileError(_ errNum: Int32, _ srcPath: String, _ dstPath: String) -> CocoaError {
+        CocoaError.fileOperationError(errNum, srcPath, sourcePath: srcPath, destinationPath: dstPath, variant: "Link")
+    }
+    
+    fileprivate static func copyFileError(_ errNum: Int32, _ srcPath: String, _ dstPath: String) -> CocoaError {
+        CocoaError.fileOperationError(errNum, srcPath, sourcePath: srcPath, destinationPath: dstPath, variant: "Copy")
+    }
+}
+
+#if canImport(Darwin)
+@_cdecl("_FileRemove_ConfirmCallback")
+internal func _FileRemove_ConfirmCallback(_ state: removefile_state_t, _ pathPtr: UnsafePointer<CChar>, _ contextPtr: UnsafeRawPointer) -> Int {
+    let context = Unmanaged<_FileOperations._FileRemoveContext>.fromOpaque(contextPtr).takeUnretainedValue()
+    let path = String(cString: pathPtr)
+    
+    // Proceed unless the delegate says to skip
+    return (context.manager?._shouldRemoveItemAtPath(path) ?? true) ? REMOVEFILE_PROCEED : REMOVEFILE_SKIP
+}
+
+@_cdecl("_FileRemove_ErrorCallback")
+internal func _FileRemove_ErrorCallback(_ state: removefile_state_t, _ pathPtr: UnsafePointer<CChar>, _ contextPtr: UnsafeRawPointer) -> Int {
+    let context = Unmanaged<_FileOperations._FileRemoveContext>.fromOpaque(contextPtr).takeUnretainedValue()
+    let path = String(cString: pathPtr)
+    
+    let err = CocoaError.removeFileError(Int32(_filemanagershims_removefile_state_get_errnum(state)), path)
+    
+    // Proceed only if the delegate says so
+    if context.manager?._shouldProceedAfter(error: err, removingItemAtPath: path) ?? false {
+        return REMOVEFILE_PROCEED
+    } else {
+        context.error = err
+        return REMOVEFILE_STOP
+    }
+}
+#endif
+
+extension FileManager {
+    fileprivate func _shouldProceedAfter(error: Error, removingItemAtPath path: String) -> Bool {
+        var delegateResponse: Bool?
+        
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, removingItemAt: URL(fileURLWithPath: path))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, removingItemAtPath: path)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, removingItemAtPath: path)
+            #endif
+        }
+        
+        return delegateResponse ?? false
+    }
+    
+    fileprivate func _shouldRemoveItemAtPath(_ path: String) -> Bool {
+        var delegateResponse: Bool?
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldRemoveItemAt: URL(fileURLWithPath: path))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldRemoveItemAtPath: path)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldRemoveItemAtPath: path)
+            #endif
+        }
+        return delegateResponse ?? true
+    }
+    
+    fileprivate func _shouldProceedAfter(error: Error, copyingItemAtPath path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, copyingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, copyingItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, copyingItemAtPath: path, toPath: dst)
+            #endif
+        }
+        
+        return delegateResponse ?? false
+    }
+    
+    fileprivate func _shouldCopyItemAtPath(_ path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldCopyItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldCopyItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldCopyItemAtPath: path, toPath: dst)
+            #endif
+        }
+        return delegateResponse ?? true
+    }
+    
+    fileprivate func _shouldProceedAfter(error: Error, linkingItemAtPath path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, linkingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, linkingItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, linkingItemAtPath: path, toPath: dst)
+            #endif
+        }
+        
+        return delegateResponse ?? false
+    }
+    
+    fileprivate func _shouldLinkItemAtPath(_ path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldLinkItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldLinkItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldLinkItemAtPath: path, toPath: dst)
+            #endif
+        }
+        return delegateResponse ?? true
+    }
+    
+    fileprivate func _shouldProceedAfter(error: Error, movingItemAtPath path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, movingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, movingItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, movingItemAtPath: path, toPath: dst)
+            #endif
+        }
+        
+        return delegateResponse ?? false
+    }
+    
+    fileprivate func _shouldMoveItemAtPath(_ path: String, to dst: String) -> Bool {
+        var delegateResponse: Bool?
+        if let delegate = self.safeDelegate {
+            #if FOUNDATION_FRAMEWORK
+            delegateResponse = delegate.fileManager?(self, shouldMoveItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
+            
+            if delegateResponse == nil {
+                delegateResponse = delegate.fileManager?(self, shouldMoveItemAtPath: path, toPath: dst)
+            }
+            #else
+            delegateResponse = delegate.fileManager(self, shouldMoveItemAtPath: path, toPath: dst)
+            #endif
+        }
+        return delegateResponse ?? true
+    }
+}
+
+#if !FOUNDATION_FRAMEWORK
+struct NSFileManagerCopyOptions: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: Void...) {}
+}
+struct NSFileManagerMoveOptions: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: Void...) {}
+}
+#endif
+
+private protocol LinkOrCopyDelegate {
+    func shouldPerformOnItemAtPath(_ path: String, to dstPtr: UnsafePointer<CChar>) -> Bool
+    func throwIfNecessary(_ errno: Int32, _ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>) throws
+    func throwIfNecessary(_ error: Error, _ srcString: String, _ dstString: String) throws
+    var extraCopyFileFlags: Int32 { get }
+    var copyData: Bool { get }
+}
+
+private extension LinkOrCopyDelegate {
+    var extraCopyFileFlags: Int32 { 0 }
+    func throwIfNecessary(_ error: Error, _ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>) throws {
+        let srcString = String(cString: srcPtr)
+        let dstString = String(cString: dstPtr)
+        try throwIfNecessary(error, srcString, dstString)
+    }
+}
+
+enum _FileOperations {
+    // MARK: removefile
+    static func removeFile(_ path: String, with fileManager: FileManager?) throws {
+        try path.withFileSystemRepresentation { rep in
+            guard let rep else {
+                throw CocoaError.errorWithFilePath(.fileNoSuchFile, path)
+            }
+            try Self._removeFile(rep, path, with: fileManager)
+        }
+    }
+    
+    #if canImport(Darwin)
+    fileprivate class _FileRemoveContext {
+        var error: CocoaError?
+        var manager: FileManager?
+        
+        init(_ manager: FileManager?) {
+            self.manager = manager
+        }
+    }
+    
+    private static func _removeFile(_ pathPtr: UnsafePointer<CChar>, _ pathStr: String, with fileManager: FileManager?) throws {
+        let state = removefile_state_alloc()
+        defer { removefile_state_free(state) }
+        
+        let ctx = _FileRemoveContext(fileManager)
+        try withExtendedLifetime(ctx) {
+            let ctxPtr = Unmanaged.passUnretained(ctx).toOpaque()
+            _filemanagershims_removefile_attach_callbacks(state, ctxPtr)
+            
+            let err = removefile(pathPtr, state, removefile_flags_t(REMOVEFILE_RECURSIVE))
+            if err > 0 {
+                throw CocoaError.removeFileError(Int32(_filemanagershims_removefile_state_get_errnum(state)), pathStr)
+            }
+            
+            if let error = ctx.error {
+                throw error
+            }
+        }
+    }
+    #else
+    private static func _removeFile(_ path: UnsafePointer<CChar>, _ pathStr: String, with fileManager: FileManager?) throws {
+        let currentDirectoryPath = fileManager?.currentDirectoryPath ?? ""
+        func resolve(path: String) -> String {
+            if path.starts(with: "/") {
+                return path
+            } else {
+                return currentDirectoryPath.appendingPathComponent(path)
+            }
+        }
+        var stat = stat()
+        guard lstat(path, &stat) == 0 && stat.isDirectory else {
+            // Was not a directory, so unlink it
+            guard fileManager?._shouldRemoveItemAtPath(pathStr) ?? true else { return }
+            guard unlink(path) == 0 else {
+                let error = CocoaError.removeFileError(errno, pathStr)
+                if !(fileManager?._shouldProceedAfter(error: error, removingItemAtPath: pathStr) ?? false) {
+                    throw error
+                }
+                return
+            }
+            return
+        }
+        
+        guard fileManager?._shouldRemoveItemAtPath(resolve(path: pathStr)) ?? true else { return }
+        let trivialResult = rmdir(path)
+        if trivialResult == 0 {
+            // Was an empty directory that we removed, so exit
+            return
+        } else if errno != ENOTEMPTY {
+            // We failed for a reason other than the directory not being empty, so throw
+            throw CocoaError.removeFileError(errno, resolve(path: pathStr))
+        }
+        
+        let seq = _FTSSequence(path, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT)
+        let iterator = seq.makeIterator()
+        var isFirst = true
+        while let item = iterator.next() {
+            switch item {
+            case let .error(err, errPath):
+                throw CocoaError.removeFileError(err, errPath)
+                
+            case let .entry(entry):
+                switch Int32(entry.ftsEnt.fts_info) {
+                case FTS_DEFAULT, FTS_F, FTS_NSOK, FTS_SL, FTS_SLNONE:
+                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    guard fileManager?._shouldRemoveItemAtPath(currentPathStr) ?? true else {
+                        break
+                    }
+                    if unlink(entry.ftsEnt.fts_path) != 0 {
+                        let error = CocoaError.removeFileError(errno, currentPathStr)
+                        if !(fileManager?._shouldProceedAfter(error: error, removingItemAtPath: currentPathStr) ?? false) {
+                            throw error
+                        }
+                    }
+                case FTS_D:
+                    if isFirst {
+                        // The first directory was already approved above
+                        isFirst = false
+                        break
+                    }
+                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    if !(fileManager?._shouldRemoveItemAtPath(currentPathStr) ?? true) {
+                        iterator.skipDescendants(of: entry, skipPostProcessing: true)
+                    }
+                case FTS_DP:
+                    if rmdir(entry.ftsEnt.fts_path) != 0 {
+                        let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                        let error = CocoaError.removeFileError(errno, currentPathStr)
+                        if !(fileManager?._shouldProceedAfter(error: error, removingItemAtPath: currentPathStr) ?? false) {
+                            throw error
+                        }
+                    }
+                case FTS_DNR, FTS_ERR, FTS_NS:
+                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    throw CocoaError.removeFileError(entry.ftsEnt.fts_errno, currentPathStr)
+                default:
+                    break
+                }
+            }
+        }
+        
+    }
+    #endif
+    
+    // MARK: Move File
+    
+    static func moveFile(_ src: URL, to dst: URL, with fileManager: FileManager, options: NSFileManagerMoveOptions) throws {
+        try src.withUnsafeFileSystemRepresentation { srcPath in
+            guard let srcPath else {
+                throw CocoaError.errorWithFilePath(.fileNoSuchFile, src)
+            }
+            
+            try dst.withUnsafeFileSystemRepresentation { dstPath in
+                guard let dstPath else {
+                    throw CocoaError.errorWithFilePath(.fileNoSuchFile, dst)
+                }
+                
+                guard fileManager._shouldMoveItemAtPath(String(cString: srcPath), to: String(cString: dstPath)) else { return }
+                
+                // If the destination path already exists, we're going to bail out completely & set the error.
+                var fileInfoBuffer = stat()
+                var delegateIgnoredOverwriteError = false
+                if lstat(dstPath, &fileInfoBuffer) == 0 {
+                    // The lstat succeeded, so this is the error case for a file existing at the destination
+                    // If the last components are case-insensitively the same, then we might be dealing with a case-only rename which should proceed ...
+                    var shouldProceed = false
+                    if src.lastPathComponent.compare(dst.lastPathComponent, options: [.caseInsensitive]) == .orderedSame {
+                        #if FOUNDATION_FRAMEWORK
+                        // TODO: Support case-only rename in swift-foundation
+                        if let srcAttrs = try? src.resourceValues(forKeys: [.parentDirectoryURLKey]), let dstAttrs = try? dst.resourceValues(forKeys: [.parentDirectoryURLKey, .volumeSupportsCasePreservedNamesKey, .volumeSupportsCaseSensitiveNamesKey]) {
+                            
+                            // ... but not if the source and destination are in different directories, meaning they're definitely different directory entries ...
+                            if srcAttrs.parentDirectory == dstAttrs.parentDirectory {
+                                // ... but only in volumes that are case insensitive, but case preserving.
+                                if dstAttrs.volumeSupportsCasePreservedNames! && !dstAttrs.volumeSupportsCaseSensitiveNames! {
+                                    shouldProceed = true
+                                }
+                            }
+                        }
+                        #endif
+                    }
+                    
+                    if !shouldProceed {
+                        let err = CocoaError.moveFileError(EEXIST, src, dst)
+                        guard fileManager._shouldProceedAfter(error: err, movingItemAtPath: String(cString: srcPath), to: String(cString: dstPath)) else {
+                            throw err
+                        }
+                        delegateIgnoredOverwriteError = true
+                    }
+                }
+                
+                // First, we should just rename (who knows? We might get lucky).
+                var renameError = rename(srcPath, dstPath) != 0
+                let renameErrno = errno
+                
+#if os(macOS) && FOUNDATION_FRAMEWORK
+                // If the rename was successful, stamp with DO_NOT_TRANSLOCATE, if requested. If rename failed with EXDEV, the copy operation will take care of it instead. Ignore failure. 26556142.
+                if !renameError && options.contains(.allowRunningResultInPlace) {
+                    if let qtn = _qtn_file_alloc() {
+                        defer { _qtn_file_free(qtn) }
+                        
+                        if _qtn_file_init_with_path(qtn, dstPath) == 0 {
+                            var flags = _qtn_file_get_flags(qtn)
+                            if flags & QTN_FLAG_DO_NOT_TRANSLOCATE.rawValue == 0 {
+                                flags |= QTN_FLAG_DO_NOT_TRANSLOCATE.rawValue
+                                _qtn_file_set_flags(qtn, flags);
+                                _qtn_file_apply_to_path(qtn, dstPath);
+                            }
+                        }
+                    }
+                }
+#endif
+                
+#if (os(macOS) || os(iOS)) && FOUNDATION_FRAMEWORK
+                if renameError && renameErrno == ENOENT {
+                    // Could this perhaps be a faulted-out iCloud file that we're attempting to move?
+                    var handled: ObjCBool = false
+                    try fileManager._handleFaultedOutCloudDoc(fromSource: src, toDestination: dst, handled: &handled)
+                    if handled.boolValue {
+                        renameError = false
+                    }
+                }
+#endif
+                
+                if renameError {
+                    if renameErrno == EXDEV {
+                        // We tried to move something across a device. We should copy and then unlink the original.
+                        var copyOptions: NSFileManagerCopyOptions = []
+#if os(macOS) && FOUNDATION_FRAMEWORK
+                        if options.contains(.allowRunningResultInPlace) {
+                            copyOptions.insert(.allowRunningResultInPlace)
+                        }
+#endif
+                        
+                        do {
+                            try Self.copyFile(src.path, to: dst.path, with: fileManager, options: copyOptions)
+                        } catch let copyError as CocoaError {
+                            // The error occurred on the copy operation, however we don't want to report those paths - we want to report the paths on the top-level item; the one the move was requested for. We'll wrap the copy operation error in the underlying error key, but we'll pick up the error code from the underlying error itself.
+                            
+                            if !delegateIgnoredOverwriteError {
+                                // Remove the incomplete copy at the destination, but only if the delegate didn't ignore the overwrite failure.
+                                try? Self.removeFile(dst.path, with: nil)
+                            }
+                            
+                            throw CocoaError(copyError.code, userInfo: [
+                                NSFilePathErrorKey : src.path,
+                                NSDestinationFilePathErrorKey : dst.path,
+                                NSUserStringVariantErrorKey : "Move",
+                                NSUnderlyingErrorKey : copyError
+                            ])
+                        }
+                        
+                        // The copy was successful. Remove the original, but only if the delegate didn't ignore the rename failure.
+                        do {
+                            try Self.removeFile(src.path, with: nil)
+                        } catch let removeError as CocoaError {
+                            // Like the error from the copy operation above, make the "Remove" error the underlying error to a "Move" error.
+                            throw CocoaError(removeError.code, userInfo: [
+                                NSFilePathErrorKey : src.path,
+                                NSDestinationFilePathErrorKey : dst.path,
+                                NSUserStringVariantErrorKey : "Move",
+                                NSUnderlyingErrorKey : removeError
+                            ])
+                        }
+                    } else {
+                        // The error was something other than EXDEV, which means the rename() failed. The error codes for the rename need to be translated into something good for Cocoa domain errors.
+                        let renameError = CocoaError.moveFileError(renameErrno, src, dst)
+                        guard fileManager._shouldProceedAfter(error: renameError, movingItemAtPath: src.path, to: dst.path) else {
+                            throw renameError
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: Link/Copy File
+    
+    #if !canImport(Darwin)
+    private static func _copyRegularFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, delegate: some LinkOrCopyDelegate) throws {
+        var fileInfo = stat()
+        guard stat(srcPtr, &fileInfo) >= 0 else {
+            try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
+            return
+        }
+
+        let srcfd = open(srcPtr, O_RDONLY)
+        guard srcfd >= 0 else {
+            try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
+            return
+        }
+        defer { close(srcfd) }
+
+        let dstfd = open(dstPtr, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC, 0o666)
+        guard dstfd >= 0 else {
+            try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
+            return
+        }
+        defer { close(dstfd) }
+
+        // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
+        let permissions = fileInfo.st_mode & ~S_IFMT
+        guard fchmod(dstfd, permissions) == 0 else {
+            try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
+            return
+        }
+
+        if fileInfo.st_size == 0 {
+            // no copying required
+            return
+        }
+        
+        let total = fileInfo.st_size
+        let chunkSize = Int(fileInfo.st_blksize)
+        var current = 0
+        
+        while current < total {
+            guard sendfile(dstfd, srcfd, &current, Swift.min(total - current, chunkSize)) != -1 else {
+                try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
+                return
+            }
+        }
+    }
+    #endif
+    
+    private static func _linkOrCopyFile(_ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
+        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { buffer in
+            let dstLen = Platform.copyCString(dst: buffer.baseAddress!, src: dstPtr, size: FileManager.MAX_PATH_SIZE)
+            let srcLen = strlen(srcPtr)
+            let dstAppendPtr = buffer.baseAddress!.advanced(by: dstLen)
+            let remainingBuffer = FileManager.MAX_PATH_SIZE - dstLen
+            
+            let seq = _FTSSequence(srcPtr, .init(FTS_PHYSICAL | FTS_NOCHDIR))
+            let iterator = seq.makeIterator()
+            while let item = iterator.next() {
+                switch item {
+                case let .error(errno, path):
+                    throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
+                    
+                case let .entry(entry):
+                    let trimmedPathPtr = entry.ftsEnt.fts_path.advanced(by: srcLen)
+                    Platform.copyCString(dst: dstAppendPtr, src: trimmedPathPtr, size: remainingBuffer)
+                    
+                    // we don't want to ask the delegate on the way back -up- the hierarchy if they want to copy a directory they've already seen and therefore already said "YES" to.
+                    guard entry.ftsEnt.fts_info == FTS_DP || delegate.shouldPerformOnItemAtPath(String(cString: entry.ftsEnt.fts_path), to: buffer.baseAddress!) else {
+                        if entry.ftsEnt.fts_info == FTS_D {
+                            iterator.skipDescendants(of: entry, skipPostProcessing: true)
+                        }
+                        continue
+                    }
+                    
+                    let extraFlags = entry.ftsEnt.fts_level == 0 ? delegate.extraCopyFileFlags : 0
+                    
+                    switch Int32(entry.ftsEnt.fts_info) {
+                    case FTS_D:
+                        // Directory being visited in pre-order - create it with whatever default perms will be on the destination.
+                        #if canImport(Darwin)
+                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_DATA | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                            try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #else
+                        do {
+                            try fileManager.createDirectory(atPath: String(cString: buffer.baseAddress!), withIntermediateDirectories: true)
+                        } catch {
+                            try delegate.throwIfNecessary(error, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #endif
+                        
+                    case FTS_DP:
+                        // Directory being visited in post-order - copy the permissions over.
+                        #if canImport(Darwin)
+                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_METADATA | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                            try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #else
+                        do {
+                            let attributes = try fileManager.attributesOfItem(atPath: String(cString: entry.ftsEnt.fts_path))
+                            try fileManager.setAttributes(attributes, ofItemAtPath: String(cString: buffer.baseAddress!))
+                        } catch {
+                            try delegate.throwIfNecessary(error, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #endif
+                        
+                    case FTS_SL: fallthrough    // Symlink.
+                    case FTS_SLNONE:            // Symlink with no target.
+                        // Do what the documentation says (and what linkPath:toPath:handler: does) - copy the symlink, instead of creating a hard link.
+                        #if canImport(Darwin)
+                        var flags: Int32
+                        if delegate.copyData {
+                            flags = COPYFILE_CLONE | COPYFILE_ALL | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags
+                        } else {
+                            flags = COPYFILE_DATA | COPYFILE_METADATA | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags
+                        }
+                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(flags)) != 0 {
+                            try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #else
+                        try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { tempBuff in
+                            tempBuff.initialize(repeating: 0)
+                            defer { tempBuff.deinitialize() }
+                            let len = readlink(entry.ftsEnt.fts_path, tempBuff.baseAddress!, FileManager.MAX_PATH_SIZE - 1)
+                            if len >= 0, symlink(tempBuff.baseAddress!, buffer.baseAddress!) != -1 {
+                                return
+                            }
+                            try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        }
+                        #endif
+                        
+                    case FTS_DEFAULT: fallthrough   // Something not defined anywhere else.
+                    case FTS_F:                     // Regular file.
+                        if delegate.copyData {
+                            #if canImport(Darwin)
+                            if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_CLONE | COPYFILE_ALL | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                                try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                            }
+                            #else
+                            try Self._copyRegularFile(entry.ftsEnt.fts_path, buffer.baseAddress!, delegate: delegate)
+                            #endif
+                        } else {
+                            if link(entry.ftsEnt.fts_path, buffer.baseAddress!) != 0 {
+                                try delegate.throwIfNecessary(errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                            }
+                        }
+                        
+                        // Error returns
+                    case FTS_DNR: fallthrough   // Directory cannot be read.
+                    case FTS_ERR: fallthrough   // Some error occurred, but we don't know what.
+                    case FTS_NS:                // No stat(2) information is available.
+                        try delegate.throwIfNecessary(entry.ftsEnt.fts_errno, entry.ftsEnt.fts_path, buffer.baseAddress!)
+                        
+                    default: break
+                    }
+                }
+            }
+        }
+    }
+    
+    private static func linkOrCopyFile(_ src: String, dst: String, with fileManager: FileManager, delegate: some LinkOrCopyDelegate) throws {
+        try src.withFileSystemRepresentation { srcPtr in
+            guard let srcPtr else {
+                throw CocoaError.errorWithFilePath(.fileReadNoSuchFile, src)
+            }
+            try dst.withFileSystemRepresentation { dstPtr in
+                guard let dstPtr else {
+                    throw CocoaError.errorWithFilePath(.fileNoSuchFile, dst)
+                }
+                try Self._linkOrCopyFile(srcPtr, dstPtr, with: fileManager, delegate: delegate)
+            }
+        }
+    }
+    
+    static func copyFile(_ src: String, to dst: String, with fileManager: FileManager, options: NSFileManagerCopyOptions) throws {
+        struct CopyFileDelegate : LinkOrCopyDelegate {
+            let copyData = true
+            let extraCopyFileFlags: Int32
+            let fileManager: FileManager
+            init(inPlace: Bool, fileManager: FileManager) {
+                self.fileManager = fileManager
+                #if canImport(Darwin)
+                extraCopyFileFlags = inPlace ? COPYFILE_RUN_IN_PLACE : 0
+                #else
+                extraCopyFileFlags = 0
+                #endif
+            }
+            
+            func shouldPerformOnItemAtPath(_ path: String, to dstPtr: UnsafePointer<CChar>) -> Bool {
+                fileManager._shouldCopyItemAtPath(path, to: String(cString: dstPtr))
+            }
+            
+            func throwIfNecessary(_ errno: Int32, _ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>) throws {
+                let srcString = String(cString: srcPtr)
+                let dstString = String(cString: dstPtr)
+                let error = CocoaError.copyFileError(errno, srcString, dstString)
+                try throwIfNecessary(error, srcString, dstString)
+            }
+            
+            func throwIfNecessary(_ error: Error, _ srcString: String, _ dstString: String) throws {
+                guard fileManager._shouldProceedAfter(error: error, copyingItemAtPath: srcString, to: dstString) else {
+                    throw error
+                }
+            }
+        }
+        var inPlace = false
+        #if FOUNDATION_FRAMEWORK
+        if options.contains(.allowRunningResultInPlace) {
+            inPlace = true
+        }
+        #endif
+        try Self.linkOrCopyFile(src, dst: dst, with: fileManager, delegate: CopyFileDelegate(inPlace: inPlace, fileManager: fileManager))
+    }
+    
+    static func linkFile(_ src: String, to dst: String, with fileManager: FileManager) throws {
+        struct LinkFileDelegate : LinkOrCopyDelegate {
+            let copyData = false
+            let fileManager: FileManager
+            
+            init(_ fileManager: FileManager) {
+                self.fileManager = fileManager
+            }
+            
+            func shouldPerformOnItemAtPath(_ path: String, to dstPtr: UnsafePointer<CChar>) -> Bool {
+                fileManager._shouldLinkItemAtPath(path, to: String(cString: dstPtr))
+            }
+            
+            func throwIfNecessary(_ errno: Int32, _ srcPtr: UnsafePointer<CChar>, _ dstPtr: UnsafePointer<CChar>) throws {
+                let srcString = String(cString: srcPtr)
+                let dstString = String(cString: dstPtr)
+                let error = CocoaError.linkFileError(errno, srcString, dstString)
+                try throwIfNecessary(error, srcString, dstString)
+            }
+            
+            func throwIfNecessary(_ error: Error, _ srcString: String, _ dstString: String) throws {
+                guard fileManager._shouldProceedAfter(error: error, linkingItemAtPath: srcString, to: dstString) else {
+                    throw error
+                }
+            }
+        }
+        try Self.linkOrCopyFile(src, dst: dst, with: fileManager, delegate: LinkFileDelegate(fileManager))
+    }
+}

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -1,0 +1,328 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !FOUNDATION_FRAMEWORK
+
+public struct FileAttributeType : Hashable, RawRepresentable, Sendable {
+    public let rawValue: String
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public static let typeBlockSpecial: Self = Self("NSFileTypeBlockSpecial")
+    public static let typeCharacterSpecial: Self = Self("NSFileTypeCharacterSpecial")
+    public static let typeDirectory: Self = Self("NSFileTypeDirectory")
+    public static let typeRegular: Self = Self("NSFileTypeRegular")
+    public static let typeSocket: Self = Self("NSFileTypeSocket")
+    public static let typeSymbolicLink: Self = Self("NSFileTypeSymbolicLink")
+    public static let typeUnknown: Self = Self("NSFileTypeUnknown")
+}
+
+public struct FileAttributeKey: Hashable, RawRepresentable, Sendable {
+    public typealias RawValue = String
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public static let type = Self(rawValue: "NSFileType")
+    public static let size = Self(rawValue: "NSFileSize")
+    public static let modificationDate = Self(rawValue: "NSFileModificationDate")
+    public static let referenceCount = Self(rawValue: "NSFileCount")
+    public static let deviceIdentifier = Self(rawValue: "NSFileDeviceIdentifier")
+    public static let ownerAccountName = Self(rawValue: "NSFileOwnerAccountName")
+    public static let groupOwnerAccountName = Self(rawValue: "NSFileGroupOwnerAccountName")
+    public static let posixPermissions = Self(rawValue: "NSFilePosixPermissions")
+    public static let systemNumber = Self(rawValue: "NSFileSystemNumber")
+    public static let systemFileNumber = Self(rawValue: "NSFileSystemFileNumber")
+    public static let extensionHidden = Self(rawValue: "NSFileExtensionHidden")
+    public static let hfsCreatorCode = Self(rawValue: "NSFileHFSCreatorCode")
+    public static let hfsTypeCode = Self(rawValue: "NSFileHFSTypeCode")
+    public static let immutable = Self(rawValue: "NSFileImmutable")
+    public static let appendOnly = Self(rawValue: "NSFileAppendOnly")
+    public static let creationDate = Self(rawValue: "NSFileCreationDate")
+    public static let ownerAccountID = Self(rawValue: "NSFileOwnerAccountID")
+    public static let groupOwnerAccountID = Self(rawValue: "NSFileGroupOwnerAccountID")
+    public static let busy = Self(rawValue: "NSFileBusy")
+    public static let protectionKey = Self(rawValue: "NSFileProtectionKey")
+    public static let systemSize = Self(rawValue: "NSFileSystemSize")
+    public static let systemFreeSize = Self(rawValue: "NSFileSystemFreeSize")
+    public static let systemNodes = Self(rawValue: "NSFileSystemNodes")
+    public static let systemFreeNodes = Self(rawValue: "NSFileSystemFreeNodes")
+}
+
+public struct FileProtectionType : RawRepresentable, Sendable {
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public static let none = Self(rawValue: "NSFileProtectionNone")
+    public static let complete = Self(rawValue: "NSFileProtectionComplete")
+    public static let completeUnlessOpen = Self(rawValue: "NSFileProtectionCompleteUnlessOpen")
+    public static let completeUntilFirstUserAuthentication = Self(rawValue: "NSFileProtectionCompleteUntilFirstUserAuthentication")
+    public static let inactive = Self(rawValue: "NSFileProtectionCompleteWhenUserInactive")
+}
+
+extension FileManager {
+    public struct UnmountOptions : OptionSet, Sendable {
+        public let rawValue: UInt
+        
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+        
+        public static let allPartitionsAndEjectDisk = Self(rawValue: 1 << 0)
+        public static let withoutUI = Self(rawValue: 1 << 1)
+    }
+    
+    public struct DirectoryEnumerationOptions : OptionSet, Sendable {
+        public let rawValue: UInt
+        
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+        
+        public static let skipsSubdirectoryDescendants = Self(rawValue: 1 << 0)
+        public static let skipsPackageDescendants = Self(rawValue: 1 << 1)
+        public static let skipsHiddenFiles = Self(rawValue: 1 << 2)
+        public static let includesDirectoriesPostOrder = Self(rawValue: 1 << 3)
+        public static let producesRelativePathURLs = Self(rawValue: 1 << 4)
+    }
+    
+    public enum SearchPathDirectory : UInt, Sendable {
+        case applicationDirectory = 1
+        case demoApplicationDirectory = 2
+        case developerApplicationDirectory = 3
+        case adminApplicationDirectory = 4
+        case libraryDirectory = 5
+        case developerDirectory = 6
+        case userDirectory = 7
+        case documentationDirectory = 8
+        case documentDirectory = 9
+        case coreServiceDirectory = 10
+        case autosavedInformationDirectory = 11
+        case desktopDirectory = 12
+        case cachesDirectory = 13
+        case applicationSupportDirectory = 14
+        case downloadsDirectory = 15
+        case inputMethodsDirectory = 16
+        case moviesDirectory = 17
+        case musicDirectory = 18
+        case picturesDirectory = 19
+        case printerDescriptionDirectory = 20
+        case sharedPublicDirectory = 21
+        case preferencePanesDirectory = 22
+        
+        // TODO: Unavailable in FoundationPreview because it requires the code signing identifier
+        // case applicationScriptsDirectory = 23
+        
+        case itemReplacementDirectory = 99
+        case allApplicationsDirectory = 100
+        case allLibrariesDirectory = 101
+        case trashDirectory = 102
+    }
+    
+    public struct SearchPathDomainMask : OptionSet, Sendable {
+        public let rawValue: UInt
+        
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+
+        public static let userDomainMask = Self(rawValue: 1 << 0)
+        public static let localDomainMask = Self(rawValue: 1 << 1)
+        public static let networkDomainMask = Self(rawValue: 1 << 2)
+        public static let systemDomainMask = Self(rawValue: 1 << 3)
+        public static let allDomainsMask = Self(rawValue: 0xFFFF)
+    }
+    
+    public enum URLRelationship : Int, Sendable {
+        case contains = 0
+        case same = 1
+        case other = 2
+    }
+    
+    public struct ItemReplacementOptions : OptionSet, Sendable {
+        public let rawValue: UInt
+        
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+        
+        public static let usingNewMetadataOnly = Self(rawValue: 1 << 0)
+        public static let withoutDeletingBackupItem = Self(rawValue: 1 << 1)
+    }
+}
+
+@_nonSendable
+open class FileManager {
+    private var _impl: _FileManagerImpl
+    
+    private static var _default = FileManager()
+    open class var `default`: FileManager {
+        _default
+    }
+    
+    open weak var delegate: (any FileManagerDelegate)?
+    
+    init() {
+        _impl = _FileManagerImpl()
+        _impl._manager = self
+    }
+
+    open func setAttributes(_ attributes: [FileAttributeKey : Any], ofItemAtPath path: String) throws {
+        try _impl.setAttributes(attributes, ofItemAtPath: path)
+    }
+
+    open func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
+        try _impl.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes)
+    }
+
+    open func contentsOfDirectory(atPath path: String) throws -> [String] {
+        try _impl.contentsOfDirectory(atPath: path)
+    }
+
+    open func subpathsOfDirectory(atPath path: String) throws -> [String] {
+        try _impl.subpathsOfDirectory(atPath: path)
+    }
+
+    open func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
+        try _impl.attributesOfItem(atPath: path)
+    }
+
+    open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+        try _impl.attributesOfFileSystem(forPath: path)
+    }
+
+    open func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+        try _impl.createSymbolicLink(atPath: path, withDestinationPath: destPath)
+    }
+
+    open func destinationOfSymbolicLink(atPath path: String) throws -> String {
+        try _impl.destinationOfSymbolicLink(atPath: path)
+    }
+
+    open func copyItem(atPath srcPath: String, toPath dstPath: String) throws {
+        try _impl.copyItem(atPath: srcPath, toPath: dstPath, options: [])
+    }
+
+    open func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
+        try _impl.moveItem(atPath: srcPath, toPath: dstPath, options: [])
+    }
+
+    open func linkItem(atPath srcPath: String, toPath dstPath: String) throws {
+        try _impl.linkItem(atPath: srcPath, toPath: dstPath)
+    }
+
+    open func removeItem(atPath path: String) throws {
+        try _impl.removeItem(atPath: path)
+    }
+
+    open func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        try _impl.copyItem(at: srcURL, to: dstURL, options: [])
+    }
+
+    open func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        try _impl.moveItem(at: srcURL, to: dstURL, options: [])
+    }
+
+    open func linkItem(at srcURL: URL, to dstURL: URL) throws {
+        try _impl.linkItem(at: srcURL, to: dstURL)
+    }
+
+    open func removeItem(at URL: URL) throws {
+        try _impl.removeItem(at: URL)
+    }
+
+    open var currentDirectoryPath: String {
+        _impl.currentDirectoryPath!
+    }
+
+    open func changeCurrentDirectoryPath(_ path: String) -> Bool {
+        _impl.changeCurrentDirectoryPath(path)
+    }
+
+    open func fileExists(atPath path: String) -> Bool {
+        _impl.fileExists(atPath: path)
+    }
+
+    open func fileExists(atPath path: String, isDirectory: inout Bool) -> Bool {
+        _impl.fileExists(atPath: path, isDirectory: &isDirectory)
+    }
+
+    open func isReadableFile(atPath path: String) -> Bool {
+        _impl.isReadableFile(atPath: path)
+    }
+
+    open func isWritableFile(atPath path: String) -> Bool {
+        _impl.isWritableFile(atPath: path)
+    }
+
+    open func isExecutableFile(atPath path: String) -> Bool {
+        _impl.isExecutableFile(atPath: path)
+    }
+
+    open func isDeletableFile(atPath path: String) -> Bool {
+        _impl.isDeletableFile(atPath: path)
+    }
+
+    open func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+        _impl.contentsEqual(atPath: path1, andPath: path2)
+    }
+    
+    open func contents(atPath path: String) -> Data? {
+        _impl.contents(atPath: path)
+    }
+
+    open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
+        _impl.createFile(atPath: path, contents: data, attributes: attr)
+    }
+
+    open func string(withFileSystemRepresentation str: UnsafePointer<CChar>, length len: Int) -> String {
+        _impl.string(withFileSystemRepresentation: str, length: len)
+    }
+    
+    open func withFileSystemRepresentation<R>(for path: String, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
+        try path.withFileSystemRepresentation(body)
+    }
+
+    open var temporaryDirectory: URL {
+        _impl.temporaryDirectory
+    }
+    
+    @available(iOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    open var homeDirectoryForCurrentUser: URL {
+        _impl.homeDirectoryForCurrentUser
+    }
+
+    @available(iOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    open func homeDirectory(forUser userName: String) -> URL? {
+        _impl.homeDirectory(forUser: userName)
+    }
+}
+
+#endif

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !FOUNDATION_FRAMEWORK
+
+public protocol FileManagerDelegate : AnyObject {
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool
+}
+
+extension FileManagerDelegate {
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool { return false }
+}
+
+#endif

--- a/Sources/FoundationEssentials/URL+Stub.swift
+++ b/Sources/FoundationEssentials/URL+Stub.swift
@@ -13,10 +13,29 @@
 #if !FOUNDATION_FRAMEWORK
 
 public struct URL : Hashable, Sendable, Codable {
-    private init() { }
+    public let path: String
     
-    public var isFileURL: Bool { false }
-    public var path: String { "" }
+    enum DirectoryHint {
+        case isDirectory
+    }
+    internal init(filePath: String, directoryHint: DirectoryHint = .isDirectory) {
+        self.path = filePath
+    }
+    internal init(fileURLWithPath: String, isDirectory: Bool? = nil) {
+        self.path = fileURLWithPath
+    }
+    
+    public var isFileURL: Bool { true }
+    public var lastPathComponent: String { path.lastPathComponent }
+    public var scheme: String? { "file" }
+    
+    internal func path(percentEncoded: Bool = true) -> String { self.path }
+    
+    internal func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
+        try path.withFileSystemRepresentation(block)
+    }
 }
+
+public struct URLResourceKey {}
 
 #endif // !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1557,12 +1557,7 @@ extension Locale {
                 return
             }
             var status = U_ZERO_ERROR
-            #if canImport(Glibc) || canImport(ucrt)
-            // Glibc doesn't support strlcpy
-            strcpy(buf, identifier)
-            #else
-            strlcpy(buf, identifier, Int(ULOC_FULLNAME_CAPACITY))
-            #endif
+            Platform.copyCString(dst: buf, src: identifier, size: Int(ULOC_FULLNAME_CAPACITY))
 
             // TODO: This could probably be lifted out of ICU; it is mostly string concatenation
             let len = uloc_setKeywordValue(key.key, value, buf, ULOC_FULLNAME_CAPACITY, &status)

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -202,6 +202,11 @@ public typealias SortComparator = FoundationEssentials.SortComparator
 public typealias ComparableComparator = FoundationEssentials.ComparableComparator
 public typealias ComparisonResult = FoundationEssentials.ComparisonResult
 
+public typealias FileManager = FoundationEssentials.FileManager
+public typealias FileAttributeKey = FoundationEssentials.FileAttributeKey
+public typealias CocoaError = FoundationEssentials.CocoaError
+public typealias FileManagerDelegate = FoundationEssentials.FileManagerDelegate
+
 #endif // FOUNDATION_FRAMEWORK
 
 /// ICU uses `\u{202f}` and `\u{020f}` interchangeably

--- a/Sources/_CShims/filemanager_shims.c
+++ b/Sources/_CShims/filemanager_shims.c
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "include/filemanager_shims.h"
+
+#if __has_include(<removefile.h>)
+
+extern void _FileRemove_ConfirmCallback(void);
+extern void _FileRemove_ErrorCallback(void);
+
+void _filemanagershims_removefile_attach_callbacks(removefile_state_t state, void *ctx) {
+    removefile_state_set(state, REMOVEFILE_STATE_CONFIRM_CONTEXT, ctx);
+    removefile_state_set(state, REMOVEFILE_STATE_CONFIRM_CALLBACK, _FileRemove_ConfirmCallback);
+    removefile_state_set(state, REMOVEFILE_STATE_ERROR_CONTEXT, ctx);
+    removefile_state_set(state, REMOVEFILE_STATE_ERROR_CALLBACK, _FileRemove_ErrorCallback);
+}
+
+int _filemanagershims_removefile_state_get_errnum(removefile_state_t state) {
+    int errnum = 0;
+    removefile_state_get(state, REMOVEFILE_STATE_ERRNO, &errnum);
+    return errnum;
+}
+
+#endif // __has_include(<removefile.h>)

--- a/Sources/_CShims/include/filemanager_shims.h
+++ b/Sources/_CShims/include/filemanager_shims.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CSHIMS_FILEMANAGER_H
+#define CSHIMS_FILEMANAGER_H
+
+#include "_CShimsMacros.h"
+
+#if __has_include(<sys/param.h>)
+#include <sys/param.h>
+#endif
+
+#if __has_include(<fts.h>)
+#include <fts.h>
+#endif
+
+#if __has_include(<sys/quota.h>)
+#include <sys/quota.h>
+#endif
+
+#if __has_include(<sys/xattr.h>)
+#include <sys/xattr.h>
+#endif
+
+#if __has_include(<dirent.h>)
+#include <dirent.h>
+#endif
+
+#if __has_include(<removefile.h>)
+#include <stdint.h>
+#include <removefile.h>
+
+INTERNAL void _filemanagershims_removefile_attach_callbacks(removefile_state_t state, void *ctx);
+INTERNAL int _filemanagershims_removefile_state_get_errnum(removefile_state_t state);
+
+#endif // __has_include(<removefile.h>)
+
+#if FOUNDATION_FRAMEWORK
+// Darwin-specific API that is implemented but not declared in any header
+// This function behaves exactly like the public mkpath_np(3) API, but it also returns the first directory it actually created, which helps us make sure we set the given attributes on the right directories.
+extern int _mkpath_np(const char *path, mode_t omode, const char **firstdir);
+#endif
+
+#endif // CSHIMS_FILEMANAGER_H

--- a/Sources/_CShims/include/filemanager_shims.h
+++ b/Sources/_CShims/include/filemanager_shims.h
@@ -44,7 +44,8 @@ INTERNAL int _filemanagershims_removefile_state_get_errnum(removefile_state_t st
 
 #endif // __has_include(<removefile.h>)
 
-#if FOUNDATION_FRAMEWORK
+#if FOUNDATION_FRAMEWORK && __has_include(<sys/types.h>)
+#include <sys/types.h>
 // Darwin-specific API that is implemented but not declared in any header
 // This function behaves exactly like the public mkpath_np(3) API, but it also returns the first directory it actually created, which helps us make sure we set the given attributes on the right directories.
 extern int _mkpath_np(const char *path, mode_t omode, const char **firstdir);

--- a/Sources/_CShims/include/io_shims.h
+++ b/Sources/_CShims/include/io_shims.h
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef IOShims_h
+#define IOShims_h
+
+#include "_CShimsTargetConditionals.h"
+
+#if TARGET_OS_MAC && (!defined(TARGET_OS_EXCLAVEKIT) || !TARGET_OS_EXCLAVEKIT)
+
+#include <stdio.h>
+#include <sys/attr.h>
+
+// See getattrlist for an explanation of the layout of these structs.
+
+#pragma pack(push, 1)
+typedef struct PreRenameAttributes {
+    u_int32_t length;
+    fsobj_type_t fileType;
+    u_int32_t mode;
+    attrreference_t fullPathAttr;
+    u_int32_t nlink;
+    char fullPathBuf[PATH_MAX];
+} PreRenameAttributes;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct FullPathAttributes {
+    u_int32_t length;
+    attrreference_t fullPathAttr;
+    char fullPathBuf[PATH_MAX];
+} FullPathAttributes;
+#pragma pack(pop)
+
+#endif // TARGET_OS_EXCLAVEKIT
+#endif /* IOShims_h */

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationEssentials
+#endif
+
+private protocol Buildable {
+    func build(in path: String, using fileManager: FileManager) throws
+}
+
+struct File : ExpressibleByStringLiteral, Buildable {
+    private let name: String
+    private let attributes: [FileAttributeKey : Any]?
+    private let contents: Data?
+    
+    init(_ name: String, attributes: [FileAttributeKey : Any]? = nil, contents: Data? = nil) {
+        self.name = name
+        self.attributes = attributes
+        self.contents = contents
+    }
+    
+    init(stringLiteral value: String) {
+        self.init(value)
+    }
+    
+    fileprivate func build(in path: String, using fileManager: FileManager) throws {
+        guard fileManager.createFile(atPath: path.appendingPathComponent(name), contents: contents, attributes: attributes) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+}
+
+struct Directory : Buildable {
+    fileprivate let name: String
+    private let attributes: [FileAttributeKey : Any]?
+    private let contents: [FileManagerPlayground.Item]
+    
+    init(_ name: String, attributes: [FileAttributeKey : Any]? = nil, @FileManagerPlayground.DirectoryBuilder _ contentsClosure: () -> [FileManagerPlayground.Item]) {
+        self.name = name
+        self.attributes = attributes
+        self.contents = contentsClosure()
+    }
+    
+    fileprivate func build(in path: String, using fileManager: FileManager) throws {
+        let dirPath = path.appendingPathComponent(name)
+        try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: attributes)
+        for item in contents {
+            try item.build(in: dirPath, using: fileManager)
+        }
+    }
+}
+
+struct FileManagerPlayground {
+    enum Item : Buildable {
+        case file(File)
+        case directory(Directory)
+        
+        fileprivate func build(in path: String, using fileManager: FileManager) throws {
+            switch self {
+            case let .file(file): try file.build(in: path, using: fileManager)
+            case let .directory(dir): try dir.build(in: path, using: fileManager)
+            }
+        }
+    }
+    
+    @resultBuilder
+    enum DirectoryBuilder {
+        static func buildBlock(_ components: Item...) -> [Item] {
+            components
+        }
+        
+        static func buildExpression(_ expression: File) -> Item {
+            .file(expression)
+        }
+        
+        static func buildExpression(_ expression: Directory) -> Item {
+            .directory(expression)
+        }
+    }
+    
+    private let directory: Directory
+    
+    init(@DirectoryBuilder _ contentsClosure: () -> [Item]) {
+        self.directory = Directory("FileManagerPlayground_\(UUID().uuidString)", contentsClosure)
+    }
+    
+    func test(captureDelegateCalls: Bool = false, file: StaticString = #file, line: UInt = #line, _ tester: (FileManager) throws -> Void) throws {
+        let capturingDelegate = CapturingFileManagerDelegate()
+        try withExtendedLifetime(capturingDelegate) {
+            let fileManager = FileManager()
+            let tempDir = String.temporaryDirectoryPath
+            try directory.build(in: tempDir, using: fileManager)
+            let previousCWD = fileManager.currentDirectoryPath
+            if captureDelegateCalls {
+                // Add the delegate after the call to `build` to ensure that the builder doesn't mutate the delegate
+                fileManager.delegate = capturingDelegate
+            }
+            let createdDir = tempDir.appendingPathComponent(directory.name)
+            XCTAssertTrue(fileManager.changeCurrentDirectoryPath(createdDir), "Failed to change CWD to the newly created playground directory", file: file, line: line)
+            try tester(fileManager)
+            XCTAssertTrue(fileManager.changeCurrentDirectoryPath(previousCWD), "Failed to change CWD back to the original directory", file: file, line: line)
+            try fileManager.removeItem(atPath: createdDir)
+        }
+    }
+}

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -1,0 +1,554 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#if canImport(TestSupport)
+import TestSupport
+#endif // canImport(TestSupport)
+
+#if canImport(FoundationEssentials)
+@testable import FoundationEssentials
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#endif
+
+extension FileManager {
+    fileprivate var delegateCaptures: DelegateCaptures {
+        (self.delegate as! CapturingFileManagerDelegate).captures
+    }
+}
+
+private struct DelegateCaptures : Equatable {
+    struct Operation : Equatable, CustomStringConvertible {
+        let src: String
+        let dst: String?
+        
+        var description: String {
+            if let dst {
+                "'\(src)' --> '\(dst)'"
+            } else {
+                "'\(src)'"
+            }
+        }
+        
+        init(_ src: String, _ dst: String? = nil) {
+            self.src = src
+            self.dst = dst
+        }
+    }
+    
+    struct ErrorOperation : Equatable, CustomStringConvertible {
+        let op: Operation
+        let code: CocoaError.Code?
+        
+        init(_ src: String, _ dst: String? = nil, code: CocoaError.Code?) {
+            self.op = Operation(src, dst)
+            self.code = code
+        }
+        
+        var description: String {
+            if let code {
+                "\(op.description) {\(code.rawValue)}"
+            } else {
+                "\(op.description) {non-CocoaError}"
+            }
+        }
+    }
+    var shouldCopy: [Operation] = []
+    var shouldProceedAfterCopyError: [ErrorOperation] = []
+    var shouldMove: [Operation] = []
+    var shouldProceedAfterMoveError: [ErrorOperation] = []
+    var shouldLink: [Operation] = []
+    var shouldProceedAfterLinkError: [ErrorOperation] = []
+    var shouldRemove: [Operation] = []
+    var shouldProceedAfterRemoveError: [ErrorOperation] = []
+    
+    var isEmpty: Bool {
+        self == DelegateCaptures()
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+class CapturingFileManagerDelegate : NSObject, FileManagerDelegate {
+    fileprivate var captures = DelegateCaptures()
+    
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldCopy.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterCopyError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldMove.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterMoveError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldLink.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterLinkError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool {
+        captures.shouldRemove.append(.init(path))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, removingItemAtPath path: String) -> Bool {
+        captures.shouldProceedAfterRemoveError.append(DelegateCaptures.ErrorOperation(path, code: (error as? CocoaError)?.code))
+        return true
+    }
+}
+#else
+class CapturingFileManagerDelegate : FileManagerDelegate {
+    fileprivate var captures = DelegateCaptures()
+    
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldCopy.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterCopyError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldMove.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterMoveError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldLink.append(.init(srcPath, dstPath))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool {
+        captures.shouldProceedAfterLinkError.append(.init(srcPath, dstPath, code: (error as? CocoaError)?.code))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool {
+        captures.shouldRemove.append(.init(path))
+        return true
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: any Error, removingItemAtPath path: String) -> Bool {
+        captures.shouldProceedAfterRemoveError.append(DelegateCaptures.ErrorOperation(path, code: (error as? CocoaError)?.code))
+        return true
+    }
+}
+#endif
+
+final class FileManagerTests : XCTestCase {
+    private func randomData(count: Int = 10000) -> Data {
+        Data((0 ..< count).map { _ in UInt8.random(in: .min ..< .max) })
+    }
+    
+    func testContentsAtPath() throws {
+        let data = randomData()
+        try FileManagerPlayground {
+            File("test", contents: data)
+        }.test {
+            XCTAssertEqual($0.contents(atPath: "test"), data)
+        }
+    }
+    
+    func testContentsEqualAtPaths() throws {
+        try FileManagerPlayground {
+            Directory("dir1") {
+                Directory("dir2") {
+                    "Foo"
+                    "Bar"
+                }
+                Directory("dir3") {
+                    "Baz"
+                }
+            }
+            Directory("dir1_copy") {
+                Directory("dir2") {
+                    "Foo"
+                    "Bar"
+                }
+                Directory("dir3") {
+                    "Baz"
+                }
+            }
+            Directory("dir1_diffdata") {
+                Directory("dir2") {
+                    "Foo"
+                    "Bar"
+                }
+                Directory("dir3") {
+                    File("Baz", contents: randomData())
+                }
+            }
+        }.test {
+            XCTAssertTrue($0.contentsEqual(atPath: "dir1", andPath: "dir1_copy"))
+            XCTAssertFalse($0.contentsEqual(atPath: "dir1/dir2", andPath: "dir1/dir3"))
+            XCTAssertFalse($0.contentsEqual(atPath: "dir1", andPath: "dir1_diffdata"))
+        }
+    }
+    
+    func testDirectoryContentsAtPath() throws {
+        try FileManagerPlayground {
+            Directory("dir1") {
+                Directory("dir2") {
+                    "Foo"
+                    "Bar"
+                }
+                Directory("dir3") {
+                    "Baz"
+                }
+            }
+        }.test {
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "dir1").sorted(), ["dir2", "dir3"])
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "dir1/dir2").sorted(), ["Bar", "Foo"])
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "dir1/dir3").sorted(), ["Baz"])
+            XCTAssertThrowsError(try $0.contentsOfDirectory(atPath: "does_not_exist")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+            }
+        }
+    }
+    
+    func testSubpathsOfDirectoryAtPath() throws {
+        try FileManagerPlayground {
+            Directory("dir1") {
+                Directory("dir2") {
+                    "Foo"
+                    "Bar"
+                }
+                Directory("dir3") {
+                    "Baz"
+                }
+            }
+        }.test {
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: "dir1").sorted(), ["dir2", "dir2/Bar", "dir2/Foo", "dir3", "dir3/Baz"])
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: "dir1/dir2").sorted(), ["Bar", "Foo"])
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: "dir1/dir3").sorted(), ["Baz"])
+            XCTAssertThrowsError(try $0.subpathsOfDirectory(atPath: "does_not_exist")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+            }
+            
+            let fullContents = ["dir1", "dir1/dir2", "dir1/dir2/Bar", "dir1/dir2/Foo", "dir1/dir3", "dir1/dir3/Baz"]
+            let cwd = $0.currentDirectoryPath
+            XCTAssertNotEqual(cwd.last, "/")
+            let paths = [cwd, "\(cwd)/", "\(cwd)//", ".", "./", ".//"]
+            for path in paths {
+                XCTAssertEqual(try $0.subpathsOfDirectory(atPath: path).sorted(), fullContents)
+            }
+        }
+    }
+    
+    func testCreateDirectoryAtPath() throws {
+        try FileManagerPlayground {
+            "preexisting_file"
+        }.test {
+            try $0.createDirectory(atPath: "create_dir_test", withIntermediateDirectories: false)
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "."), ["create_dir_test", "preexisting_file"])
+            try $0.createDirectory(atPath: "create_dir_test2/nested", withIntermediateDirectories: true)
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "create_dir_test2"), ["nested"])
+            try $0.createDirectory(atPath: "create_dir_test2/nested2", withIntermediateDirectories: true)
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "create_dir_test2").sorted(), ["nested", "nested2"])
+            XCTAssertNoThrow(try $0.createDirectory(atPath: "create_dir_test2/nested2", withIntermediateDirectories: true))
+            XCTAssertThrowsError(try $0.createDirectory(atPath: "create_dir_test", withIntermediateDirectories: false)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
+            }
+            XCTAssertThrowsError(try $0.createDirectory(atPath: "create_dir_test3/nested", withIntermediateDirectories: false)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileNoSuchFile)
+            }
+            XCTAssertThrowsError(try $0.createDirectory(atPath: "preexisting_file", withIntermediateDirectories: false)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
+            }
+            XCTAssertThrowsError(try $0.createDirectory(atPath: "preexisting_file", withIntermediateDirectories: true)) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
+            }
+        }
+    }
+    
+    func testLinkFileAtPathToPath() throws {
+        try FileManagerPlayground {
+            "foo"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.linkItem(atPath: "foo", toPath: "bar")
+            XCTAssertEqual($0.delegateCaptures.shouldLink, [.init("foo", "bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterLinkError, [])
+            XCTAssertTrue($0.fileExists(atPath: "bar"))
+        }
+        
+        try FileManagerPlayground {
+            "foo"
+            "bar"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.linkItem(atPath: "foo", toPath: "bar")
+            XCTAssertEqual($0.delegateCaptures.shouldLink, [.init("foo", "bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterLinkError, [.init("foo", "bar", code: .fileWriteFileExists)])
+        }
+    }
+    
+    func testCopyFileAtPathToPath() throws {
+        try FileManagerPlayground {
+            "foo"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.copyItem(atPath: "foo", toPath: "bar")
+            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("foo", "bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError, [])
+            XCTAssertTrue($0.fileExists(atPath: "bar"))
+        }
+        
+        try FileManagerPlayground {
+            "foo"
+            "bar"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.copyItem(atPath: "foo", toPath: "bar")
+            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("foo", "bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError, [.init("foo", "bar", code: .fileWriteFileExists)])
+        }
+    }
+    
+    func testCreateSymbolicLinkAtPath() throws {
+        try FileManagerPlayground {
+            "foo"
+        }.test {
+            try $0.createSymbolicLink(atPath: "bar", withDestinationPath: "foo")
+            XCTAssertEqual(try $0.destinationOfSymbolicLink(atPath: "bar"), "foo")
+            
+            XCTAssertThrowsError(try $0.createSymbolicLink(atPath: "bar", withDestinationPath: "foo")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
+            }
+            XCTAssertThrowsError(try $0.createSymbolicLink(atPath: "foo", withDestinationPath: "baz")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
+            }
+            XCTAssertThrowsError(try $0.destinationOfSymbolicLink(atPath: "foo")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadUnknown)
+            }
+        }
+    }
+    
+    func testMoveItemAtPathToPath() throws {
+        let data = randomData()
+        try FileManagerPlayground {
+            Directory("dir") {
+                File("foo", contents: data)
+                "bar"
+            }
+            "other_file"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.moveItem(atPath: "dir", toPath: "dir2")
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["dir2", "dir2/bar", "dir2/foo", "other_file"])
+            XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
+            #if FOUNDATION_FRAMEWORK
+            // Behavior differs here due to usage of URL(filePath:)
+            let rootDir = $0.currentDirectoryPath
+            XCTAssertEqual($0.delegateCaptures.shouldMove, [.init("\(rootDir)/dir", "\(rootDir)/dir2")])
+            #else
+            XCTAssertEqual($0.delegateCaptures.shouldMove, [.init("dir", "dir2")])
+            #endif
+            
+            try $0.moveItem(atPath: "does_not_exist", toPath: "dir3")
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError, [])
+
+            try $0.moveItem(atPath: "dir2", toPath: "other_file")
+            #if FOUNDATION_FRAMEWORK
+            XCTAssertTrue($0.delegateCaptures.shouldProceedAfterMoveError.contains(.init("\(rootDir)/dir2", "\(rootDir)/other_file", code: .fileWriteFileExists)))
+            #else
+            XCTAssertTrue($0.delegateCaptures.shouldProceedAfterMoveError.contains(.init("dir2", "other_file", code: .fileWriteFileExists)))
+            #endif
+        }
+    }
+    
+    func testCopyItemAtPathToPath() throws {
+        let data = randomData()
+        try FileManagerPlayground {
+            Directory("dir") {
+                File("foo", contents: data)
+                "bar"
+            }
+            "other_file"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.copyItem(atPath: "dir", toPath: "dir2")
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["dir", "dir/bar", "dir/foo", "dir2", "dir2/bar", "dir2/foo", "other_file"])
+            XCTAssertEqual($0.contents(atPath: "dir/foo"), data)
+            XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
+            XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
+            
+            try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError.first, .init("does_not_exist", "dir3", code: .fileNoSuchFile))
+            
+            #if canImport(Darwin)
+            // Not supported on linux because it ends up trying to set attributes that are currently unimplemented
+            try $0.copyItem(atPath: "dir", toPath: "other_file")
+            XCTAssertTrue($0.delegateCaptures.shouldProceedAfterCopyError.contains(.init("dir", "other_file", code: .fileWriteFileExists)))
+            #endif
+        }
+    }
+    
+    func testRemoveItemAtPath() throws {
+        try FileManagerPlayground {
+            Directory("dir") {
+                "foo"
+                "bar"
+            }
+            "other"
+        }.test(captureDelegateCalls: true) {
+            XCTAssertTrue($0.delegateCaptures.isEmpty)
+            try $0.removeItem(atPath: "dir/bar")
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["dir", "dir/foo", "other"])
+            XCTAssertEqual($0.delegateCaptures.shouldRemove, [.init("dir/bar")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterRemoveError, [])
+            
+            let rootDir = $0.currentDirectoryPath
+            try $0.removeItem(atPath: "dir")
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["other"])
+            XCTAssertEqual($0.delegateCaptures.shouldRemove, [.init("dir/bar"), .init("\(rootDir)/dir"), .init("\(rootDir)/dir/foo")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterRemoveError, [])
+            
+            try $0.removeItem(atPath: "other")
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), [])
+            XCTAssertEqual($0.delegateCaptures.shouldRemove, [.init("dir/bar"), .init("\(rootDir)/dir"), .init("\(rootDir)/dir/foo"), .init("other")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterRemoveError, [])
+            
+            try $0.removeItem(atPath: "does_not_exist")
+            XCTAssertEqual($0.delegateCaptures.shouldRemove, [.init("dir/bar"), .init("\(rootDir)/dir"), .init("\(rootDir)/dir/foo"), .init("other"), .init("does_not_exist")])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterRemoveError, [.init("does_not_exist", code: .fileNoSuchFile)])
+        }
+    }
+    
+    func testFileExistsAtPath() throws {
+        try FileManagerPlayground {
+            Directory("dir") {
+                "foo"
+                "bar"
+            }
+            "other"
+        }.test {
+            #if FOUNDATION_FRAMEWORK
+            var isDir: ObjCBool = false
+            func isDirBool() -> Bool {
+                isDir.boolValue
+            }
+            #else
+            var isDir: Bool = false
+            func isDirBool() -> Bool {
+                isDir
+            }
+            #endif
+            XCTAssertTrue($0.fileExists(atPath: "dir/foo", isDirectory: &isDir))
+            XCTAssertFalse(isDirBool())
+            XCTAssertTrue($0.fileExists(atPath: "dir/bar", isDirectory: &isDir))
+            XCTAssertFalse(isDirBool())
+            XCTAssertTrue($0.fileExists(atPath: "dir", isDirectory: &isDir))
+            XCTAssertTrue(isDirBool())
+            XCTAssertTrue($0.fileExists(atPath: "other", isDirectory: &isDir))
+            XCTAssertFalse(isDirBool())
+            XCTAssertFalse($0.fileExists(atPath: "does_not_exist"))
+        }
+    }
+    
+    func testFileAccessAtPath() throws {
+        guard getuid() != 0 else {
+            // Root users can always access anything, so this test will not function when run as root
+            throw XCTSkip("This test is not available when running as the root user")
+        }
+        
+        try FileManagerPlayground {
+            File("000", attributes: [.posixPermissions: 0o000])
+            File("111", attributes: [.posixPermissions: 0o111])
+            File("222", attributes: [.posixPermissions: 0o222])
+            File("333", attributes: [.posixPermissions: 0o333])
+            File("444", attributes: [.posixPermissions: 0o444])
+            File("555", attributes: [.posixPermissions: 0o555])
+            File("666", attributes: [.posixPermissions: 0o666])
+            File("777", attributes: [.posixPermissions: 0o777])
+        }.test {
+            let readable = ["444", "555", "666", "777"]
+            let writable = ["222", "333", "666", "777"]
+            let executable = ["111", "333", "555", "777"]
+            for number in 0...7 {
+                let file = "\(number)\(number)\(number)"
+                XCTAssertEqual($0.isReadableFile(atPath: file), readable.contains(file), "'\(file)' failed readable check")
+                XCTAssertEqual($0.isWritableFile(atPath: file), writable.contains(file), "'\(file)' failed writable check")
+                XCTAssertEqual($0.isExecutableFile(atPath: file), executable.contains(file), "'\(file)' failed executable check")
+                XCTAssertTrue($0.isDeletableFile(atPath: file), "'\(file)' failed deletable check")
+            }
+        }
+    }
+    
+    func testFileSystemAttributesAtPath() throws {
+        try FileManagerPlayground {
+            "Foo"
+        }.test {
+            let dict = try $0.attributesOfFileSystem(forPath: "Foo")
+            XCTAssertNotNil(dict[.systemSize])
+            XCTAssertThrowsError(try $0.attributesOfFileSystem(forPath: "does_not_exist")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+            }
+        }
+    }
+    
+    func testCurrentWorkingDirectory() throws {
+        try FileManagerPlayground {
+            Directory("dir") {
+                "foo"
+            }
+            "bar"
+        }.test {
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
+            XCTAssertTrue($0.changeCurrentDirectoryPath("dir"))
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: "."), ["foo"])
+            XCTAssertFalse($0.changeCurrentDirectoryPath("foo"))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+            XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["bar", "dir", "dir/foo"])
+            XCTAssertFalse($0.changeCurrentDirectoryPath("does_not_exist"))
+        }
+    }
+    
+    func testImplicitlyConvertibleFileAttributes() throws {
+        try FileManagerPlayground {
+            File("foo", attributes: [.posixPermissions : UInt16(0o644)])
+        }.test {
+            let attributes = try $0.attributesOfItem(atPath: "foo")
+            // Ensure the unconventional UInt16 was accepted as input
+            XCTAssertEqual(attributes[.posixPermissions] as? UInt, 0o644)
+            #if FOUNDATION_FRAMEWORK
+            // Where we have NSNumber, ensure that we can get the value back as an unconventional Double value
+            XCTAssertEqual(attributes[.posixPermissions] as? Double, Double(0o644))
+            #endif
+        }
+    }
+}

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -274,7 +274,7 @@ final class FileManagerTests : XCTestCase {
             "preexisting_file"
         }.test {
             try $0.createDirectory(atPath: "create_dir_test", withIntermediateDirectories: false)
-            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "."), ["create_dir_test", "preexisting_file"])
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: ".").sorted(), ["create_dir_test", "preexisting_file"])
             try $0.createDirectory(atPath: "create_dir_test2/nested", withIntermediateDirectories: true)
             XCTAssertEqual(try $0.contentsOfDirectory(atPath: "create_dir_test2"), ["nested"])
             try $0.createDirectory(atPath: "create_dir_test2/nested2", withIntermediateDirectories: true)
@@ -408,7 +408,7 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
             
             try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")
-            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError.first, .init("does_not_exist", "dir3", code: .fileNoSuchFile))
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError.last, .init("does_not_exist", "dir3", code: .fileNoSuchFile))
             
             #if canImport(Darwin)
             // Not supported on linux because it ends up trying to set attributes that are currently unimplemented


### PR DESCRIPTION
This PR adds a swift-native implementation of `FileManager` that also serves as the new underlying implementation of `NSFileManager`/`FileManager` in Foundation itself on Darwin. With a swift-first approach, there are definitely some areas around this API that we could improve to make more natural in swift (such as the delegate pattern, `async`/`await` support, etc.) but we'd like to land the API as-is currently to provide compatibility with the existing `FileManager` APIs, and leave API improvements as a future direction.

There are some areas of `FileManager` that aren't fully implemented here - notably those APIs that require `URL` implementations. For now the `FileManager` operates on `String`-based path APIs and I'll circle back to add the `URL` functionality later once we can port more of that to Swift.