### PR TITLE
[Gregorian Calendar] Guard against julian dates that are too far away to be representable by `Int`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -31,13 +31,22 @@ import CRT
 /// maps to JulianDay  `2451545`                 (Jan 01 2000, 12:00)
 extension Date {
     static let julianDayAtDateReference: Double = 2_451_910.5 // 2001 Jan 1, midnight, UTC
+    static let maxJulianDay = 0x7F000000
+    static let minJulianDay = -0x7F000000
 
     var julianDate: Double {
         timeIntervalSinceReferenceDate / 86400 + Self.julianDayAtDateReference
     }
 
     var julianDay: Int {
-        Int((julianDate + 0.5).rounded(.down))
+        let jd = (julianDate + 0.5).rounded(.down)
+        guard jd <= Double(Self.maxJulianDay) else {
+            return Self.maxJulianDay
+        }
+        guard jd >= Double(Self.minJulianDay) else {
+            return Self.minJulianDay
+        }
+        return Int(jd)
     }
 
     init(julianDay: Int) {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -63,6 +63,12 @@ final class GregorianCalendarTests : XCTestCase {
         XCTAssertEqual(gregorianCalendar.numberOfDaysInMonth(50, year: 2024), 29) //  equivalent to month: 2, year: 2028, leap
     }
 
+    func testRemoteJulianDayCrash() {
+        // Accessing the integer julianDay of a remote date should not crash
+        let d = Date(julianDate: 9223372036854775808) // Int64.max + 1
+        _ = d.julianDay
+    }
+
     // MARK: Date from components
     func testDateFromComponents_DST() {
         // The expected dates were generated using ICU Calendar

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -899,6 +899,11 @@ final class CalendarTests : XCTestCase {
         XCTAssertTrue(shouldBeEmpty.isEmpty)
     }
 
+    func test_dateComponentsFromFarDateCrash() {
+        // Calling dateComponents(:from:) on a remote date should not crash
+        let c = Calendar(identifier: .gregorian)
+        _ = c.dateComponents([.month], from: Date(timeIntervalSinceReferenceDate: 7.968993439840418e+23))
+    }
 }
 
 


### PR DESCRIPTION
We triggered a Swift runtime error when converting a `Double` to an `Int` because the value exceeds the value representable by an `Int`. This patch works-around this issue with the following:
- Return a capped value if the date exceeds the bound before conversion.
- Ensure compatibility among various `_CalendarProtocol` observers by capping the input date upfront.

Resolves 123664232