### PR TITLE
Exclude some paths from automount standardization

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -292,10 +292,14 @@ extension String {
         result = components.enumerated().filter { $0 == 0 || !$1.isEmpty }.map(\.1).joined(separator: "/")
         
         // Automounted paths need to be stripped for various flavors of paths
+        let exclusionList = ["/Applications", "/Library", "/System", "/Users", "/Volumes", "/bin", "/cores", "/dev", "/opt", "/private", "/sbin", "/usr"]
         for path in ["/private/var/automount", "/var/automount", "/private"] {
             if result.starts(with: "\(path)/") {
                 let newPath = String(result.dropFirst(path.count))
-                if FileManager.default.fileExists(atPath: newPath) {
+                let isExcluded = exclusionList.contains {
+                    newPath == $0 || newPath.starts(with: "\($0)/")
+                }
+                if !isExcluded && FileManager.default.fileExists(atPath: newPath) {
                     result = newPath
                 }
                 break

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -551,4 +551,19 @@ final class FileManagerTests : XCTestCase {
             #endif
         }
     }
+    
+    func testStandardizingPathAutomount() {
+        #if canImport(Darwin)
+        let tests = [
+            "/private/System" : "/private/System",
+            "/private/tmp" : "/tmp",
+            "/private/System/foo" : "/private/System/foo"
+        ]
+        for (input, expected) in tests {
+            XCTAssertEqual(input.standardizingPath, expected, "Standardizing the path '\(input)' did not produce the expected result")
+        }
+        #else
+        throw XCTSkip("This test is not applicable to this platform")
+        #endif
+    }
 }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -552,7 +552,7 @@ final class FileManagerTests : XCTestCase {
         }
     }
     
-    func testStandardizingPathAutomount() {
+    func testStandardizingPathAutomount() throws {
         #if canImport(Darwin)
         let tests = [
             "/private/System" : "/private/System",


### PR DESCRIPTION
Standardizing a path has historically unconditionally changed some paths in certain directories to support auto mount paths. However, there are certain directories on Darwin that exist when the system is installed that we know will never be an auto mount path, so we now instead exclude them from this behavior to avoid standardizing a path to something that has different semantic meaning.