### PR TITLE
Unexpected behavior when getting a `Date` after setting `day` on a date components

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1188,14 +1188,16 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
             if let value = components.weekdayOrdinal { ucal_set(ucalendar, UCAL_DAY_OF_WEEK_IN_MONTH, Int32(truncatingIfNeeded: value)) }
             // DateComponents month field is +1 from ICU
             if let value = components.month { ucal_set(ucalendar, UCAL_MONTH, Int32(truncatingIfNeeded: value - 1)) }
+
+            // The later the value is set via `ucal_set` the higher priority it takes when ICU resolves ambiguous components. For compatibility, always set `day of year` before `day (of month)`
+            if let value = components.dayOfYear { ucal_set(ucalendar, UCAL_DAY_OF_YEAR, Int32(truncatingIfNeeded: value)) }
             if let value = components.day { ucal_set(ucalendar, UCAL_DAY_OF_MONTH, Int32(truncatingIfNeeded: value)) }
             if let value = components.hour { ucal_set(ucalendar, UCAL_HOUR_OF_DAY, Int32(truncatingIfNeeded: value)) }
             if let value = components.minute { ucal_set(ucalendar, UCAL_MINUTE, Int32(truncatingIfNeeded: value)) }
             if let value = components.second { ucal_set(ucalendar, UCAL_SECOND, Int32(truncatingIfNeeded: value)) }
             if let value = components.nanosecond { nanosecond = Double(value) }
             if let isLeap = components.isLeapMonth, isLeap { ucal_set(ucalendar, UCAL_IS_LEAP_MONTH, 1) }
-            if let value = components.dayOfYear { ucal_set(ucalendar, UCAL_DAY_OF_YEAR, Int32(truncatingIfNeeded: value)) }
-            
+
             var status = U_ZERO_ERROR
             let udate = ucal_getMillis(ucalendar, &status)
             var date = Date(udate: udate) + nanosecond * 1.0e-9

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -924,6 +924,24 @@ final class CalendarTests : XCTestCase {
         let c = Calendar(identifier: .gregorian)
         _ = c.dateComponents([.month], from: Date(timeIntervalSinceReferenceDate: 7.968993439840418e+23))
     }
+
+    func test_dateBySettingDay() {
+        func firstDayOfMonth(_ calendar: Calendar, for date: Date) -> Date? {
+            var startOfCurrentMonthComponents = calendar.dateComponents(in: calendar.timeZone, from: date)
+            startOfCurrentMonthComponents.day = 1
+            return calendar.date(from: startOfCurrentMonthComponents)
+        }
+        var iso8601calendar = Calendar(identifier: .iso8601)
+        iso8601calendar.timeZone = .gmt
+        var gregorianCalendar = Calendar(identifier: .gregorian)
+        gregorianCalendar.timeZone = .gmt
+        let date = Date(timeIntervalSince1970: 1609459199) // 2020-12-31T23:59:59Z
+        XCTAssertEqual(firstDayOfMonth(iso8601calendar, for: date), Date(timeIntervalSinceReferenceDate: 628559999.0)) // 2020-12-01T23:59:59Z
+        XCTAssertEqual(firstDayOfMonth(gregorianCalendar, for: date), Date(timeIntervalSinceReferenceDate: 628559999.0)) // 2020-12-01T23:59:59Z
+        let date2 = Date(timeIntervalSinceReferenceDate: 730860719) // 2024-02-29T00:51:59Z
+        XCTAssertEqual(firstDayOfMonth(iso8601calendar, for: date2), Date(timeIntervalSinceReferenceDate: 728441519)) // 2024-02-01T00:51:59Z
+        XCTAssertEqual(firstDayOfMonth(gregorianCalendar, for: date2), Date(timeIntervalSinceReferenceDate: 728441519.0)) // 2024-02-01T00:51:59Z
+    }
 }
 
 


### PR DESCRIPTION
This is due to ICU's handling of ambiguous/conflicting components. If both "day of year" and "day of month" fields are set via `ucal_set`, the newer one takes priority. Therefore it breaks existing behavior when we set "day of year" after having set "day of month".

Fix this by moving "day of year" before "day of month" to maintain compatibility.

Resolves 123703256