### PR TITLE
Enable implicit casting of file attribute values without NSNumber

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -75,19 +75,19 @@ extension _FileManagerImpl {
             let finderInfo = finderInfoData.withUnsafeBytes({ $0.load(as: _HFSFinderInfo.self) })
             // Record the creator and file type of a file.
             if statInfo.isRegular {
-                attributes[.hfsCreatorCode] = _writeFileAttributePrimitive(finderInfo.fileInfo.fdCreator, as: UInt.self)
-                attributes[.hfsTypeCode] = _writeFileAttributePrimitive(finderInfo.fileInfo.fdType, as: UInt.self)
+                attributes[.hfsCreatorCode] = AnyHashable(finderInfo.fileInfo.fdCreator)
+                attributes[.hfsTypeCode] = AnyHashable(finderInfo.fileInfo.fdType)
             } else if statInfo.isSymbolicLink {
-                attributes[.hfsCreatorCode] = _writeFileAttributePrimitive(kSymLinkCreator, as: UInt.self)
-                attributes[.hfsTypeCode] = _writeFileAttributePrimitive(kSymLinkFileType, as: UInt.self)
+                attributes[.hfsCreatorCode] = AnyHashable(kSymLinkCreator)
+                attributes[.hfsTypeCode] = AnyHashable(kSymLinkFileType)
             }
-            attributes[.busy] = _writeFileAttributePrimitive((finderInfo.extendedFileInfo.extended_flags & 0x80 /*kExtendedFlagObjectIsBusy*/) != 0)
+            attributes[.busy] = AnyHashable((finderInfo.extendedFileInfo.extended_flags & 0x80 /*kExtendedFlagObjectIsBusy*/) != 0)
         }
         #endif
         
         // Record whether or not the file or directory's name extension is hidden.
         if let value = values.hasHiddenExtension {
-            attributes[.extensionHidden] = _writeFileAttributePrimitive(value)
+            attributes[.extensionHidden] = AnyHashable(value)
         }
 
         // Record the creation date of the object.

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -545,10 +545,8 @@ final class FileManagerTests : XCTestCase {
             let attributes = try $0.attributesOfItem(atPath: "foo")
             // Ensure the unconventional UInt16 was accepted as input
             XCTAssertEqual(attributes[.posixPermissions] as? UInt, 0o644)
-            #if FOUNDATION_FRAMEWORK
-            // Where we have NSNumber, ensure that we can get the value back as an unconventional Double value
+            // Ensure that we can read attribute values as any type, even an unconventional type like Double
             XCTAssertEqual(attributes[.posixPermissions] as? Double, Double(0o644))
-            #endif
         }
     }
     


### PR DESCRIPTION
In Foundation.framework, file attributes are stored as an `NSNumber` to ensure that swift callers dynamically casting to any applicable numeric type can receive a valid value. However, we previously did not do this in swift-foundation due to the lack of `NSNumber`. `AnyHashable` has the same implicit casting behavior between numeric types, for example:

```
print(AnyHashable(1) as? Bool) // "true"
print(AnyHashable(Int(3)) as? UInt // "3"
```

In order to enable the same behavior in all uses of FileManager, this PR changes the implementation to box file attribute values in an `AnyHashable` to allow for dynamic, implicit conversions between numeric types when requested