### PR TITLE
Add lock when retrieving ProcessInfo.environment

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -44,6 +44,10 @@ final class _ProcessInfo: Sendable {
     }
 
     var environment: [String : String] {
+        _platform_shims_lock_environ()
+        defer {
+            _platform_shims_unlock_environ()
+        }
         var results: [String : String] = [:]
         guard var environments: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> =
                 _platform_shims_get_environ() else {

--- a/Sources/_CShims/include/platform_shims.h
+++ b/Sources/_CShims/include/platform_shims.h
@@ -24,7 +24,10 @@
 #include <libkern/OSThermalNotification.h>
 #endif
 
-INTERNAL char ** _platform_shims_get_environ();
+INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ();
+
+INTERNAL void _platform_shims_lock_environ();
+INTERNAL void _platform_shims_unlock_environ();
 
 #if __has_include(<libkern/OSThermalNotification.h>)
 typedef enum {
@@ -45,7 +48,7 @@ typedef enum {
 } _platform_shims_OSThermalPressureLevel;
 
 
-INTERNAL const char *_platform_shims_kOSThermalNotificationPressureLevelName();
+INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName();
 #endif
 
 #endif /* CSHIMS_PLATFORM_SHIMS */

--- a/Sources/_CShims/platform_shims.c
+++ b/Sources/_CShims/platform_shims.c
@@ -19,6 +19,20 @@
 extern char **environ;
 #endif
 
+#if __has_include(<libc_private.h>)
+#import <libc_private.h>
+void _platform_shims_lock_environ() {
+    environ_lock_np();
+}
+
+void _platform_shims_unlock_environ() {
+    environ_unlock_np();
+}
+#else
+void _platform_shims_lock_environ() { /* noop */ }
+void _platform_shims_unlock_environ() { /* noop */ }
+#endif
+
 char **
 _platform_shims_get_environ()
 {


### PR DESCRIPTION
Lock the environment when resolving.

While I was here: also added nullability annotations.