### PR TITLE
Add components in the order of granularity in `date(byAdding:to:)`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -2590,7 +2590,10 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     internal func date(byAddingAndWrapping components: DateComponents, to date: Date) -> Date? {
         let timeZone = components.timeZone ?? self.timeZone
         var result = date
+
         // No leap month support needed here, since these are quantities, not values
+
+        // Add from the largest component to the smallest
         if let amount = components.era {
             result = addAndWrap(.era, to: result, amount: amount, inTimeZone: timeZone) }
         if let amount = components.year {
@@ -2605,12 +2608,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         if let amount = components.month {
             result = addAndWrap(.month, to: result, amount: amount, inTimeZone: timeZone)
         }
-        if let amount = components.day {
-            result = addAndWrap(.day, to: result, amount: amount, inTimeZone: timeZone)
-        }
-        if let amount = components.dayOfYear {
-            result = addAndWrap(.dayOfYear, to: result, amount: amount, inTimeZone: timeZone)
-        }
+
+        // Weeks
         if let amount = components.weekOfYear {
             result = addAndWrap(.weekOfYear, to: result, amount: amount, inTimeZone: timeZone)
         }
@@ -2621,12 +2620,22 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         if let amount = components.weekOfMonth {
             result = addAndWrap(.weekOfMonth, to: result, amount: amount, inTimeZone: timeZone)
         }
-        if let amount = components.weekday {
-            result = addAndWrap(.weekday, to: result, amount: amount, inTimeZone: timeZone)
-        }
         if let amount = components.weekdayOrdinal {
             result = addAndWrap(.weekdayOrdinal, to: result, amount: amount, inTimeZone: timeZone)
         }
+
+        // Days
+        if let amount = components.day {
+            result = addAndWrap(.day, to: result, amount: amount, inTimeZone: timeZone)
+        }
+        if let amount = components.dayOfYear {
+            result = addAndWrap(.dayOfYear, to: result, amount: amount, inTimeZone: timeZone)
+        }
+        if let amount = components.weekday {
+            result = addAndWrap(.weekday, to: result, amount: amount, inTimeZone: timeZone)
+        }
+
+        // Time
         if let amount = components.hour {
             result = addAndWrap(.hour, to: result, amount: amount, inTimeZone: timeZone)
         }
@@ -2645,7 +2654,10 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     internal func date(byAddingAndCarryingOverComponents components: DateComponents, to date: Date) -> Date? {
         let timeZone = components.timeZone ?? self.timeZone
         var result = date
+
         // No leap month support needed here, since these are quantities, not values
+
+        // Add from the largest component to the smallest
         if let amount = components.era {
             result = add(.era, to: result, amount: amount, inTimeZone: timeZone) }
         if let amount = components.year {
@@ -2660,28 +2672,34 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         if let amount = components.month {
             result = add(.month, to: result, amount: amount, inTimeZone: timeZone)
         }
+
+        // Weeks
+        if let amount = components.weekOfYear {
+            result = add(.weekOfYear, to: result, amount: amount, inTimeZone: timeZone)
+        }
+        if let amount = components.weekOfMonth {
+            result = add(.weekOfMonth, to: result, amount: amount, inTimeZone: timeZone)
+        }
+        if let amount = components.weekdayOrdinal {
+            result = add(.weekdayOrdinal, to: result, amount: amount, inTimeZone: timeZone)
+        }
+        // `week` is for backward compatibility only, and is only used if weekOfYear is missing
+        if let amount = components.week, components.weekOfYear == nil {
+            result = add(.weekOfYear, to: result, amount: amount, inTimeZone: timeZone)
+        }
+
+        // Days
         if let amount = components.day {
             result = add(.day, to: result, amount: amount, inTimeZone: timeZone)
         }
         if let amount = components.dayOfYear {
             result = add(.dayOfYear, to: result, amount: amount, inTimeZone: timeZone)
         }
-        if let amount = components.weekOfYear {
-            result = add(.weekOfYear, to: result, amount: amount, inTimeZone: timeZone)
-        }
-        // `week` is for backward compatibility only, and is only used if weekOfYear is missing
-        if let amount = components.week, components.weekOfYear == nil {
-            result = add(.weekOfYear, to: result, amount: amount, inTimeZone: timeZone)
-        }
-        if let amount = components.weekOfMonth {
-            result = add(.weekOfMonth, to: result, amount: amount, inTimeZone: timeZone)
-        }
         if let amount = components.weekday {
             result = add(.weekday, to: result, amount: amount, inTimeZone: timeZone)
         }
-        if let amount = components.weekdayOrdinal {
-            result = add(.weekdayOrdinal, to: result, amount: amount, inTimeZone: timeZone)
-        }
+
+        // Time
         if let amount = components.hour {
             result = add(.hour, to: result, amount: amount, inTimeZone: timeZone)
         }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -2593,7 +2593,9 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
         // No leap month support needed here, since these are quantities, not values
 
-        // Add from the largest component to the smallest
+        // Add from the largest component to the smallest to match the order used in `dateComponents(_:from:to:)` to allow round tripping
+        // The results are the same for most cases regardless of the order except for when the addition moves the date across DST transition.
+        // We aim to maintain the clock time when adding larger-than-day units, so that the time in the day remains unchanged even after time zone changes. However, we cannot hold this promise if the result lands in the "skipped hour" on the DST start date as that time does not actually exist. In this case we adjust the time of the day to the correct timezone. There is always some ambiguity, but matching the order used in `dateComponents(_:from:to:)` at least allows round tripping.
         if let amount = components.era {
             result = addAndWrap(.era, to: result, amount: amount, inTimeZone: timeZone) }
         if let amount = components.year {
@@ -2657,7 +2659,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
 
         // No leap month support needed here, since these are quantities, not values
 
-        // Add from the largest component to the smallest
+        // Add from the largest component to the smallest to match the order used in `dateComponents(_:from:to:)` to allow round tripping
+        // See more discussion in date(byAddingAndWrapping:to:)
         if let amount = components.era {
             result = add(.era, to: result, amount: amount, inTimeZone: timeZone) }
         if let amount = components.year {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1263,7 +1263,9 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
 
             // No leap month support needed here, since these are quantities, not values
 
-            // Add from the largest component to the smallest
+            // Add from the largest component to the smallest to match the order used in `dateComponents(_:from:to:)` to allow round tripping
+            // The results are the same for most cases regardless of the order except for when the addition moves the date across DST transition.
+            // We aim to maintain the clock time when adding larger-than-day units, so that the time in the day remains unchanged even after time zone changes. However, we cannot hold this promise if the result lands in the "skipped hour" on the DST start date as that time does not actually exist. In this case we adjust the time of the day to the correct timezone. There is always some ambiguity, but matching the order used in `dateComponents(_:from:to:)` at least allows round tripping.
             if let amount = components.era { _ = _locked_add(UCAL_ERA, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.year { _ = _locked_add(UCAL_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.yearForWeekOfYear { _ = _locked_add(UCAL_YEAR_WOY, amount: amount, wrap: wrappingComponents, status: &status) }

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1262,20 +1262,27 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
             var nanosecond = 0
 
             // No leap month support needed here, since these are quantities, not values
+
+            // Add from the largest component to the smallest
             if let amount = components.era { _ = _locked_add(UCAL_ERA, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.year { _ = _locked_add(UCAL_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.yearForWeekOfYear { _ = _locked_add(UCAL_YEAR_WOY, amount: amount, wrap: wrappingComponents, status: &status) }
             // TODO: Support quarter
             // if let _ = components.quarter {  }
             if let amount = components.month { _ = _locked_add(UCAL_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
-            if let amount = components.day { _ = _locked_add(UCAL_DAY_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
-            if let amount = components.dayOfYear { _ = _locked_add(UCAL_DAY_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
+
+            // Weeks
             if let amount = components.weekOfYear { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
+            if let amount = components.weekOfMonth { _ = _locked_add(UCAL_WEEK_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
+            if let amount = components.weekdayOrdinal { _ = _locked_add(UCAL_DAY_OF_WEEK_IN_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
             // `week` is for backward compatibility only, and is only used if weekOfYear is missing
             if let amount = components.week, components.weekOfYear == nil { _ = _locked_add(UCAL_WEEK_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
-            if let amount = components.weekOfMonth { _ = _locked_add(UCAL_WEEK_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
+
+            // Days
+            if let amount = components.day { _ = _locked_add(UCAL_DAY_OF_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
+            if let amount = components.dayOfYear { _ = _locked_add(UCAL_DAY_OF_YEAR, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.weekday { _ = _locked_add(UCAL_DAY_OF_WEEK, amount: amount, wrap: wrappingComponents, status: &status) }
-            if let amount = components.weekdayOrdinal { _ = _locked_add(UCAL_DAY_OF_WEEK_IN_MONTH, amount: amount, wrap: wrappingComponents, status: &status) }
+
             if let amount = components.hour { _ = _locked_add(UCAL_HOUR_OF_DAY, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.minute { _ = _locked_add(UCAL_MINUTE, amount: amount, wrap: wrappingComponents, status: &status) }
             if let amount = components.second { _ = _locked_add(UCAL_SECOND, amount: amount, wrap: wrappingComponents, status: &status) }
@@ -1814,6 +1821,7 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
     }
 
     private func _locked_add(_ field: UCalendarDateFields, amount: Int, wrap: Bool, status: inout UErrorCode) -> UDate {
+        let original = ucal_getMillis(ucalendar, &status)
         // we rely on ICU to add and roll units which are larger than or equal to DAYs
         // we have an assumption which is we assume that there is no time zone with a backward repeated day
         // at the time of writing this code, there is only one instance of DST that forwards a day
@@ -1882,6 +1890,7 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
                 dst = ucal_get(ucalendar, UCAL_DST_OFFSET, &status) + ucal_get(ucalendar, UCAL_ZONE_OFFSET, &status)
                 hour = ucal_get(ucalendar, UCAL_HOUR_OF_DAY, &status)
             }
+
 
             var result = ucal_getMillis(ucalendar, &status)
             result += Double(newAmount) * unitLength

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1821,7 +1821,6 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
     }
 
     private func _locked_add(_ field: UCalendarDateFields, amount: Int, wrap: Bool, status: inout UErrorCode) -> UDate {
-        let original = ucal_getMillis(ucalendar, &status)
         // we rely on ICU to add and roll units which are larger than or equal to DAYs
         // we have an assumption which is we assume that there is no time zone with a backward repeated day
         // at the time of writing this code, there is only one instance of DST that forwards a day

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -1892,7 +1892,6 @@ internal final class _CalendarICU: _CalendarProtocol, @unchecked Sendable {
                 hour = ucal_get(ucalendar, UCAL_HOUR_OF_DAY, &status)
             }
 
-
             var result = ucal_getMillis(ucalendar, &status)
             result += Double(newAmount) * unitLength
             result += leftoverTime * 1000.0

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -530,15 +530,16 @@ final class GregorianCalendarTests : XCTestCase {
 
     func testAddDateComponents() {
 
+        let s = Date.ISO8601FormatStyle(timeZone: TimeZone(secondsFromGMT: 3600)!)
         func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: wrap)!
-            XCTAssertEqual(result, expected, file: file, line: line)
+            XCTAssertEqual(result, expected, "actual = \(result.timeIntervalSince1970), \(s.format(result))", file: file, line: line)
         }
 
         var gregorianCalendar: _CalendarGregorian
         gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: 3600)!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 7, gregorianStartDate: nil)
 
-        let march1_1996 = Date(timeIntervalSince1970: 825723300)
+        let march1_1996 = Date(timeIntervalSince1970: 825723300) // 1996-03-01 23:35:00 +0000
         testAdding(.init(day: -1, hour: 1 ), to: march1_1996, wrap: false, expected: Date(timeIntervalSince1970:825640500.0))
         testAdding(.init(month: -1, hour: 1 ), to: march1_1996, wrap: false, expected: Date(timeIntervalSince1970:823221300.0))
         testAdding(.init(month: -1, day: 30 ), to: march1_1996, wrap: false, expected: Date(timeIntervalSince1970:825809700.0))
@@ -554,32 +555,37 @@ final class GregorianCalendarTests : XCTestCase {
         testAdding(.init(month: -1, day: 30 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:823304100.0))
         testAdding(.init(year: 4, day: -1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:951867300.0))
         testAdding(.init(day: -1, hour: 24 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:825636900.0))
-        testAdding(.init(day: -1, weekday: 1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:825723300.0))
-        testAdding(.init(day: -7, weekOfYear: 1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:828401700.0))
-        testAdding(.init(day: -7, weekOfMonth: 1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:825982500.0))
-        testAdding(.init(day: -7, weekOfMonth: 1, weekOfYear: 1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:829006500.0))
+        testAdding(.init(day: -1, weekday: 1), to: march1_1996, wrap: true, expected: march1_1996)
+        testAdding(.init(day: -7, weekOfYear: 1), to: march1_1996, wrap: true, expected: march1_1996)
+        testAdding(.init(day: -7, weekOfMonth: 1), to: march1_1996, wrap: true, expected: march1_1996)
 
-        let oct14_1582 = Date(timeIntervalSince1970: -12218515200.0)
-        testAdding(.init(day: -1, hour: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218598000.0))
-        testAdding(.init(month: -1, hour: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12220239600.0))
-        testAdding(.init(month: -1, day: 30), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12217651200.0))
-        testAdding(.init(year: 4, day: -1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12092371200.0))
-        testAdding(.init(day: -1, hour: 24), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -1, weekday: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfYear: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfMonth: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfMonth: 1, weekOfYear: 1), to: oct14_1582, wrap: false, expected: Date(timeIntervalSince1970:-12217910400.0))
+        let oct24_1582 = Date(timeIntervalSince1970: -12218515200.0) // Expect: 1582-10-24T00:00:00Z
+        testAdding(.init(day: -1, hour: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218598000.0))
+        testAdding(.init(month: -1, hour: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12220239600.0))
+        testAdding(.init(month: -1, day: 30), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12217651200.0))
+        testAdding(.init(year: 4, day: -1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12092371200.0))
+        testAdding(.init(day: -1, hour: 24), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -1, weekday: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -7, weekOfYear: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -7, weekOfMonth: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -7, weekOfMonth: 2), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12217910400.0))
+        testAdding(.init(day: -7, weekOfYear: 2), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12217910400.0))
 
-        testAdding(.init(day: -1, hour: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218598000.0))
-        testAdding(.init(month: -1, hour: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12220239600.0))
-        testAdding(.init(month: -1, day: 30), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12220243200.0))
-        testAdding(.init(year: 4, day: -1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12092371200.0))
-        testAdding(.init(day: -1, hour: 24), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218601600.0))
-        testAdding(.init(day: -1, weekday: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfYear: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfMonth: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
-        testAdding(.init(day: -7, weekOfMonth: 1, weekOfYear: 1), to: oct14_1582, wrap: true, expected: Date(timeIntervalSince1970:-12217910400.0))
+        testAdding(.init(day: -1, hour: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218598000.0))
+        testAdding(.init(month: -1, hour: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12220239600.0))
+        testAdding(.init(month: -1, day: 30), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12220243200.0))
+        testAdding(.init(year: 4, day: -1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12092371200.0))
+        testAdding(.init(day: -1, hour: 24), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218601600.0))
+        testAdding(.init(day: -1, weekday: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -7, weekOfYear: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
+        testAdding(.init(day: -7, weekOfMonth: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12218515200.0))
 
+        testAdding(.init(weekOfMonth: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12217910400.0)) // Expect: 1582-10-31 00:00:00Z
+        testAdding(.init(weekOfYear: 1), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12217910400.0))
+        testAdding(.init(weekOfYear: 2), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12217305600.0)) // Expect: 1582-11-07 00:00:00
+        testAdding(.init(day: -7, weekOfMonth: 2), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12217910400.0)) // Expect: 1582-10-31 00:00:00 +0000
+
+        testAdding(.init(day: -7, weekOfYear: 2), to: oct24_1582, wrap: true, expected: Date(timeIntervalSince1970:-12215318400.0)) // expect: 1582-11-30 00:00:00 - adding 2 weeks is 1582-11-07, adding -7 days wraps around to 1582-11-30
 
         do {
             let firstWeekday = 1
@@ -621,9 +627,10 @@ final class GregorianCalendarTests : XCTestCase {
 
         func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: wrap)!
-            XCTAssertEqual(result, expected, file: file, line: line)
+            XCTAssertEqual(result, expected, "result = \(result.timeIntervalSince1970)" , file: file, line: line)
         }
 
+        // 1996-03-01 23:35:00 UTC, 1996-03-01T15:35:00-0800
         let march1_1996 = Date(timeIntervalSince1970: 825723300)
         testAdding(.init(day: -1, hour: 1), to: march1_1996, wrap: false, expected: Date(timeIntervalSince1970: 825640500.0))
         testAdding(.init(month: -1, hour: 1), to: march1_1996, wrap: false, expected: Date(timeIntervalSince1970: 823221300.0))
@@ -641,9 +648,11 @@ final class GregorianCalendarTests : XCTestCase {
         testAdding(.init(year: 4, day: -1), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 954545700.0))
         testAdding(.init(day: -1, hour: 24), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 828315300.0))
         testAdding(.init(day: -1, weekday: 1), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 827796900.0))
-        testAdding(.init(day: -7, weekOfYear: 1), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 828401700.0))
-        testAdding(.init(day: -7, weekOfMonth: 1), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 825982500.0))
-        testAdding(.init(day: -7, weekOfMonth: 1, weekOfYear: 1), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 829002900.0))
+        testAdding(.init(day: -7, weekOfYear: 1), to: march1_1996, wrap: true, expected: march1_1996)
+        testAdding(.init(day: -7, weekOfMonth: 1), to: march1_1996, wrap: true, expected: march1_1996)
+
+        testAdding(.init(day: -7, weekOfYear: 2), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 826328100.0)) // Expect: 1996-03-08 23:35:00 +0000
+        testAdding(.init(day: -7, weekOfMonth: 2), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970: 826328100.0)) // Expect: 1996-03-08 23:35:00 +0000
     }
 
     func testAddDateComponents_DSTBoundaries() {

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -558,6 +558,7 @@ final class GregorianCalendarTests : XCTestCase {
         testAdding(.init(day: -1, weekday: 1), to: march1_1996, wrap: true, expected: march1_1996)
         testAdding(.init(day: -7, weekOfYear: 1), to: march1_1996, wrap: true, expected: march1_1996)
         testAdding(.init(day: -7, weekOfMonth: 1), to: march1_1996, wrap: true, expected: march1_1996)
+        testAdding(.init(day: -7, weekOfMonth: 1, weekOfYear: 1 ), to: march1_1996, wrap: true, expected: Date(timeIntervalSince1970:826328100.0))
 
         let oct24_1582 = Date(timeIntervalSince1970: -12218515200.0) // Expect: 1582-10-24T00:00:00Z
         testAdding(.init(day: -1, hour: 1), to: oct24_1582, wrap: false, expected: Date(timeIntervalSince1970:-12218598000.0))

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1103,25 +1103,23 @@ final class CalendarTests : XCTestCase {
         c.timeZone = timeZone
 
         let s = Date.ISO8601FormatStyle(timeZone: timeZone)
-        let tests = [
-            // 2024-03-09T02:34:36-0800, 2024-03-17T03:34:36-0700, 10:34:36 UTC
-            (Date(timeIntervalSinceReferenceDate: 731673276), Date(timeIntervalSinceReferenceDate: 732364476)),
-
-            // 2063-03-10T02:27:06-0800, 2063-03-18T03:27:06-0700
-            (Date(timeIntervalSinceReferenceDate: 1962440826), Date(timeIntervalSinceReferenceDate: 1963132026)),
-
-            // 2024-03-08T02:34:36-0800, 2063-03-18T11:27:06-0700
-            (Date(timeIntervalSinceReferenceDate: 731586876.690495), Date(timeIntervalSinceReferenceDate: 1963160826.550588)),
-            
-            // 2024-03-03T02:34:36-0800, 2024-03-11T02:34:36-0700
-            (Date(timeIntervalSinceReferenceDate: 731154876), Date(timeIntervalSinceReferenceDate: 731842476)),
-        ]
-
-        for (start, end) in tests {
+        func test(_ start: Date, _ end: Date) throws {
             let components = try XCTUnwrap(c.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond, .weekOfMonth], from: start, to: end))
             let added = try XCTUnwrap(c.date(byAdding: components, to: start))
             XCTAssertEqual(added, end, "actual: \(s.format(added)), expected: \(s.format(end))")
         }
+
+        // 2024-03-09T02:34:36-0800, 2024-03-17T03:34:36-0700, 10:34:36 UTC
+        try test(Date(timeIntervalSinceReferenceDate: 731673276), Date(timeIntervalSinceReferenceDate: 732364476))
+
+        // 2063-03-10T02:27:06-0800, 2063-03-18T03:27:06-0700
+        try test(Date(timeIntervalSinceReferenceDate: 1962440826), Date(timeIntervalSinceReferenceDate: 1963132026))
+
+        // 2024-03-08T02:34:36-0800, 2063-03-18T11:27:06-0700
+        try test(Date(timeIntervalSinceReferenceDate: 731586876.690495), Date(timeIntervalSinceReferenceDate: 1963160826.550588))
+
+        // 2024-03-03T02:34:36-0800, 2024-03-11T02:34:36-0700
+        try test(Date(timeIntervalSinceReferenceDate: 731154876), Date(timeIntervalSinceReferenceDate: 731842476))
     }
 }
 

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1119,13 +1119,10 @@ final class CalendarTests : XCTestCase {
             (Date(timeIntervalSinceReferenceDate: 731154876), Date(timeIntervalSinceReferenceDate: 731842476)),
         ]
 
-        for test in tests {
-            let a = test.0
-            let b = test.1
-
-            let components = try XCTUnwrap(c.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond, .weekOfMonth], from: a, to: b))
-            let added = try XCTUnwrap(c.date(byAdding: components, to: a))
-            XCTAssertEqual(added, b, "actual: \(s.format(added)), expected: \(s.format(b))")
+        for (start, end) in tests {
+            let components = try XCTUnwrap(c.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond, .weekOfMonth], from: start, to: end))
+            let added = try XCTUnwrap(c.date(byAdding: components, to: start))
+            XCTAssertEqual(added, end, "actual: \(s.format(added)), expected: \(s.format(end))")
         }
     }
 }

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1083,6 +1083,51 @@ final class CalendarTests : XCTestCase {
         }
     }
     
+
+    func test_addingDaysAndWeeks() throws {
+        let timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = timeZone
+
+        let s = Date.ISO8601FormatStyle(timeZone: timeZone)
+        let a = Date(timeIntervalSinceReferenceDate: 731673276) // "2024-03-09T02:34:36-0800", 10:34:36 UTC
+        let d1_w1 = c.date(byAdding: .init(day: 1, weekOfMonth: 1), to: a)!
+        let exp = try Date("2024-03-17T02:34:36-0700", strategy: s)
+        XCTAssertEqual(d1_w1, exp)
+
+        let d8 = c.date(byAdding: .init(day: 8), to: a)!
+        XCTAssertEqual(d8, exp)
+    }
+
+    func test_addingDifferencesRoundtrip() throws {
+        let timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = timeZone
+
+        let s = Date.ISO8601FormatStyle(timeZone: timeZone)
+        let tests = [
+            // 2024-03-09T02:34:36-0800, 2024-03-17T03:34:36-0700, 10:34:36 UTC
+            (Date(timeIntervalSinceReferenceDate: 731673276), Date(timeIntervalSinceReferenceDate: 732364476)),
+
+            // 2063-03-10T02:27:06-0800, 2063-03-18T03:27:06-0700
+            (Date(timeIntervalSinceReferenceDate: 1962440826), Date(timeIntervalSinceReferenceDate: 1963132026)),
+
+            // 2024-03-08T02:34:36-0800, 2063-03-18T11:27:06-0700
+            (Date(timeIntervalSinceReferenceDate: 731586876.690495), Date(timeIntervalSinceReferenceDate: 1963160826.550588)),
+            
+            // 2024-03-03T02:34:36-0800, 2024-03-11T02:34:36-0700
+            (Date(timeIntervalSinceReferenceDate: 731154876), Date(timeIntervalSinceReferenceDate: 731842476)),
+        ]
+
+        for test in tests {
+            let a = test.0
+            let b = test.1
+
+            let components = try XCTUnwrap(c.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond, .weekOfMonth], from: a, to: b))
+            let added = try XCTUnwrap(c.date(byAdding: components, to: a))
+            XCTAssertEqual(added, b, "actual: \(s.format(added)), expected: \(s.format(b))")
+        }
+    }
 }
 
 // MARK: - Bridging Tests

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -1004,8 +1004,6 @@ final class CalendarTests : XCTestCase {
             let date = calendar.date(from: dc)!
             XCTAssertEqual(date, expectation, "expect: \(date.timeIntervalSinceReferenceDate)", file: file, line: line)
         }
-        // Tuesday in the first week of 2000
-        let components_woy = DateComponents(weekday: 3, weekOfYear: 1, yearForWeekOfYear: 2000)
 
         // The first week of year 2000 is Dec 26, 1999...Jan 1, 2000
         test(.init(weekday: 3, weekOfYear: 1, yearForWeekOfYear: 2000), Date(timeIntervalSinceReferenceDate: -31968000.0)) // 1999-12-28


### PR DESCRIPTION
We compute the differences in Calendar component values from the largest to the smallest in `dateComponents(_:from:to:)`, but we are not following the same order in `date(byAdding:to:)`. Change the order of the latter so we add the largest components first.

The results are the same for most cases regardless of the order. The only exception is when the addition moves the date across DST transition. The reason for this is that the implementation aims to maintain the clock time when adding units that are larger than `day` to a date, so that the time in the day remains unchanged even after time zone offset changes. However, we cannot hold this promise if the result lands in the "skipped hour" on the DST start date as that time does not actually exist. To adjust for this case, we adjust the time of the day to the correct timezone.

For example, the DST start of year 2024 in the Los Angeles time zone is 2024-03-10, where 02:00:00-0800 becomes 03:00:00-0700.

Here's what happens when we add 1 day first, then add 1 week, to 2024-03-09T02:34:36-0800, the day before DST start:

We start by adding 1 day:
2024-03-09T02:34:36-0800 + 1 day --> 2024-03-10T02:34:36-0800

This is not a valid date in this time zone, so we adjust it to -0700:
2024-03-10T02:34:36-0800 --> 2024-03-10T03:34:36-0700

Then we add a week, which is 7 days:
2024-03-10T03:34:36-0700 + 7 days -> 2024-03-17T03:34:36-0700

Notice that the local time is different in the result from that of the original, which changes from 02:34 to 03:34.

If we start by adding 1 week:
2024-03-09T02:34:36-0800 + 7 days -> 2024-03-16T02:34:36-0700

Then add a day:
2024-03-16T02:34:36-0700 + 1 day -> 2024-03-17T02:34:36-0700

The local time is the same as that of the original.

We go for the latter to allow round-tripping a date to the date by adding their differences back.

Resolves 124414807
