### PR TITLE
Make `DateAttributedFormatStyleTests.testSettingLocale` time zone independent

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -699,11 +699,14 @@ final class DateAttributedFormatStyleTests : XCTestCase {
             XCTAssertEqual(attributedResult, expected.attributedString, file: file, line: line)
         }
 
-        test(date.formatted(.dateTime.weekday().locale(enUSLocale).attributed), [("Mon", .weekday)])
-        test(date.formatted(.dateTime.weekday().locale(zhTW).attributed), [("週一", .weekday)])
+        var format = Date.FormatStyle.dateTime
+        format.timeZone = .gmt
 
-        test(date.formatted(.dateTime.weekday().attributed.locale(enUSLocale)), [("Mon", .weekday)])
-        test(date.formatted(.dateTime.weekday().attributed.locale(zhTW)),  [("週一", .weekday)])
+        test(date.formatted(format.weekday().locale(enUSLocale).attributed), [("Mon", .weekday)])
+        test(date.formatted(format.weekday().locale(zhTW).attributed), [("週一", .weekday)])
+
+        test(date.formatted(format.weekday().attributed.locale(enUSLocale)), [("Mon", .weekday)])
+        test(date.formatted(format.weekday().attributed.locale(zhTW)),  [("週一", .weekday)])
     }
 
 #if FOUNDATION_FRAMEWORK


### PR DESCRIPTION
In JST (GMT+9) the date will be `2021-04-13 00:04:32`, so the tests would fail.

Kudos to @norio-nomura