### PR TITLE
Update swift-collections dependency to the 1.1 tag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-collections",
-            revision: "d8003787efafa82f9805594bc51100be29ac6903"), // on release/1.1
+            from: "1.1.0"),
         .package(
             url: "https://github.com/apple/swift-foundation-icu",
             exact: "0.0.5"),


### PR DESCRIPTION
Now that [swift-collections 1.1](https://github.com/apple/swift-collections/releases/tag/1.1.0) is released, we can update our dependency to point at that tag. Our previous dependency was on a particular commit on the `release/1.1` branch, but now we'll depend on the official tag instead of a particular commit. This tag includes everything that swift-foundation needs.