### PR TITLE
Calendar should return the first day of week of its locale

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -255,8 +255,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         get {
             if let _firstWeekday {
                 return _firstWeekday
-            } else if let localePrefs, let forcedWeekdayNumber = localePrefs.firstWeekday?[identifier], Locale.Weekday(forcedWeekdayNumber) != nil {
-                return forcedWeekdayNumber
+            } else if let locale {
+                return locale.firstDayOfWeek.icuIndex
             } else {
                 return 1
             }
@@ -278,8 +278,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         get {
             if let _minimumDaysInFirstWeek {
                 return _minimumDaysInFirstWeek
-            } else if let localePrefs, let forcedMinimumDaysInFirstWeek = localePrefs.minDaysInFirstWeek?[identifier] {
-                return forcedMinimumDaysInFirstWeek
+            } else if let locale {
+                return locale.minimumDaysInFirstWeek
             } else {
                 return 1
             }

--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -477,6 +477,10 @@ public struct Locale : Hashable, Equatable, Sendable {
         _locale.weekendRange
     }
 
+    internal var minimumDaysInFirstWeek: Int {
+        _locale.minimumDaysInFirstWeek
+    }
+    
     // MARK: - Preferences support (Internal)
 
     package var forceHourCycle: HourCycle? {

--- a/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
@@ -179,6 +179,10 @@ internal final class _LocaleAutoupdating : _LocaleProtocol, @unchecked Sendable 
         LocaleCache.cache.current.weekendRange
     }
 
+    var minimumDaysInFirstWeek: Int {
+        LocaleCache.cache.current.minimumDaysInFirstWeek
+    }
+
     var language: Locale.Language {
         LocaleCache.cache.current.language
     }

--- a/Sources/FoundationEssentials/Locale/Locale_Protocol.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Protocol.swift
@@ -64,6 +64,7 @@ package protocol _LocaleProtocol : AnyObject, Sendable, CustomDebugStringConvert
     var availableNumberingSystems: [Locale.NumberingSystem] { get }
     var firstDayOfWeek: Locale.Weekday { get }
     var weekendRange: WeekendRange? { get }
+    var minimumDaysInFirstWeek: Int { get }
     var language: Locale.Language { get }
     var hourCycle: Locale.HourCycle { get }
     var collation: Locale.Collation { get }

--- a/Sources/FoundationEssentials/Locale/Locale_Unlocalized.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Unlocalized.swift
@@ -178,6 +178,11 @@ internal final class _LocaleUnlocalized : _LocaleProtocol, @unchecked Sendable {
         WeekendRange(onsetTime: 0, ceaseTime: 86400, start: 7, end: 1)
     }
 
+    var minimumDaysInFirstWeek: Int {
+        // Minimum days in first week for 001 region
+        1
+    }
+
     var language: Locale.Language {
         Locale.Language(components: .init(languageCode: .init("en"), script: nil, region: .init("001")))
     }

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -948,6 +948,45 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(firstDayOfMonth(gregorianCalendar, for: date2), Date(timeIntervalSinceReferenceDate: 728441519.0)) // 2024-02-01T00:51:59Z
     }
 
+    func test_firstWeekday() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(calendar.firstWeekday, 1)
+
+        calendar.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(calendar.firstWeekday, 2)
+
+        var calendarWithCustomLocale = Calendar(identifier: .gregorian)
+        calendarWithCustomLocale.locale = Locale(identifier: "en_US", preferences: .init(firstWeekday: [.gregorian: 3]))
+        XCTAssertEqual(calendarWithCustomLocale.firstWeekday, 3)
+
+        calendarWithCustomLocale.firstWeekday = 5
+        XCTAssertEqual(calendarWithCustomLocale.firstWeekday, 5) // Returns the one set directly on Calendar
+
+        var calendarWithCustomLocaleAndCustomWeekday = Calendar(identifier: .gregorian)
+        calendarWithCustomLocaleAndCustomWeekday.firstWeekday = 2
+        calendarWithCustomLocaleAndCustomWeekday.locale = Locale(identifier: "en_US", preferences: .init(firstWeekday: [.gregorian: 3]))
+        XCTAssertEqual(calendarWithCustomLocaleAndCustomWeekday.firstWeekday, 2) // Returns the one set directly on Calendar even if `.locale` is set later
+    }
+
+    func test_minDaysInFirstWeek() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(calendar.minimumDaysInFirstWeek, 4)
+
+        calendar.minimumDaysInFirstWeek = 5
+        XCTAssertEqual(calendar.minimumDaysInFirstWeek, 5)
+
+        var calendarWithCustomLocale = Calendar(identifier: .gregorian)
+        calendarWithCustomLocale.locale = Locale(identifier: "en_US", preferences: .init(minDaysInFirstWeek: [.gregorian: 6]))
+        XCTAssertEqual(calendarWithCustomLocale.minimumDaysInFirstWeek, 6)
+
+        var calendarWithCustomLocaleAndCustomMinDays = Calendar(identifier: .gregorian)
+        calendarWithCustomLocaleAndCustomMinDays.minimumDaysInFirstWeek = 2
+        calendarWithCustomLocaleAndCustomMinDays.locale = Locale(identifier: "en_US", preferences: .init(minDaysInFirstWeek: [.gregorian: 6]))
+        XCTAssertEqual(calendarWithCustomLocaleAndCustomMinDays.minimumDaysInFirstWeek, 2)
+
+    }
 }
 
 // MARK: - Bridging Tests


### PR DESCRIPTION
"First day of week" and "minimum days in first week" are locale specific. Move the logic of fetching the locale's preferred value into `LocaleProtocol`, so that calendar can return the value from its enclosed locale.

Resolves 123630636
