### PR TITLE
FileManager.removeItem does not throw error when encoutering long paths

### DIFF
--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -38,7 +38,7 @@ public struct POSIXError : _BridgedStoredNSError {
 #else
 
 /// Describes an error in the POSIX error domain.
-public struct POSIXError : _StoredError, Hashable {
+public struct POSIXError : Error, _StoredError, Hashable {
     public let code: Code
 
     public static var errorDomain: String { return "NSPOSIXErrorDomain" }

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -301,7 +301,10 @@ enum _FileOperations {
             _filemanagershims_removefile_attach_callbacks(state, ctxPtr)
             
             let err = removefile(pathPtr, state, removefile_flags_t(REMOVEFILE_RECURSIVE))
-            if err > 0 {
+            if err < 0 {
+                if errno != 0 {
+                    throw CocoaError.removeFileError(Int32(errno), pathStr)
+                }
                 throw CocoaError.removeFileError(Int32(_filemanagershims_removefile_state_get_errnum(state)), pathStr)
             }
             

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -205,6 +205,7 @@ public typealias ComparisonResult = FoundationEssentials.ComparisonResult
 public typealias FileManager = FoundationEssentials.FileManager
 public typealias FileAttributeKey = FoundationEssentials.FileAttributeKey
 public typealias CocoaError = FoundationEssentials.CocoaError
+public typealias POSIXError = FoundationEssentials.POSIXError
 public typealias FileManagerDelegate = FoundationEssentials.FileManagerDelegate
 
 #endif // FOUNDATION_FRAMEWORK

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -447,6 +447,61 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.delegateCaptures.shouldRemove, [.init("dir/bar"), .init("\(rootDir)/dir"), .init("\(rootDir)/dir/foo"), .init("other"), .init("does_not_exist")])
             XCTAssertEqual($0.delegateCaptures.shouldProceedAfterRemoveError, [.init("does_not_exist", code: .fileNoSuchFile)])
         }
+
+        #if canImport(Darwin)
+        // not supported on linux as the test depends on FileManager.removeItem calling removefile(3)
+        try FileManagerPlayground {
+        }.test(captureDelegateCalls: true) {
+            // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
+            let rootDir = $0.currentDirectoryPath
+            let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
+            let bbs = Array(repeating: "b", count: Int(NAME_MAX) - 3).joined()
+            let ccs = Array(repeating: "c", count: Int(NAME_MAX) - 3).joined()
+            let dds = Array(repeating: "d", count: Int(NAME_MAX) - 3).joined()
+            let ees = Array(repeating: "e", count: Int(NAME_MAX) - 3).joined()
+            let leaf = "longpath"
+
+            try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
+            $0.changeCurrentDirectoryPath(aas)
+            try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
+            $0.changeCurrentDirectoryPath(bbs)
+            try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
+            $0.changeCurrentDirectoryPath(ccs)
+            try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
+            $0.changeCurrentDirectoryPath(dds)
+            try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
+            $0.changeCurrentDirectoryPath(ees)
+            try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
+
+            $0.changeCurrentDirectoryPath(rootDir)
+            let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
+            var failed = false
+            do {
+                try $0.removeItem(atPath: fullPath)
+            } catch {
+                if let error = (error as? CocoaError)?.underlying as? POSIXError,
+                      error == POSIXError(.ENAMETOOLONG) {
+                    failed = true
+                }
+            }
+            XCTAssert(failed, "removeItem didn't fail with ENAMETOOLONG")
+
+            // Clean up
+            $0.changeCurrentDirectoryPath(aas)
+            $0.changeCurrentDirectoryPath(bbs)
+            $0.changeCurrentDirectoryPath(ccs)
+            $0.changeCurrentDirectoryPath(dds)
+            try $0.removeItem(atPath: ees)
+            $0.changeCurrentDirectoryPath("..")
+            try $0.removeItem(atPath: dds)
+            $0.changeCurrentDirectoryPath("..")
+            try $0.removeItem(atPath: ccs)
+            $0.changeCurrentDirectoryPath("..")
+            try $0.removeItem(atPath: bbs)
+            $0.changeCurrentDirectoryPath("..")
+            try $0.removeItem(atPath: aas)
+        }
+        #endif
     }
     
     func testFileExistsAtPath() throws {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -450,50 +450,53 @@ final class FileManagerTests : XCTestCase {
 
         #if canImport(Darwin)
         // not supported on linux as the test depends on FileManager.removeItem calling removefile(3)
-        try FileManagerPlayground {
-        }.test {
-            // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
-            let rootDir = $0.currentDirectoryPath
-            let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
-            let bbs = Array(repeating: "b", count: Int(NAME_MAX) - 3).joined()
-            let ccs = Array(repeating: "c", count: Int(NAME_MAX) - 3).joined()
-            let dds = Array(repeating: "d", count: Int(NAME_MAX) - 3).joined()
-            let ees = Array(repeating: "e", count: Int(NAME_MAX) - 3).joined()
-            let leaf = "longpath"
-
-            try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
-            try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
-            try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
-            try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
-            try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(ees))
-            try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
-
-            XCTAssertTrue($0.changeCurrentDirectoryPath(rootDir))
-            let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
-            XCTAssertThrowsError(try $0.removeItem(atPath: fullPath)) {
-                let underlyingPosixError = ($0 as? CocoaError)?.underlying as? POSIXError
-                XCTAssertEqual(underlyingPosixError?.code, .ENAMETOOLONG, "removeItem didn't fail with ENAMETOOLONG; produced error: \($0)")
+        // not supported on older versions of Darwin where removefile would return ENOENT instead of ENAMETOOLONG
+        if #available(macOS 14.4, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            try FileManagerPlayground {
+            }.test {
+                // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
+                let rootDir = $0.currentDirectoryPath
+                let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
+                let bbs = Array(repeating: "b", count: Int(NAME_MAX) - 3).joined()
+                let ccs = Array(repeating: "c", count: Int(NAME_MAX) - 3).joined()
+                let dds = Array(repeating: "d", count: Int(NAME_MAX) - 3).joined()
+                let ees = Array(repeating: "e", count: Int(NAME_MAX) - 3).joined()
+                let leaf = "longpath"
+                
+                try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
+                try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
+                try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
+                try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
+                try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(ees))
+                try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
+                
+                XCTAssertTrue($0.changeCurrentDirectoryPath(rootDir))
+                let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
+                XCTAssertThrowsError(try $0.removeItem(atPath: fullPath)) {
+                    let underlyingPosixError = ($0 as? CocoaError)?.underlying as? POSIXError
+                    XCTAssertEqual(underlyingPosixError?.code, .ENAMETOOLONG, "removeItem didn't fail with ENAMETOOLONG; produced error: \($0)")
+                }
+                
+                // Clean up
+                XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
+                XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
+                XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
+                XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
+                try $0.removeItem(atPath: ees)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+                try $0.removeItem(atPath: dds)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+                try $0.removeItem(atPath: ccs)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+                try $0.removeItem(atPath: bbs)
+                XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
+                try $0.removeItem(atPath: aas)
             }
-
-            // Clean up
-            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
-            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
-            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
-            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
-            try $0.removeItem(atPath: ees)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-            try $0.removeItem(atPath: dds)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-            try $0.removeItem(atPath: ccs)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-            try $0.removeItem(atPath: bbs)
-            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
-            try $0.removeItem(atPath: aas)
         }
         #endif
     }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -451,7 +451,7 @@ final class FileManagerTests : XCTestCase {
         #if canImport(Darwin)
         // not supported on linux as the test depends on FileManager.removeItem calling removefile(3)
         try FileManagerPlayground {
-        }.test(captureDelegateCalls: true) {
+        }.test {
             // Create hierarchy in which the leaf is a long path (length > PATH_MAX)
             let rootDir = $0.currentDirectoryPath
             let aas = Array(repeating: "a", count: Int(NAME_MAX) - 3).joined()
@@ -462,43 +462,37 @@ final class FileManagerTests : XCTestCase {
             let leaf = "longpath"
 
             try $0.createDirectory(atPath: aas, withIntermediateDirectories: true)
-            $0.changeCurrentDirectoryPath(aas)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
             try $0.createDirectory(atPath: bbs, withIntermediateDirectories: true)
-            $0.changeCurrentDirectoryPath(bbs)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
             try $0.createDirectory(atPath: ccs, withIntermediateDirectories: true)
-            $0.changeCurrentDirectoryPath(ccs)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
             try $0.createDirectory(atPath: dds, withIntermediateDirectories: true)
-            $0.changeCurrentDirectoryPath(dds)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
             try $0.createDirectory(atPath: ees, withIntermediateDirectories: true)
-            $0.changeCurrentDirectoryPath(ees)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ees))
             try $0.createDirectory(atPath: leaf, withIntermediateDirectories: true)
 
-            $0.changeCurrentDirectoryPath(rootDir)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(rootDir))
             let fullPath = "\(aas)/\(bbs)/\(ccs)/\(dds)/\(ees)/\(leaf)"
-            var failed = false
-            do {
-                try $0.removeItem(atPath: fullPath)
-            } catch {
-                if let error = (error as? CocoaError)?.underlying as? POSIXError,
-                      error == POSIXError(.ENAMETOOLONG) {
-                    failed = true
-                }
+            XCTAssertThrowsError(try $0.removeItem(atPath: fullPath)) {
+                let underlyingPosixError = ($0 as? CocoaError)?.underlying as? POSIXError
+                XCTAssertEqual(underlyingPosixError?.code, .ENAMETOOLONG, "removeItem didn't fail with ENAMETOOLONG; produced error: \($0)")
             }
-            XCTAssert(failed, "removeItem didn't fail with ENAMETOOLONG")
 
             // Clean up
-            $0.changeCurrentDirectoryPath(aas)
-            $0.changeCurrentDirectoryPath(bbs)
-            $0.changeCurrentDirectoryPath(ccs)
-            $0.changeCurrentDirectoryPath(dds)
+            XCTAssertTrue($0.changeCurrentDirectoryPath(aas))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(bbs))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(ccs))
+            XCTAssertTrue($0.changeCurrentDirectoryPath(dds))
             try $0.removeItem(atPath: ees)
-            $0.changeCurrentDirectoryPath("..")
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
             try $0.removeItem(atPath: dds)
-            $0.changeCurrentDirectoryPath("..")
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
             try $0.removeItem(atPath: ccs)
-            $0.changeCurrentDirectoryPath("..")
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
             try $0.removeItem(atPath: bbs)
-            $0.changeCurrentDirectoryPath("..")
+            XCTAssertTrue($0.changeCurrentDirectoryPath(".."))
             try $0.removeItem(atPath: aas)
         }
         #endif


### PR DESCRIPTION
This change updates the checking of the `removefile` result value to ensure that errors are properly thrown from `removeItem(atPath:)` calls on Darwin where we use `removefile`