### PR TITLE
FileManager should standardize home directory paths

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -142,13 +142,13 @@ extension String {
     internal static func homeDirectoryPath(forUser user: String? = nil) -> String {
         #if targetEnvironment(simulator)
         if user == nil, let envValue = getenv("CFFIXED_USER_HOME") ?? getenv("HOME") {
-            return String(cString: envValue)
+            return String(cString: envValue).standardizingPath
         }
         #endif
         
         // First check CFFIXED_USER_HOME if the environment is not considered tainted
         if let envVar = Platform.getEnvSecure("CFFIXED_USER_HOME") {
-            return envVar
+            return envVar.standardizingPath
         }
         
         // Next, attempt to find the home directory via getpwnam/getpwuid
@@ -160,12 +160,12 @@ extension String {
         }
         
         if let dir = pass?.pointee.pw_dir {
-            return String(cString: dir)
+            return String(cString: dir).standardizingPath
         }
         
         // Fallback to HOME for the current user if possible
         if user == nil, let home = getenv("HOME") {
-            return String(cString: home)
+            return String(cString: home).standardizingPath
         }
         
         // If all else fails, log and fall back to /var/empty


### PR DESCRIPTION
The previous ObjC implementation of `FileManager` standardized the home directory path, but the new Swift implementation did not. This could lead to home directory paths (vended by APIs such as `urls(for:in:)`) beginning with prefixes such as `/private/var` instead of `/var`. Restore the old behavior of standardizing home directory paths for behavioral compatibility.