### PR TITLE
Standardize on using internal import

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -30,8 +30,8 @@ public enum AttributeScopes { }
 #if FOUNDATION_FRAMEWORK
 
 import Darwin
-@_implementationOnly import MachO.dyld
-@_implementationOnly import ReflectionInternal
+internal import MachO.dyld
+@preconcurrency internal import ReflectionInternal
 
 fileprivate struct ScopeDescription : Sendable {
     var attributes: [String : any AttributedStringKey.Type] = [:]

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRun.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRun.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRuns.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRuns.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRunsSlice.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRunsSlice.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -11,10 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import ReflectionInternal
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 // MARK: AttributedStringKey API

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 // MARK: AttributedStringKey

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -13,10 +13,10 @@
 
 #if FOUNDATION_FRAMEWORK
 import Darwin
-@_implementationOnly import os
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+internal import os
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 extension String {

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -13,10 +13,10 @@
 // MARK: Attribute Scope
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import Foundation_Private.NSAttributedString
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+internal import Foundation_Private.NSAttributedString
+@_spi(Unstable) internal import CollectionsInternal
 #else
-package import _RopeModule
+internal import _RopeModule
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -11,11 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import os
-#else
-package import os
-#endif
+internal import os
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -26,7 +22,7 @@ import CRT
 
 #if FOUNDATION_FRAMEWORK
 // For feature flag
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #endif
 
 /**

--- a/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Cache.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
 #endif
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 // For Logger
-@_implementationOnly import os
+internal import os
 #endif
 
 /// Internal-use error for indicating unexpected situations when finding dates.

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -11,11 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(os)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import os
-#else
-package import os
-#endif // FOUNDATION_FRAMEWORK
+internal import os
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/FoundationEssentials/Calendar/DateComponents.swift
+++ b/Sources/FoundationEssentials/Calendar/DateComponents.swift
@@ -602,7 +602,7 @@ extension DateComponents : Codable {
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension DateComponents : ReferenceConvertible, _ObjectiveCBridgeable {

--- a/Sources/FoundationEssentials/Data/Data+Error.swift
+++ b/Sources/FoundationEssentials/Data/Data+Error.swift
@@ -12,9 +12,9 @@
 
 #if FOUNDATION_FRAMEWORK
 // For Logger
-@_implementationOnly import os
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import _CShims
+internal import os
+internal import _ForSwiftFoundation
+internal import _CShims
 #endif
 
 internal func logFileIOErrno(_ err: Int32, at place: String) {

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -11,11 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import _CShims
-#else
-package import _CShims
+internal import _ForSwiftFoundation
 #endif
+
+internal import _CShims
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -11,12 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import _CShims
-@_implementationOnly import DarwinPrivate // for VREG
-#else
-package import _CShims
+internal import _ForSwiftFoundation
+internal import DarwinPrivate // for VREG
 #endif
+
+internal import _CShims
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -10,7 +10,7 @@
  //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #endif
 
 #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Bridge.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Bridge.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import Foundation_Private.NSFileManager
+internal import Foundation_Private.NSFileManager
 
 @objc(_NSFileManagerBridge)
 @objcMembers

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -11,18 +11,18 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import containermanager
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import _CShims
-@_implementationOnly import os
+internal import containermanager
+internal import _ForSwiftFoundation
+internal import os
 #endif
 
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-package import _CShims
 #endif
+
+internal import _CShims
 
 #if FOUNDATION_FRAMEWORK
 var _shouldLog: Bool = {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -11,15 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import Foundation_Private.NSFileManager
-@_implementationOnly import DarwinPrivate.sys.content_protection
+internal import Foundation_Private.NSFileManager
+internal import DarwinPrivate.sys.content_protection
 #endif
 
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-package import _CShims
+internal import _CShims
 #endif
 
 extension Date {

--- a/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import Foundation_Private.NSFileManager
-@_implementationOnly import Foundation_Private.NSPathUtilities
-@_implementationOnly import DarwinPrivate.dirhelper
-@_implementationOnly import DarwinPrivate.sysdir
-@_implementationOnly import _ForSwiftFoundation
+internal import Foundation_Private.NSFileManager
+internal import Foundation_Private.NSPathUtilities
+internal import DarwinPrivate.dirhelper
+internal import DarwinPrivate.sysdir
+internal import _ForSwiftFoundation
 #endif
 
 #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import XPCPrivate
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import Foundation_Private.NSFileManager
-@_implementationOnly import DarwinPrivate
+internal import XPCPrivate
+internal import _ForSwiftFoundation
+internal import Foundation_Private.NSFileManager
+internal import DarwinPrivate
 
 #if os(macOS)
-@_implementationOnly import QuarantinePrivate
+internal import QuarantinePrivate
 #endif
 #endif
 
@@ -25,7 +25,7 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-package import _CShims
+internal import _CShims
 #endif
 
 extension stat {

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -14,7 +14,7 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-package import _CShims
+internal import _CShims
 #endif
 
 // MARK: Directory Iteration

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -17,16 +17,15 @@ import Glibc
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import Foundation_Private.NSFileManager
+internal import _ForSwiftFoundation
+internal import Foundation_Private.NSFileManager
 
 #if os(macOS)
-@_implementationOnly import QuarantinePrivate
+internal import QuarantinePrivate
 #endif
-#else
-package import _CShims
 #endif
+
+internal import _CShims
 
 extension CocoaError {
     private static func fileOperationError(_ errNum: Int32, _ suspectedErroneousPath: String, sourcePath: String? = nil, destinationPath: String? = nil, variant: String? = nil) -> CocoaError {

--- a/Sources/FoundationEssentials/IndexPath.swift
+++ b/Sources/FoundationEssentials/IndexPath.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #endif
 
 /**

--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -16,12 +16,7 @@ import Darwin
 import Glibc
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-#else
-package import _CShims
-#endif
-
+internal import _CShims
 
 internal struct JSON5Scanner {
     let options: Options

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -16,11 +16,7 @@ import Darwin
 import Glibc
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-#else
-package import _CShims
-#endif
+internal import _CShims
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -59,11 +59,7 @@ import Darwin
 import Glibc
 #endif // canImport(Darwin)
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-#else
-package import _CShims
-#endif
+internal import _CShims
 
 internal class JSONMap {
     enum TypeDescriptor : Int {

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -11,14 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import CoreFoundation_Private.CFNotificationCenter
-@_implementationOnly import os
-@_implementationOnly import _CShims
-#else
-package import _CShims
+internal import CoreFoundation_Private.CFNotificationCenter
+internal import os
 #endif
+
+internal import _CShims
 
 /// Singleton which listens for notifications about preference changes for Locale and holds cached singletons.
 struct LocaleCache : Sendable {

--- a/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Preferences.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 // for CFXPreferences call
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #endif
 
 /// Holds user preferences about `Locale`, retrieved from user defaults. It is only used when creating the `current` Locale. Fixed-identifier locales never have preferences.

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -11,12 +11,7 @@
 
 #if canImport(Darwin)
 import Darwin
-
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import MachO.dyld
-#else
-package import MachO.dyld
-#endif // FOUNDATION_FRAMEWORK
+internal import MachO.dyld
 
 fileprivate var _pageSize: Int {
     Int(vm_page_size)
@@ -39,11 +34,10 @@ fileprivate let _pageSize: Int = Int(getpagesize())
 #endif // canImport(Darwin)
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-@_implementationOnly import CoreFoundation_Private
-#else
-package import _CShims
+internal import CoreFoundation_Private
 #endif
+
+internal import _CShims
 
 package struct Platform {
     static var pageSize: Int {

--- a/Sources/FoundationEssentials/Predicate/Archiving/ExpressionArchiving.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/ExpressionArchiving.swift
@@ -12,8 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly
-import ReflectionInternal
+@preconcurrency internal import ReflectionInternal
 
 @available(FoundationPredicate 0.1, *)
 enum PredicateCodableError : Error, CustomStringConvertible {

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -13,8 +13,7 @@
 #if FOUNDATION_FRAMEWORK
 
 #if canImport(ReflectionInternal)
-@_implementationOnly
-import ReflectionInternal
+@preconcurrency internal import ReflectionInternal
 
 @available(FoundationPredicate 0.1, *)
 public protocol PredicateCodableKeyPathProviding {

--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -11,8 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly
-import Synchronization
+internal import Synchronization
 #endif
 
 @available(FoundationPredicate 0.1, *)

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -13,8 +13,8 @@
 #if FOUNDATION_FRAMEWORK
 
 #if canImport(Foundation_Private.NSExpression)
-@_implementationOnly import Foundation_Private.NSExpression
-@_implementationOnly import Foundation_Private.NSPredicate
+internal import Foundation_Private.NSExpression
+internal import Foundation_Private.NSPredicate
 
 private struct NSPredicateConversionState {
     private var nextLocalVariable: UInt = 1

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+ObjC.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+ObjC.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK && !NO_PROCESS
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import MachO_Private.dyld
-@_implementationOnly import CoreFoundation_Private
+internal import _ForSwiftFoundation
+internal import MachO_Private.dyld
+internal import CoreFoundation_Private
 
 @objc(_NSSwiftProcessInfo)
 internal final class _NSSwiftProcessInfo: ProcessInfo {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-#else
-package import _CShims
-#endif
+internal import _CShims
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
+++ b/Sources/FoundationEssentials/String/BuiltInUnicodeScalarSet.swift
@@ -9,11 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims
-#else
-package import _CShims
-#endif
+internal import _CShims
 
 // Native implementation of CFCharacterSet.
 // Represents sets of unicode scalars of those whose bitmap data we own.

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(_Unicode) import Swift
-@_implementationOnly import Foundation_Private.NSString
+internal import Foundation_Private.NSString
 #endif
 
 #if canImport(Darwin)

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -11,17 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import os
-@_implementationOnly import _CShims
-#else
-package import os
-package import _CShims
-#endif
+internal import os
 #elseif canImport(Glibc)
 import Glibc
-package import _CShims
 #endif
+
+internal import _CShims
 
 extension String {
     internal func deletingLastPathComponent() -> String {

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #else
 internal func _foundation_essentials_feature_enabled() -> Bool { return true }
 #endif

--- a/Sources/FoundationEssentials/String/UnicodeScalar.swift
+++ b/Sources/FoundationEssentials/String/UnicodeScalar.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(_Unicode) import Swift
-@_implementationOnly import CoreFoundation_Private.CFString
+internal import CoreFoundation_Private.CFString
 #endif // FOUNDATION_FRAMEWORK
 
 extension UnicodeScalar {

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -23,8 +23,8 @@ import WinSDK
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
-@_implementationOnly import CoreFoundation_Private.CFNotificationCenter
+internal import _ForSwiftFoundation
+internal import CoreFoundation_Private.CFNotificationCenter
 #endif
 
 /// Singleton which listens for notifications about preference changes for TimeZone and holds cached values for current, fixed time zones, etc.

--- a/Sources/FoundationEssentials/UUID.swift
+++ b/Sources/FoundationEssentials/UUID.swift
@@ -9,11 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import _CShims // uuid.h
-#else
-package import _CShims // uuid.h
-#endif
+internal import _CShims // uuid.h
 
 public typealias uuid_t = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 public typealias uuid_string_t = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)

--- a/Sources/FoundationEssentials/UUID_Wrappers.swift
+++ b/Sources/FoundationEssentials/UUID_Wrappers.swift
@@ -11,7 +11,7 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 
 #if canImport(Darwin.uuid)
 // Needed this for backward compatibility even though we don't use it.

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -16,17 +16,9 @@ import Glibc
 #elseif canImport(WinSDK)
 import WinSDK
 #elseif canImport(threads_h)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import threads_h
-#else
-package import threads_h
-#endif
+internal import threads_h
 #elseif canImport(threads)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import threads
-#else
-package import threads
-#endif
+internal import threads
 #endif
 
 struct _ThreadLocal {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_Bridge.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_Bridge.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 
 /// Wraps an `NSCalendar` with more Swift-like `Calendar` API. See also: `_NSSwiftCalendar`.
 /// This is only used in the case where we have custom Objective-C subclasses of `NSCalendar`. It is assumed that the subclass is Sendable.

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -22,11 +22,7 @@ import Glibc
 import CRT
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
     let lock: LockedState<Void>

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ObjC.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ObjC.swift
@@ -12,10 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import os
-@_implementationOnly import CoreFoundation_Private.CFLocale
+internal import os
+internal import CoreFoundation_Private.CFLocale
 
 extension NSCalendar.Unit {
     // Avoid the deprecation warning for .NSWeekCalendarUnit

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -13,11 +13,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 #if canImport(Glibc)
 import Glibc

--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ByteCountFormatStyle: FormatStyle, Sendable {

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+AnchoredRelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+AnchoredRelativeFormatStyle.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 // MARK: Date.AnchoredRelativeFormatStyle
 

--- a/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/Date+RelativeFormatStyle.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 typealias CalendarComponentAndValue = (component: Calendar.Component, value: Int)
 

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 // MARK: Date Extensions
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 final class ICUDateIntervalFormatter {
     struct Signature : Hashable {

--- a/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICURelativeDateFormatter {

--- a/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+TimeFormatStyle.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 let hourSymbol: Character = "h"
 let minuteSymbol: Character = "m"

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -14,12 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
-
+internal import FoundationICU
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension Duration {

--- a/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICUListFormatter {

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 internal final class ICULegacyNumberFormatter {

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 typealias ICUNumberFormatterSkeleton = String
 

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberAttributedFormat.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberAttributedFormat.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 extension AttributeScopes.FoundationAttributes.NumberFormatAttributes.SymbolAttribute.Symbol {
     init?(unumberFormatField: UNumberFormatFields) {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {

--- a/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+CaseMap.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 extension ICU {
     final class CaseMap : @unchecked Sendable {

--- a/Sources/FoundationInternationalization/ICU/ICU+Enumeration.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enumeration.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 extension ICU {
 

--- a/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Enums.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 #if os(Windows)
 typealias EnumRawType = CInt

--- a/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+FieldPositer.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 extension ICU {
     final class FieldPositer {

--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 enum ICU { }
 

--- a/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
+++ b/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 final class ICUPatternGenerator {
 

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -18,11 +18,7 @@ import Glibc
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Components {

--- a/Sources/FoundationInternationalization/Locale/Locale_Bridge.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_Bridge.swift
@@ -12,11 +12,11 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import os
-@_implementationOnly import CoreFoundation_Private.CFLocale
-@_implementationOnly import Foundation_Private.NSLocale
+internal import os
+internal import CoreFoundation_Private.CFLocale
+internal import Foundation_Private.NSLocale
 
 /// Wraps an NSLocale with a more Swift-like `Locale` API.
 /// This is only used in the case where we have custom Objective-C subclasses of `NSLocale`. It is assumed that the subclass is Sendable.

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -16,13 +16,12 @@ import FoundationEssentials
 
 #if FOUNDATION_FRAMEWORK
 // for CFXPreferences call
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 // For Logger
-@_implementationOnly import os
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
+internal import os
 #endif
+
+internal import FoundationICU
 
 #if canImport(Glibc)
 import Glibc

--- a/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
@@ -12,14 +12,14 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import os
+internal import os
 #if canImport(CoreFoundation_Private.CFLocale)
-@_implementationOnly import CoreFoundation_Private.CFLocale
+internal import CoreFoundation_Private.CFLocale
 #endif
 #if canImport(Foundation_Private.NSLocale)
-@_implementationOnly import Foundation_Private.NSLocale
+internal import Foundation_Private.NSLocale
 #endif
 
 /// Entry points for the ObjC and C code to call into the common Swift implementation.

--- a/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
+++ b/Sources/FoundationInternationalization/String/StringProtocol+Locale.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 #endif
 
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_Bridge.swift
@@ -12,9 +12,9 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import os
+internal import os
 
 /// Wraps an `NSTimeZone` with a more Swift-like `TimeZone` API.
 /// This is only used in the case where we have a custom Objective-C subclass of `NSTimeZone`.

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_GMTICU.swift
@@ -14,11 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 internal final class _TimeZoneGMTICU : _TimeZoneProtocol, @unchecked Sendable {
     let offset: Int

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -23,11 +23,7 @@ import ucrt
 #endif
 
 #if canImport(FoundationICU)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import FoundationICU
-#else
-package import FoundationICU
-#endif
+internal import FoundationICU
 
 internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
     init?(secondsFromGMT: Int) {

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
@@ -12,9 +12,9 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_implementationOnly import _ForSwiftFoundation
+internal import _ForSwiftFoundation
 import CoreFoundation
-@_implementationOnly import os
+internal import os
 
 @objc
 extension NSTimeZone {

--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -12,14 +12,8 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
-
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import SwiftDiagnostics
-@_implementationOnly import SwiftSyntaxBuilder
-#else
-package import SwiftDiagnostics
-package import SwiftSyntaxBuilder
-#endif
+internal import SwiftDiagnostics
+internal import SwiftSyntaxBuilder
 
 // A list of all functions supported by Predicate itself, any other functions called will be diagnosed as an error
 // This allows for checking the function name, the number of arguments, and the argument labels, but the types of the arguments will need to be validated by the post-expansion type checking pass

--- a/Sources/_FoundationInternals/LockedState.swift
+++ b/Sources/_FoundationInternals/LockedState.swift
@@ -11,13 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(os)
-#if FOUNDATION_FRAMEWORK
-@_implementationOnly import os
-#if canImport(C.os.lock)
-@_implementationOnly import C.os.lock
-#endif
-#else
-package import os
+internal import os
+#if FOUNDATION_FRAMEWORK && canImport(C.os.lock)
+internal import C.os.lock
 #endif
 #elseif canImport(Glibc)
 import Glibc

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -28,7 +28,7 @@ import TestSupport
 @testable import Foundation
 #endif
 
-#if canImport(_CShims)
+#if !FOUNDATION_FRAMEWORK
 import _CShims
 #endif
 
@@ -166,7 +166,7 @@ final class JSONEncoderTests : XCTestCase {
     func x_testEncodingDate() {
 
         func formattedLength(of value: Double) -> Int {
-        #if canImport(_CShims)
+        #if !FOUNDATION_FRAMEWORK
             return Int(_stringshims_get_formatted_str_length(value))
         #else
             let empty = UnsafeMutablePointer<Int8>.allocate(capacity: 0)

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -24,7 +24,7 @@ import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) import CollectionsInternal
 #else
 import _RopeModule
 #endif

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -21,7 +21,7 @@ import TestSupport
 
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
-@_implementationOnly @_spi(Unstable) import CollectionsInternal
+@_spi(Unstable) import CollectionsInternal
 #else
 import _RopeModule
 #endif


### PR DESCRIPTION
We've previously had to use `@_implementationOnly` imports in Foundation itself for internal imports, while we used `package` imports in the package to achieve the same goal in swift-foundation of hiding imports from clients. The `internal import` feature has been completed for some time now and provides us the same fundamental behaviors in both the resilient Foundation module as well as the non-resilient swift-foundation modules. This PR changes all uses of `@_implementationOnly`/`package` imports to `internal import` to standardize on one spelling of these imports. This also resolves a slew of build warnings produced by `package import`s that were not used in any `package` declarations.