### PR TITLE
Efficient buffer size calculation for String file system representation

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -90,8 +90,11 @@ extension String {
     }
     
     private var maxFileSystemRepresentationSize: Int {
-        // TODO: Likely an over estimate and slow for non-UTF16 strings, we should investigate to see if it can be smaller and computed more quickly, especially if we know the string is ASCII
-        self.utf16.count * 9 + 1
+        // The Darwin file system representation expands the UTF-8 contents to decomposed UTF-8 contents (only decomposing specific scalars)
+        // For any given scalar that we decompose, we will increase its UTF-8 length by at most a factor of 3 during decomposition
+        // (ex. U+0390 expands from 2 to 6 UTF-8 scalars, U+1D160 expands from 4 to 12 UTF-8 scalars)
+        // Therefore in the worst case scenario, the result will be the UTF-8 length multiplied by a factor of 3 plus an additional byte for the null byte
+        self.utf8.count * 3 + 1
     }
     #endif
     

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -92,7 +92,7 @@ extension String {
     private var maxFileSystemRepresentationSize: Int {
         // The Darwin file system representation expands the UTF-8 contents to decomposed UTF-8 contents (only decomposing specific scalars)
         // For any given scalar that we decompose, we will increase its UTF-8 length by at most a factor of 3 during decomposition
-        // (ex. U+0390 expands from 2 to 6 UTF-8 scalars, U+1D160 expands from 4 to 12 UTF-8 scalars)
+        // (ex. U+0390 expands from 2 to 6 UTF-8 code-units, U+1D160 expands from 4 to 12 UTF-8 code-units)
         // Therefore in the worst case scenario, the result will be the UTF-8 length multiplied by a factor of 3 plus an additional byte for the null byte
         self.utf8.count * 3 + 1
     }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -370,6 +370,13 @@ final class StringTests : XCTestCase {
         Array(repeating: "A", count: Int(PATH_MAX)).joined().withFileSystemRepresentation { ptr in
             XCTAssertNotNil(ptr)
         }
+        
+        // The buffer should fit the scalars that expand the most during decomposition
+        for string in ["\u{1D160}", "\u{0CCB}", "\u{0390}"] {
+            string.withFileSystemRepresentation { ptr in
+                XCTAssertNotNil(ptr, "Could not create file system representation for \(string.debugDescription)")
+            }
+        }
 #endif
     }
 


### PR DESCRIPTION
The file system representation for a `String` previously used `utf16.count * 9 + 1` because (given the specific character decomposition rules for file system representations) the largest ratio of UTF-16 scalar to decomposed UTF-8 scalar was 1:9. However, `utf16.count` is not efficient for native Swift strings which are backed by UTF-8 buffers, so this switches the calculation to use the UTF-8 view instead with `utf8.count * 3 + 1`. This is a similarly-calculated ratio: the maximum ratio of UTF-8 scalars to produced decomposed UTF-8 scalars is 1:3 (see examples inline in the comments) and I added some of these examples as a test case for validation as well to ensure that in the worst possible scenario we don't overflow the buffer.