### PR TITLE
Add framework-style builds to Benchmarks

### DIFF
--- a/Benchmarks/Benchmarks/Calendar/Calendar.swift
+++ b/Benchmarks/Benchmarks/Calendar/Calendar.swift
@@ -12,16 +12,19 @@
 
 import Benchmark
 import func Benchmark.blackHole
+
+#if FOUNDATION_FRAMEWORK
+import Foundation
+#else
 import FoundationEssentials
 import FoundationInternationalization
+#endif
 
 let benchmarks = {
     Benchmark.defaultConfiguration.maxIterations = 1_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo
-    //    Benchmark.defaultConfiguration.metrics = .arc + [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // use ARC to see traffic
-    //  Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // skip ARC as it has some overhead
-    Benchmark.defaultConfiguration.metrics = .all // Use all metrics to easily see which ones are of interest for this benchmark suite
+    Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .mallocCountTotal, .throughput]
     
     let thanksgivingComponents = DateComponents(month: 11, weekday: 5, weekOfMonth: 4)
     let cal = Calendar(identifier: .gregorian)

--- a/Benchmarks/Benchmarks/Essentials/Essentials.swift
+++ b/Benchmarks/Benchmarks/Essentials/Essentials.swift
@@ -12,13 +12,18 @@
 
 import Benchmark
 import func Benchmark.blackHole
+
+#if FOUNDATION_FRAMEWORK
+import Foundation
+#else
 import FoundationEssentials
+#endif
 
 let benchmarks = {
     Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
     Benchmark.defaultConfiguration.maxDuration = .seconds(3)
     Benchmark.defaultConfiguration.scalingFactor = .kilo
-    Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .throughput] // use ARC to see traffic
+    Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .throughput]
     
     // MARK: UUID
     

--- a/Benchmarks/Benchmarks/Formatting/Formatting.swift
+++ b/Benchmarks/Benchmarks/Formatting/Formatting.swift
@@ -12,8 +12,12 @@
 
 import Benchmark
 import func Benchmark.blackHole
+
+#if FOUNDATION_FRAMEWORK
+import Foundation
+#else
 import FoundationEssentials
-import FoundationInternationalization
+#endif
 
 let benchmarks = {
     Benchmark.defaultConfiguration.maxIterations = 1_000

--- a/Benchmarks/Benchmarks/Predicates/Predicates.swift
+++ b/Benchmarks/Benchmarks/Predicates/Predicates.swift
@@ -12,18 +12,62 @@
 
 import Benchmark
 import func Benchmark.blackHole
+
+#if FOUNDATION_FRAMEWORK
+import Foundation
+#else
 import FoundationEssentials
+#endif
 
-let benchmarks = {
-    Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
-    Benchmark.defaultConfiguration.maxDuration = .seconds(3)
-    Benchmark.defaultConfiguration.scalingFactor = .kilo
-    Benchmark.defaultConfiguration.metrics = .arc + [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // use ARC to see traffic
-//  Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .mallocCountTotal, .throughput] // skip ARC as it has some overhead
-//  Benchmark.defaultConfiguration.metrics = .all // Use all metrics to easily see which ones are of interest for this benchmark suite
+let monster = Monster(name: "Orc", level: 80, hp: 100, mana: 0, weapon: .sword(Sword(p1: 1, p2: 2, p3: 3, p4: 4, p5: 5)))
+let monster2 = Monster(name: "Orc", level: 80, hp: 100, mana: 0, weapon: .sword(Sword(p1: 1, p2: 2, p3: 3, p4: 4, p5: 5)))
+
+// These tests are disabled, as enabling them will make compilation fail due to https://github.com/apple/swift/issues/69277
+#if false
+func registerPredicateTests_disabled() {
+    predicateTests.append(("predicateThreeKeypathNestedComputedPropertyCondition", #Predicate<Monster> { monster in
+        ((monster.weaponP1 == 1) &&
+         (monster.weaponP2 == 2) &&
+         (monster.weaponP3 == 3))
+    }))
+    
+    predicateTests.append(("predicateFiveKeypathNestedComputedPropertyCondition", #Predicate<Monster> { monster in
+        ((monster.weaponP1 == 1) &&
+         (monster.weaponP2 == 2) &&
+         (monster.weaponP3 == 3) &&
+         (monster.weaponP4 == 4) &&
+         (monster.weaponP5 == 5))
+    }))
+    
+    var variadicPredicateTests : [(String, Predicate<Monster, Monster>)] = []
+
+    variadicPredicateTests.append(("predicateVariadicThreeKeypathNestedComputedPropertyCondition",
+                                   #Predicate<Monster, Monster> { monster, monster2 in
+        ((monster.weaponP1 == 1) &&
+         (monster.weaponP2 == 2) &&
+         (monster2.weaponP2 == 2))
+    }))
+
+    variadicPredicateTests.forEach { (testDescription, predicate) in
+        Benchmark(testDescription) { benchmark in
+            var matched = 0
+
+            for _ in benchmark.scaledIterations {
+                if try predicate.evaluate(monster, monster2) {
+                    matched += 1
+                }
+            }
+
+            guard matched == benchmark.scaledIterations.count else {
+                fatalError("Internal error: wrong number of matched monsters")
+            }
+        }
+    }
+}
+#endif
+
+func registerPredicateTests() {
     if #available(macOS 14, *) {
-
-        let monster = Monster(name: "Orc", level: 80, hp: 100, mana: 0, weapon: .sword(Sword(p1: 1, p2: 2, p3: 3, p4: 4, p5: 5)))
 
         var predicateTests : [(String, Predicate<Monster>)] = []
 
@@ -43,21 +87,6 @@ let benchmarks = {
             (monster.weaponP1 == 1)
         }))
 
