### PR TITLE
Data.write fails with EINVAL when writing 2GiB or more

### DIFF
--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -200,6 +200,22 @@ class DataIOTests : XCTestCase {
         try data.write(to: url)
         let read = try Data(contentsOf: url, options: [])
         XCTAssertEqual(data, read)
+        
+        cleanup(at: url)
+    }
+    
+    func test_largeFile() throws {
+#if !os(watchOS)
+        // More than 2 GB
+        let size = 0x80010000
+        let url = testURL()
+
+        let data = Data(count: size)
+        
+        try data.write(to: url)
+        
+        cleanup(at: url)
+#endif
     }
 
     // MARK: - String Path Tests


### PR DESCRIPTION
On Darwin, at least, we need to limit the size of each chunk to 2GB. Other platforms may have higher requirements, which this is compatible with. If any have lower, we will need to account for that in the future.

I also fixed a bit of code where we are passing a `0` to `POSIXError` instead of errno.