### PR TITLE
Round towards zero, matching behavior of previous ICU implementation

### DIFF
--- a/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
+++ b/Sources/FoundationEssentials/Formatting/Date+ISO8601FormatStyle.swift
@@ -446,7 +446,7 @@ extension Date.ISO8601FormatStyle : FormatStyle {
                 
                 if includingFractionalSeconds {
                     let ns = components.nanosecond!
-                    let ms = Int((Double(ns) / 1_000_000.0).rounded(.toNearestOrAwayFromZero))
+                    let ms = Int((Double(ns) / 1_000_000.0).rounded(.towardZero))
                     buffer.appendElement(asciiPeriod)
                     append(ms, zeroPad: 3, buffer: &buffer)
                 }

--- a/Tests/FoundationEssentialsTests/Formatting/DateISO8601FormatStyleEssentialsTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/DateISO8601FormatStyleEssentialsTests.swift
@@ -131,4 +131,11 @@ final class DateISO8601FormatStyleEssentialsTests: XCTestCase {
         let str = Date.ISO8601FormatStyle().format(dc, appendingTimeZoneOffset: 0)
         XCTAssertEqual(str, "-2025-01-20T00:00:00Z")
     }
+    
+    func test_rounding() {
+        // Date is: "1970-01-01 15:35:45.9999"
+        let date = Date(timeIntervalSinceReferenceDate: -978251054.0 - 0.0001)
+        let str = Date.ISO8601FormatStyle().timeZone(separator: .colon).time(includingFractionalSeconds: true).timeSeparator(.colon).format(date)
+        XCTAssertEqual(str, "15:35:45.999Z")
+    }
 }


### PR DESCRIPTION
Round towards zero, matching previous ICU implementation and also avoiding a situation where we round from 999 to 1000 for milliseconds.