### PR TITLE
Return early if the component value being added is zero

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -2130,6 +2130,10 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
     func add(_ field: Calendar.Component, to date: Date, amount: Int, inTimeZone timeZone: TimeZone) -> Date {
 
+        guard amount != 0 else {
+            return date
+        }
+
         let ti = date.timeIntervalSinceReferenceDate
         var startingFrac = ti.truncatingRemainder(dividingBy: 1)
         var startingInt = ti - startingFrac

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -987,6 +987,25 @@ final class CalendarTests : XCTestCase {
         XCTAssertEqual(calendarWithCustomLocaleAndCustomMinDays.minimumDaysInFirstWeek, 2)
 
     }
+
+    func test_addingZeroComponents() {
+        var calendar = Calendar(identifier: .gregorian)
+        let timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        calendar.timeZone = timeZone
+
+        // 2021-11-07 08:30:00 GMT, which is 2021-11-07 01:30:00 PDT. Daylight saving time ends 30 minutes after this.
+        let date = Date(timeIntervalSinceReferenceDate: 657966600)
+        let dateComponents = DateComponents(era: 0, year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0)
+        let result = calendar.date(byAdding: dateComponents, to: date)
+        XCTAssertEqual(date, result)
+
+        let allComponents : [Calendar.Component] = [.era, .year, .month, .day, .hour, .minute, .second]
+        for component in allComponents {
+            let res = calendar.date(byAdding: component, value: 0, to: date)
+            XCTAssertEqual(res, date, "component: \(component)")
+        }
+    }
+    
 }
 
 // MARK: - Bridging Tests


### PR DESCRIPTION
When adding month or year to a `Date`, we convert a `Date` to a `DateComponent`, modify the component, and convert the modified `DateComponent` back to `Date`. However for dates falling into the "repeated" time frame on DST end date, we do not have the information of which time the `DateComponent` represents when converting it back to `Date`.
    
This has been the design, and we have always assumed the second occurrence. The only implementation difference is that in the ICU implementation, we return early when the value is 0 and do not proceed onto adding. We should do that for GregorianCalendar too.
    
Resolves 124231654