### PR TITLE
[Predicate] Use a global atomic counter for VariableID

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if FOUNDATION_FRAMEWORK
+import Synchronization
+#endif
+
 @available(FoundationPredicate 0.1, *)
 public protocol PredicateExpression<Output> {
     associatedtype Output
@@ -81,15 +85,23 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
 extension PredicateExpressions {
     public struct VariableID: Hashable, Codable, Sendable {
         let id: UInt
+        #if FOUNDATION_FRAMEWORK
+        private static let nextID = Atomic<UInt>(0)
+        #else
         private static let nextID = LockedState(initialState: UInt(0))
+        #endif
         
         init() {
+            #if FOUNDATION_FRAMEWORK
+            self.id = Self.nextID.wrappingAdd(1, ordering: .relaxed).oldValue
+            #else
             self.id = Self.nextID.withLock { value in
                 defer {
                     (value, _) = value.addingReportingOverflow(1)
                 }
                 return value
             }
+            #endif
         }
         
         public func encode(to encoder: Encoder) throws {

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
+@_implementationOnly
 import Synchronization
 #endif
 


### PR DESCRIPTION
Instead of a global lock, we can use a global atomic counter instead for incrementing PredicateExpression.VariableID. Let's use it!