### PR TITLE
FileManager should not crash on malformed modificationDate attribute value

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -619,6 +619,20 @@ final class FileManagerTests : XCTestCase {
         #endif
     }
     
+    func testMalformedModificationDateAttribute() throws {
+        let sentinelDate = Date(timeIntervalSince1970: 100)
+        try FileManagerPlayground {
+            File("foo", attributes: [.modificationDate: sentinelDate])
+        }.test {
+            XCTAssertEqual(try $0.attributesOfItem(atPath: "foo")[.modificationDate] as? Date, sentinelDate)
+            for value in [Double.infinity, -Double.infinity, Double.nan] {
+                // Malformed modification dates should be dropped instead of throwing or crashing
+                try $0.setAttributes([.modificationDate : Date(timeIntervalSince1970: value)], ofItemAtPath: "foo")
+            }
+            XCTAssertEqual(try $0.attributesOfItem(atPath: "foo")[.modificationDate] as? Date, sentinelDate)
+        }
+    }
+    
     func testImplicitlyConvertibleFileAttributes() throws {
         try FileManagerPlayground {
             File("foo", attributes: [.posixPermissions : UInt16(0o644)])


### PR DESCRIPTION
Previously, the ObjC implementation of `FileManager` did not crash on modification dates provided that were malformed (for example, having a time interval of +/-Inf or NaN), but the new swift implementation crashes because that new value cannot fit inside of the integer sized type defined by the system module. Instead, we now ignore this attribute value if the date cannot fit into the appropriately sized integer type.