### PR TITLE
Resolving symlinks can remove prefix from path

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -361,11 +361,10 @@ extension String {
             return nil
         }
         
+        let length = Int(buffer.fullPathAttr.attr_length) // Includes null byte
         return withUnsafePointer(to: buffer.fullPathBuf) { pathPtr in
-            let start = UnsafeRawPointer(pathPtr).advanced(by: Int(buffer.fullPathAttr.attr_dataoffset))
-            let length = Int(buffer.fullPathAttr.attr_length) // Includes null byte
-            return start.withMemoryRebound(to: CChar.self, capacity: length) { ccharPtr in
-                return String(cString: ccharPtr)
+            pathPtr.withMemoryRebound(to: CChar.self, capacity: length) { ccharPtr in
+                String(cString: ccharPtr)
             }
         }
         #else
@@ -373,7 +372,7 @@ extension String {
         #endif
     }
     
-    private func _resolvingSymlinksInPath() -> String? {
+    func _resolvingSymlinksInPath() -> String? {
         guard !isEmpty else { return nil }
         return self.withFileSystemRepresentation { fsPtr -> String? in
             guard let fsPtr else { return nil }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -566,4 +566,15 @@ final class FileManagerTests : XCTestCase {
         throw XCTSkip("This test is not applicable to this platform")
         #endif
     }
+    
+    func testResolveSymlinksViaGetAttrList() throws {
+        try FileManagerPlayground {
+            "destination"
+        }.test {
+            try $0.createSymbolicLink(atPath: "link", withDestinationPath: "destination")
+            let absolutePath = $0.currentDirectoryPath.appendingPathComponent("link")
+            let resolved = absolutePath._resolvingSymlinksInPath() // Call internal function to avoid path standardization
+            XCTAssertEqual(resolved, $0.currentDirectoryPath.appendingPathComponent("destination"))
+        }
+    }
 }


### PR DESCRIPTION
When resolving symlinks via the quick-path using `getattrlist`, we accidentally dropped ~8 characters from the start of the path due to incorrectly offsetting by `attr_dataoffset`. Since this offset is the offset from the start of the returned buffer struct and not from the path buffer itself, we don't need to use this offset here and instead can just use the pointer directly without advancing it. Previously, the unit test would drop the leading 8 characters from the path (and we call the internal function from the unit test to avoid standardizing `/private/var` paths to `/var` which coincidentally also looks like dropping the leading 8 characters but is intentional.