### PR TITLE
Avoid copying mutable NSData subclasses when writing

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2419,7 +2419,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
         
 #if !NO_FILESYSTEM
-        try writeDataToFile(path: .url(url), data: self, options: options, reportProgress: true)
+        try writeToFile(path: .url(url), data: self, options: options, reportProgress: true)
 #else
         throw CocoaError(.featureUnsupported)
 #endif
@@ -2432,7 +2432,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             fatalError("withoutOverwriting is not supported with atomic")
         }
         
-        try writeDataToFile(path: .path(path), data: self, options: options, reportProgress: true)
+        try writeToFile(path: .path(path), data: self, options: options, reportProgress: true)
     }
 #endif
 

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -181,7 +181,7 @@ class DataIOTests : XCTestCase {
         // Data doesn't have a direct API to write with attributes, but our I/O code has it. Use it via @testable interface here.
         
         let writeAttrs: [String : Data] = [FileAttributeKey.hfsCreatorCode.rawValue : "abcd".data(using: .ascii)!]
-        try writeDataToFile(path: .url(url), data: writeData, options: [], attributes: writeAttrs)
+        try writeToFile(path: .url(url), data: writeData, options: [], attributes: writeAttrs)
         
         // Verify attributes
         var readAttrs: [String : Data] = [:]


### PR DESCRIPTION
A case I missed when bringing Data writing into Swift -- `NSMutableData` is copied when bridged into `struct Data`. There is no need to do that.

Here I just lower the stack of writing functions to the lowest common denominator, which we used eventually when we call the bare `write` function -- `UnsafeRawBufferPointer`. Explicitly listing the input type of the ObjC function as `NSData` instead of `Data` avoids the bridge itself and allows the Swift code to grab a pointer/size pair.