### PR TITLE
Use `_CalendarGregorian` as the backing calendar for `struct Calendar`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -24,13 +24,18 @@ import Glibc
 import CRT
 #endif
 
+#if FOUNDATION_FRAMEWORK
+// For feature flag
+@_implementationOnly import _ForSwiftFoundation
+#endif
+
 /**
  `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
 */
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct Calendar : Hashable, Equatable, Sendable {
     private var _calendar: any _CalendarProtocol & AnyObject
-    
+
     /// Calendar supports many different kinds of calendars. Each is identified by an identifier here.
     public enum Identifier : Sendable, CustomDebugStringConvertible {
         /// The common calendar in Europe, the Western Hemisphere, and elsewhere.
@@ -483,7 +488,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - returns: A new `DateInterval` if the starting time and duration of a component could be calculated, otherwise `nil`.
     @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func dateInterval(of component: Component, for date: Date) -> DateInterval? {
-        _calendar.dateInterval(of: component, for: date)
+        _calendar.dateInterval(of: component, for: date.capped)
     }
 
     /// Returns, for a given absolute time, the ordinal number of a smaller calendar component (such as a day) within a specified larger calendar component (such as a week).
@@ -582,7 +587,6 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// - returns: The date components of the specified date.
     public func dateComponents(_ components: Set<Component>, from date: Date) -> DateComponents {
         var dc = _calendar.dateComponents(Calendar.ComponentSet(components), from: date)
-
         // Fill out the Calendar field of dateComponents, if requested.
         if components.contains(.calendar) {
             dc.calendar = self
@@ -594,7 +598,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// Same as `dateComponents:from:` but uses the more efficient bitset form of ComponentSet.
     /// Prefixed with `_` to avoid ambiguity at call site with the `Set<Component>` method.
     internal func _dateComponents(_ components: ComponentSet, from date: Date) -> DateComponents {
-        var dc = _calendar.dateComponents(components, from: date)
+        var dc = _calendar.dateComponents(components, from: date.capped)
 
         // Fill out the Calendar field of dateComponents, if requested.
         if components.contains(.calendar) {

--- a/Sources/TestSupport/Utilities.swift
+++ b/Sources/TestSupport/Utilities.swift
@@ -113,6 +113,7 @@ public func expectEqual(_ first: DateComponents, _ second: DateComponents, withi
     XCTAssertEqual(first.year, second.year, message(), file: file, line: line)
     XCTAssertEqual(first.month, second.month, message(), file: file, line: line)
     XCTAssertEqual(first.day, second.day, message(), file: file, line: line)
+    XCTAssertEqual(first.dayOfYear, second.dayOfYear, message(), file: file, line: line)
     XCTAssertEqual(first.hour, second.hour, message(), file: file, line: line)
     XCTAssertEqual(first.minute, second.minute, message(), file: file, line: line)
     XCTAssertEqual(first.second, second.second, message(), file: file, line: line)
@@ -126,7 +127,7 @@ public func expectEqual(_ first: DateComponents, _ second: DateComponents, withi
     }
 
     if let ns = first.nanosecond, let otherNS = second.nanosecond {
-        XCTAssertLessThan(abs(ns - otherNS), nanosecondAccuracy, message(), file: file, line: line)
+        XCTAssertLessThanOrEqual(abs(ns - otherNS), nanosecondAccuracy, message(), file: file, line: line)
     } else {
         XCTAssertEqual(first.nanosecond, second.nanosecond, message(), file: file, line: line)
     }

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -3534,7 +3534,10 @@ final class GregorianCalendarTests : XCTestCase {
         calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -8*3600), locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
         start = Date(timeIntervalSinceReferenceDate: 0)         // 2000-12-31 16:00:00 PT
         end = Date(timeIntervalSinceReferenceDate: 5458822.0) // 2001-03-04 20:20:22 PT
-        test([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .dayOfYear, .calendar, .timeZone], expected: .init(era: 0, year: 0, month: 2, day: 4, hour: 4, minute: 20, second: 22, nanosecond: 0, weekday: 0, weekdayOrdinal: 0, quarter: 0 , weekOfMonth: 0, weekOfYear: 0,  yearForWeekOfYear: 0))
+        var expected = DateComponents(era: 0, year: 0, month: 2, day: 4, hour: 4, minute: 20, second: 22, nanosecond: 0, weekday: 0, weekdayOrdinal: 0, quarter: 0 , weekOfMonth: 0, weekOfYear: 0,  yearForWeekOfYear: 0)
+        // FIXME 123202377: This is wrong, but it's the same as Calendar_ICU's current behavior
+        expected.dayOfYear = 0
+        test([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .dayOfYear, .calendar, .timeZone], expected: expected)
     }
 
     func testDifference() {
@@ -3702,82 +3705,83 @@ final class GregorianCalendarTests : XCTestCase {
         test(.hour, expected: 1441)
         test(.minute, expected: 86460)
         test(.second, expected: 5187600)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.max))
 
         start = Date(timeIntervalSince1970: 852105540.0) // 1996-12-31 23:59:00
         end = Date(timeIntervalSince1970: 857203205.0) // 1997-03-01 00:00:05
         test(.hour, expected: 1416)
         test(.minute, expected: 84961)
         test(.second, expected: 5097665)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.max))
 
         start = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
         end = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
         test(.hour, expected: 0)
         test(.minute, expected: 1)
         test(.second, expected: 85)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.max))
 
         start = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
         end = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
         test(.hour, expected: 24)
         test(.minute, expected: 1441)
         test(.second, expected: 86485)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.max))
 
         start = Date(timeIntervalSince1970: 794044710.0) // 1995-02-28 23:58:30
         end = Date(timeIntervalSince1970: 794044805.0) // 1995-03-01 00:00:05
         test(.hour, expected: 0)
         test(.minute, expected: 1)
         test(.second, expected: 95)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.max))
 
         start = Date(timeIntervalSince1970: 857203205.0) // 1997-03-01 00:00:05
         end = Date(timeIntervalSince1970: 852105520.0) // 1996-12-31 23:58:40
         test(.hour, expected: -1416)
         test(.minute, expected: -84961)
         test(.second, expected: -5097685)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         start = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
         end = Date(timeIntervalSince1970: 820483120.0) // 1995-12-31 23:58:40
         test(.hour, expected: -1440)
         test(.minute, expected: -86401)
         test(.second, expected: -5184085)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         start = Date(timeIntervalSince1970: 825667205.0) // 1996-03-01 00:00:05
         end = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
         test(.hour, expected: -24)
         test(.minute, expected: -1441)
         test(.second, expected: -86485)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         start = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
         end = Date(timeIntervalSince1970: 825580720.0) // 1996-02-28 23:58:40
         test(.hour, expected: 0)
         test(.minute, expected: -1)
         test(.second, expected: -85)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         start = Date(timeIntervalSince1970: 825580805.0) // 1996-02-29 00:00:05
         end = Date(timeIntervalSince1970: 820569520.0) // 1996-01-01 23:58:40
         test(.hour, expected: -1392)
         test(.minute, expected: -83521)
         test(.second, expected: -5011285)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         start = Date(timeIntervalSince1970: 794044805.0) // 1995-03-01 00:00:05
         end = Date(timeIntervalSince1970: 794044710.0) // 1995-02-28 23:58:30
         test(.hour, expected: 0)
         test(.minute, expected: -1)
         test(.second, expected: -95)
-        test(.nanosecond, expected: 0)
+        test(.nanosecond, expected: Int(Int32.min))
 
         calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -8*3600), locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
         start = Date(timeIntervalSinceReferenceDate: 0)         // 2000-12-31 16:00:00 PT
         end = Date(timeIntervalSinceReferenceDate: 5458822.0) // 2001-03-04 20:20:22 PT
         test(.month, expected: 2)
+        test(.dayOfYear, expected: 63)
     }
 
     func testDifference_DST() {


### PR DESCRIPTION
- Fix precision issues around nanoseconds calculation.

Update test expectations.

- Lessen the chance of overflowing `func add(:)` by using `Double`

We eventually convert to Double before return anyways.

- Disable TestDateComponentsDiscreteConformance.testRandomSamples temporarily for 32-bit platforms

This test triggers code path that has wrong assumption on Calendar API's return value, and overflows when the input dates are distant from each other. Disable it for now. Will track the fix in 123262305

Resolves 123318367
