### PR TITLE
Prevent data writing integer underflow on 32 bit platforms

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -83,7 +83,7 @@ private func writeToFileDescriptorWithProgress(_ fd: Int32, data: Data, reportPr
         }
         
         // Don't ever attempt to write more than (2GB - 1 byte). Some platforms will return an error over that amount.
-        let numBytesRequested = min(preferredChunkSize, (1 << 31) - 1)
+        let numBytesRequested = min(preferredChunkSize, Int(Int32.max))
         let smallestAmountToRead = min(numBytesRequested, numBytesRemaining)
         let upperBound = nextRange.startIndex + smallestAmountToRead
         nextRange = nextRange.startIndex..<upperBound


### PR DESCRIPTION
Previously on 32 bit platforms, taking `1 << 31` and subtracting `1` here would cause an integer underflow (which causes an abort) as `1 << 31 == Int.min` on 32 bit platforms. Instead, we now use `Int32.max` here (which is equivalent to `(1 << 31) - 1` but without possibly causing issues due to different integer sizes)