### PR TITLE
Import DarwinPrivate to get VREG

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -13,6 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 @_implementationOnly import _ForSwiftFoundation
 @_implementationOnly import _CShims
+@_implementationOnly import DarwinPrivate // for VREG
 #else
 package import _CShims
 #endif


### PR DESCRIPTION
We need to import DarwinPrivate for the framework build to get the `VREG` constant.