### PR TITLE
Add bounds check for CommandLine.arguments since it could be empty

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -48,7 +48,12 @@ final class _ProcessInfo: Sendable {
             var current = CommandLine.arguments
             // Replace the process path
             if let fullPath = Platform.getFullExecutablePath() {
-                current[0] = fullPath
+                // Swift's CommandLine.arguments can be empty
+                if current.isEmpty {
+                    current = [fullPath]
+                } else {
+                    current[0] = fullPath
+                }
             }
             $0.arguments = current
             return current


### PR DESCRIPTION
`ProcessInfo.arguments` assumed `CommandLine.arguments` is always non-empty, and that turns out not to be the case 100%. Added bounds check to avoid crashing.