### PR TITLE
FileManager's setAttributes:forItemAtPath: is unnecessarily slow

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -97,7 +97,7 @@ extension _FileManagerImpl {
         #endif
     }
     
-    private static let _catInfoKeys = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
+    private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
     static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
         let hasRelevantKeys = attributes.keys.contains(where: { _catInfoKeys.contains($0) })
         guard hasRelevantKeys else { return }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -97,9 +97,9 @@ extension _FileManagerImpl {
         #endif
     }
     
+    private static let _catInfoKeys = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
     static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
-        let usedKeys: Set<FileAttributeKey> = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
-        let hasRelevantKeys = attributes.keys.contains(where: { usedKeys.contains($0) })
+        let hasRelevantKeys = attributes.keys.contains(where: { _catInfoKeys.contains($0) })
         guard hasRelevantKeys else { return }
         
         #if !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -98,12 +98,13 @@ extension _FileManagerImpl {
     }
     
     static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
+        let usedKeys: Set<FileAttributeKey> = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
+        let hasRelevantKeys = attributes.keys.contains(where: { usedKeys.contains($0) })
+        guard hasRelevantKeys else { return }
+        
         #if !FOUNDATION_FRAMEWORK
-        let usedKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
-        guard !attributes.keys.contains(where: { usedKeys.contains($0) }) else {
-            // TODO: Implement CAT info attributes for swift-foundation
-            throw CocoaError.errorWithFilePath(.featureUnsupported, path)
-        }
+        // TODO: Implement CAT info attributes for swift-foundation
+        throw CocoaError.errorWithFilePath(.featureUnsupported, path)
         #else
         // -setAttributes:ofItemAtPath:error: follows symlinks (<rdar://5815920>), but the NSURL resource value API doesn't, so we have to manually resolve the symlink.
         // We lie to fileURLWithPath:isDirectory: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -376,7 +376,7 @@ extension String {
             // If not using the cache (which may not require hitting the disk at all if it's warm), try getting the full path from getattrlist.
             // If it succeeds, this approach always returns an absolute path starting from the root. Since this function returns relative paths when given a relative path to a relative symlink, dont use this approach unless the path is absolute.
             
-            if !self._isAbsolutePath, let resolved = Self._resolvingSymlinksInPathUsingFullPathAttribute(fsPtr) {
+            if self._isAbsolutePath, let resolved = Self._resolvingSymlinksInPathUsingFullPathAttribute(fsPtr) {
                 return resolved
             }
             


### PR DESCRIPTION
This PR fixes two small issues:

1. Resolving symlinks in a path should use `getattrlist` for absolute paths, not relative paths (this resulted in slower-than-expected performance for absolute paths)
2. Setting cat info attributes for a file should be a no-op when no relevant attributes are specified