### PR TITLE
Incorrect result for secondsFromGMT for remote dates

### DIFF
--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -130,6 +130,13 @@ final class TimeZoneTests : XCTestCase {
         testAbbreviation("GMT+0800", 28800, "GMT+0800")
         testAbbreviation("UTC", 0, "GMT")
     }
+
+    func testSeondsFromGMT_RemoteDates() {
+        let date = Date(timeIntervalSinceReferenceDate: -5001243627) // "1842-07-09T05:39:33+0000"
+        let europeRome = TimeZone(identifier: "Europe/Rome")!
+        let secondsFromGMT = europeRome.secondsFromGMT(for: date)
+        XCTAssertEqual(secondsFromGMT, 2996) //  Before 1893 the time zone is UTC+00:49:56
+    }
 }
 
 final class TimeZoneGMTTests : XCTestCase {


### PR DESCRIPTION
We're capping the time zone offset calculation to some arbitrary dates, so the results outside of the date range are incorrect.

The range was added originally as a workaround for poor ICU performance in `ucal_get` for rdar://6238412, but since then ICU has added new API, which we also adopted, so it shouldn't been needed now.