### PR TITLE
Fix lexical sorting for SortComparator

### DIFF
--- a/Sources/FoundationInternationalization/String/String+SortComparator.swift
+++ b/Sources/FoundationInternationalization/String/String+SortComparator.swift
@@ -144,7 +144,12 @@ extension String {
         public func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
 #if FOUNDATION_FRAMEWORK
             // https://github.com/apple/swift-foundation/issues/284
-            return lhs.compare(rhs, options: options, locale: Locale.current).withOrder(order)
+            
+            if isLocalized {
+                return lhs.compare(rhs, options: options, locale: Locale.current).withOrder(order)
+            } else {
+                return lhs.compare(rhs, options: options).withOrder(order)
+            }
 #else
             // TODO: Until compare(_:options:locale:) is ported to FoundationInternationalization, only support unlocalized
             return lhs.compare(rhs, options: options).withOrder(order)

--- a/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
+++ b/Tests/FoundationInternationalizationTests/StringSortComparatorTests.swift
@@ -30,5 +30,23 @@ class StringSortComparatorTests: XCTestCase {
         XCTAssertEqual(swedishComparator.compare("ă", "ã"), .orderedAscending)
         XCTAssertEqual(swedishComparator.locale, Locale(identifier: "sv"))
     }
-#endif    
+    
+    func test_nil_locale() {
+        let swedishComparator = String.Comparator(options: [], locale: nil)
+        XCTAssertEqual(swedishComparator.compare("ă", "ã"), .orderedDescending)
+    }
+    
+    func test_standard_localized() throws {
+        // This test is only verified to work with en
+        guard Locale.current.language.languageCode == .english else {
+            throw XCTSkip("Test only verified to work with English as current language")
+        }
+        
+        let localizedStandard = String.StandardComparator.localizedStandard
+        XCTAssertEqual(localizedStandard.compare("ă", "ã"), .orderedAscending)
+        
+        let unlocalizedStandard = String.StandardComparator.lexical
+        XCTAssertEqual(unlocalizedStandard.compare("ă", "ã"), .orderedDescending)
+    }
+#endif
 }


### PR DESCRIPTION
SortComparator’s StandardComparator always uses `Locale.current` instead of checking the `isLocalized` property.