-        predicateTests.append(("predicateThreeKeypathNestedComputedPropertyCondition", #Predicate<Monster> { monster in
-            ((monster.weaponP1 == 1) &&
-             (monster.weaponP2 == 2) &&
-             (monster.weaponP3 == 3))
-        }))
-
-    // This test disabled, as enabling it will make compilation fail due to https://github.com/apple/swift/issues/69277
-    //      predicateTests.append(("predicateFiveKeypathNestedComputedPropertyCondition", #Predicate<Monster> { monster in
-    //          ((monster.weaponP1 == 1) &&
-    //           (monster.weaponP2 == 2) &&
-    //           (monster.weaponP3 == 3) &&
-    //           (monster.weaponP4 == 4) &&
-    //           (monster.weaponP5 == 5))
-    //      }))
-
         predicateTests.forEach { (testDescription, predicate) in
             Benchmark(testDescription) { benchmark in
                 var matched = 0
@@ -73,31 +102,14 @@ let benchmarks = {
                 }
             }
         }
-
-        var variadicPredicateTests : [(String, Predicate<Monster, Monster>)] = []
-        let monster2 = Monster(name: "Orc", level: 80, hp: 100, mana: 0, weapon: .sword(Sword(p1: 1, p2: 2, p3: 3, p4: 4, p5: 5)))
-
-        variadicPredicateTests.append(("predicateVariadicThreeKeypathNestedComputedPropertyCondition",
-                                       #Predicate<Monster, Monster> { monster, monster2 in
-            ((monster.weaponP1 == 1) &&
-             (monster.weaponP2 == 2) &&
-             (monster2.weaponP2 == 2))
-        }))
-
-        variadicPredicateTests.forEach { (testDescription, predicate) in
-            Benchmark(testDescription) { benchmark in
-                var matched = 0
-
-                for _ in benchmark.scaledIterations {
-                    if try predicate.evaluate(monster, monster2) {
-                        matched += 1
-                    }
-                }
-
-                guard matched == benchmark.scaledIterations.count else {
-                    fatalError("Internal error: wrong number of matched monsters")
-                }
-            }
-        }
     }
+}
+
+let benchmarks : () -> Void = {
+    Benchmark.defaultConfiguration.maxIterations = 1_000_000_000
+    Benchmark.defaultConfiguration.maxDuration = .seconds(3)
+    Benchmark.defaultConfiguration.scalingFactor = .kilo
+    Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .mallocCountTotal, .throughput]
+
+    registerPredicateTests()
 }


### PR DESCRIPTION
Adds use of the `FOUNDATION_FRAMEWORK` define to the benchmarks so we can use them in more build configurations.

I also took the opportunity to clean up some of the settings (don't use ARC counting, for example), and further segment the predicate tests until we get some attention on that compile time issue with predicates with 3 items.