### PR TITLE
Fix FileManager macOS trash folder truncation

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
@@ -125,12 +125,13 @@ private struct _SearchPathsSequence: Sequence {
         private func _specialFindReturn(_ buffer: UnsafeMutableBufferPointer<CChar>) -> String? {
             guard buffer.baseAddress!.pointee != 0 else { return nil }
             
+            let path = String(cString: buffer.baseAddress!)
             // strip trailing slashes because NSPathUtilities doesn't return paths with trailing slashes.
-            let len = strlen(buffer.baseAddress!)
-            let lastNonSlash = buffer.prefix(upTo: len).lastIndex {
-                $0 != 0x2F // Slash Character
+            guard let endIndex = path.unicodeScalars.lastIndex(where: { $0 != "/" }) else {
+                // It's only slashes, so just return a single slash
+                return "/"
             }
-            return FileManager.default.string(withFileSystemRepresentation: buffer.baseAddress!, length: lastNonSlash ?? len)
+            return String(path[...endIndex])
         }
         
         private func _specialFind(_ directory: FileManager.SearchPathDirectory, in mask: FileManager.SearchPathDomainMask) -> String? {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -629,4 +629,14 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual(resolved, $0.currentDirectoryPath.appendingPathComponent("destination"))
         }
     }
+    
+    #if os(macOS) && FOUNDATION_FRAMEWORK
+    func testSpecialTrashDirectoryTruncation() throws {
+        try FileManagerPlayground {}.test {
+            if let trashURL = try? $0.url(for: .trashDirectory, in: .allDomainsMask, appropriateFor: nil, create: false) {
+                XCTAssertEqual(trashURL.pathComponents.last, ".Trash")
+            }
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
This code is only called for specially handled cases in search path enumeration. In these specially handled cases, the previous code to strip trailing slashes from the string accidentally truncated one too many characters for strings ending in a slash, resulting in paths ending like `<some path>/.Tras` instead of `<some path>/.Trash`. This replaces the buffer truncation logic with a string initialization and string index logic (which is now correct). It's ok to not call to FileManager here since we use the default file manager, so calling `String(cString:)` directly is much more efficient.