### PR TITLE
Add missing FOUNDATION_FRAMEWORK import for file protection classes

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -12,6 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import Foundation_Private.NSFileManager
+@_implementationOnly import DarwinPrivate.sys.content_protection
 #endif
 
 #if canImport(Darwin)


### PR DESCRIPTION
This adds a missing module import to use the file protection declarations in some `FOUNDATION_FRAMEWORK` sections