### PR TITLE
FileManager should always return values for immutable/appendOnly attributes

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -78,7 +78,9 @@ func _readFileAttributePrimitive(_ value: Any?, as type: Bool.Type) -> Bool? {
     }
     #endif
     
-    if let binInt = value as? (any BinaryInteger), let result = Int(exactly: binInt) {
+    if let boolValue = value as? Bool {
+        return boolValue
+    } else if let binInt = value as? (any BinaryInteger), let result = Int(exactly: binInt) {
         switch result {
         case 0: return false
         case 1: return true
@@ -149,12 +151,10 @@ extension stat {
             result[.deviceIdentifier] = _writeFileAttributePrimitive(st_rdev, as: UInt.self)
         }
         #if canImport(Darwin)
-        if (st_flags & UInt32(UF_IMMUTABLE)) != 0 || (st_flags & UInt32(SF_IMMUTABLE)) != 0 {
-            result[.immutable] = _writeFileAttributePrimitive(true)
-        }
-        if (st_flags & UInt32(UF_APPEND)) != 0 || (st_flags & UInt32(SF_APPEND)) != 0 {
-            result[.appendOnly] = _writeFileAttributePrimitive(true)
-        }
+        let immutable = (st_flags & UInt32(UF_IMMUTABLE)) != 0 || (st_flags & UInt32(SF_IMMUTABLE)) != 0
+        result[.immutable] = _writeFileAttributePrimitive(immutable)
+        let appendOnly = (st_flags & UInt32(UF_APPEND)) != 0 || (st_flags & UInt32(SF_APPEND)) != 0
+        result[.appendOnly] = _writeFileAttributePrimitive(appendOnly)
         #endif
         return result
     }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -590,6 +590,31 @@ final class FileManagerTests : XCTestCase {
         }
     }
     
+    func testBooleanFileAttributes() throws {
+        try FileManagerPlayground {
+            "none"
+            File("immutable", attributes: [.immutable: true])
+            File("appendOnly", attributes: [.appendOnly: true])
+            File("immutable_appendOnly", attributes: [.immutable: true, .appendOnly: true])
+        }.test {
+            let tests: [(path: String, immutable: Bool, appendOnly: Bool)] = [
+                ("none", false, false),
+                ("immutable", true, false),
+                ("appendOnly", false, true),
+                ("immutable_appendOnly", true, true)
+            ]
+            
+            for test in tests {
+                let result = try $0.attributesOfItem(atPath: test.path)
+                XCTAssertEqual(result[.immutable] as? Bool, test.immutable, "Item at path '\(test.path)' did not provide expected result for immutable key")
+                XCTAssertEqual(result[.appendOnly] as? Bool, test.appendOnly, "Item at path '\(test.path)' did not provide expected result for appendOnly key")
+                
+                // Manually clean up attributes so removal does not fail
+                try $0.setAttributes([.immutable: false, .appendOnly: false], ofItemAtPath: test.path)
+            }
+        }
+    }
+    
     func testImplicitlyConvertibleFileAttributes() throws {
         try FileManagerPlayground {
             File("foo", attributes: [.posixPermissions : UInt16(0o644)])

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -591,6 +591,7 @@ final class FileManagerTests : XCTestCase {
     }
     
     func testBooleanFileAttributes() throws {
+        #if canImport(Darwin)
         try FileManagerPlayground {
             "none"
             File("immutable", attributes: [.immutable: true])
@@ -613,6 +614,9 @@ final class FileManagerTests : XCTestCase {
                 try $0.setAttributes([.immutable: false, .appendOnly: false], ofItemAtPath: test.path)
             }
         }
+        #else
+        throw XCTSkip("This test is not applicable on this platform")
+        #endif
     }
     
     func testImplicitlyConvertibleFileAttributes() throws {


### PR DESCRIPTION
Currently, `FileManager`'s `attributesOfItem(atPath:)` returns a dictionary which only contains values for the `immutable` and `appendOnly` keys if the value is true, otherwise the dictionary does not contain the key. Instead, we should always add the value to the dictionary even if the value is false to match the previous behavior of the ObjC implementation.

This also adds a drive-by fix to ensure that we can also read `Bool` values for these keys in `setAttributes(_:ofItemAtPath:)` instead of just numeric values like `Int` outside of `FOUNDATION_FRAMEWORK`.

Resolves rdar://123713046