### PR TITLE
Update Data.swift framework side builds; add base64 benchmark

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Base64.swift
+++ b/Sources/FoundationEssentials/Data/Data+Base64.swift
@@ -26,6 +26,13 @@ extension Data {
     /// - parameter base64String: The string to parse.
     /// - parameter options: Encoding options. Default value is `[]`.
     public init?(base64Encoded base64String: __shared String, options: Base64DecodingOptions = []) {
+#if FOUNDATION_FRAMEWORK
+        if let d = NSData(base64Encoded: base64String, options: NSData.Base64DecodingOptions(rawValue: options.rawValue)) {
+            self.init(referencing: d)
+        } else {
+            return nil
+        }
+#else
         var encoded = base64String
         let decoded = encoded.withUTF8 {
             // String won't pass an empty buffer with a `nil` `baseAddress`.
@@ -33,6 +40,7 @@ extension Data {
         }
         guard let decoded else { return nil }
         self = decoded
+#endif
     }
 
     /// Initialize a `Data` from a Base-64, UTF-8 encoded `Data`.
@@ -42,11 +50,19 @@ extension Data {
     /// - parameter base64Data: Base-64, UTF-8 encoded input data.
     /// - parameter options: Decoding options. Default value is `[]`.
     public init?(base64Encoded base64Data: __shared Data, options: Base64DecodingOptions = []) {
+#if FOUNDATION_FRAMEWORK
+        if let d = NSData(base64Encoded: base64Data, options: NSData.Base64DecodingOptions(rawValue: options.rawValue)) {
+            self.init(referencing: d)
+        } else {
+            return nil
+        }
+#else
         let decoded = base64Data.withBufferView {
             Data(decodingBase64: $0, options: options)
         }
         guard let decoded else { return nil }
         self = decoded
+#endif
     }
 
     init?(decodingBase64 bytes: borrowing BufferView<UInt8>, options: Base64DecodingOptions = []) {
@@ -76,6 +92,14 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded string.
     public func base64EncodedString(options: Base64EncodingOptions = []) -> String {
+#if FOUNDATION_FRAMEWORK
+        // Previously inlinable
+        return _representation.withInteriorPointerReference {
+            return $0.base64EncodedString(
+                options: NSData.Base64EncodingOptions(
+                    rawValue: options.rawValue))
+        }
+#else
         if self.isEmpty { return "" }
 
         return self.withBufferView { inputBuffer in
@@ -84,6 +108,7 @@ extension Data {
                 Self.base64EncodeBytes(inputBuffer, &$0, options: options)
             }
         }
+#endif
     }
 
     /// Returns a Base-64 encoded `Data`.
@@ -91,6 +116,14 @@ extension Data {
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.
     public func base64EncodedData(options: Base64EncodingOptions = []) -> Data {
+#if FOUNDATION_FRAMEWORK
+        // Previously inlinable
+        return _representation.withInteriorPointerReference {
+            return $0.base64EncodedData(
+                options: NSData.Base64EncodingOptions(
+                    rawValue: options.rawValue))
+        }
+#else
         let dataLength = self.count
         if dataLength == 0 { return Data() }
 
@@ -100,6 +133,7 @@ extension Data {
                 Self.base64EncodeBytes(inputBuffer, &$0, options: options)
             }
         }
+#endif
     }
 
     // MARK: - Internal Helpers

--- a/Sources/FoundationEssentials/Data/Data+Stub.swift
+++ b/Sources/FoundationEssentials/Data/Data+Stub.swift
@@ -12,21 +12,6 @@
 
 #if !FOUNDATION_FRAMEWORK
 
-// FIXME: rdar://103535015 (Implement stub methods in struct Data)
-extension Data {
-    /// Find the given `Data` in the content of this `Data`.
-    ///
-    /// - parameter dataToFind: The data to be searched for.
-    /// - parameter options: Options for the search. Default value is `[]`.
-    /// - parameter range: The range of this data in which to perform the search. Default value is `nil`, which means the entire content of this data.
-    /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
-    /// - precondition: `range` must be in the bounds of the Data.
-    public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
-        // FIXME: Implement Data IO
-        fatalError("Not implemented")
-    }
-}
-
 // Placeholder for Progress
 internal final class Progress {
     var completedUnitCount: Int64

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2608,6 +2608,36 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
+    // MARK: - Range
+    
+#if FOUNDATION_FRAMEWORK
+    /// Find the given `Data` in the content of this `Data`.
+    ///
+    /// - parameter dataToFind: The data to be searched for.
+    /// - parameter options: Options for the search. Default value is `[]`.
+    /// - parameter range: The range of this data in which to perform the search. Default value is `nil`, which means the entire content of this data.
+    /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
+    /// - precondition: `range` must be in the bounds of the Data.
+    public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
+        let nsRange : NSRange
+        if let r = range {
+            nsRange = NSRange(location: r.lowerBound - startIndex, length: r.upperBound - r.lowerBound)
+        } else {
+            nsRange = NSRange(location: 0, length: count)
+        }
+        let result = _representation.withInteriorPointerReference {
+            let opts = NSData.SearchOptions(rawValue: options.rawValue)
+            return $0.range(of: dataToFind, options: opts, in: nsRange)
+        }
+        if result.location == NSNotFound {
+            return nil
+        }
+        return (result.location + startIndex)..<((result.location + startIndex) + result.length)
+    }
+#else
+    // TODO: Implement range(of:options:in:) for Foundation package.
+#endif
+
     // MARK: -
     //
 
@@ -2671,6 +2701,14 @@ extension Data {
         /// Modify the decoding algorithm so that it ignores unknown non-Base-64 bytes, including line ending characters.
         public static let ignoreUnknownCharacters = Base64DecodingOptions(rawValue: 1 << 0)
     }
+}
+#else
+@available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
+extension Data {
+    // These types are typealiased to the `NSData` options for framework builds only.
+    public typealias SearchOptions = NSData.SearchOptions
+    public typealias Base64EncodingOptions = NSData.Base64EncodingOptions
+    public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
 }
 #endif //!FOUNDATION_FRAMEWORK
 


### PR DESCRIPTION
Update Data with some requirements for the Framework side builds of base64 and others. For now we will continue to use the NSData implementation there, and come back later to unify once we have validated the performance requirements. Added a base64 benchmark.