### PR TITLE
Ensure stable home directory for processes calling seteuid

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -109,16 +109,22 @@ private var _cachedUGIDs: (uid_t, gid_t) = {
 #endif
 
 extension Platform {
-    static func getUGIDs() -> (uid: UInt32, gid: UInt32) {
+    private static var ROOT_USER: UInt32 { 0 }
+    static func getUGIDs(allowEffectiveRootUID: Bool = true) -> (uid: UInt32, gid: UInt32) {
+        var result: (uid: UInt32, gid: UInt32)
         #if canImport(Darwin)
         if _canChangeUIDs {
-            _lookupUGIDs()
+            result = _lookupUGIDs()
         } else {
-            _cachedUGIDs
+            result = _cachedUGIDs
         }
         #else
-        return (uid: geteuid(), gid: getegid())
+        result = (uid: geteuid(), gid: getegid())
         #endif
+        if !allowEffectiveRootUID && result.uid == Self.ROOT_USER {
+            result.uid = getuid()
+        }
+        return result
     }
 }
 

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -121,6 +121,8 @@ extension Platform {
         #else
         result = (uid: geteuid(), gid: getegid())
         #endif
+        // Some callers need to use the real UID in cases where a process has called seteuid(0)
+        // If that is the case for this caller, and the eUID is the root user, return the real UID instead
         if !allowEffectiveRootUID && result.uid == Self.ROOT_USER {
             result.uid = getuid()
         }

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -151,6 +151,8 @@ extension String {
         if let user {
             pass = getpwnam(user)
         } else {
+            // We use the real UID instead of the EUID here when the EUID is the root user (i.e. a process has called seteuid(0))
+            // In this instance, we historically do this to ensure a stable home directory location for processes that call seteuid(0)
             pass = getpwuid(Platform.getUGIDs(allowEffectiveRootUID: false).uid)
         }
         

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -151,7 +151,7 @@ extension String {
         if let user {
             pass = getpwnam(user)
         } else {
-            pass = getpwuid(Platform.getUGIDs().uid)
+            pass = getpwuid(Platform.getUGIDs(allowEffectiveRootUID: false).uid)
         }
         
         if let dir = pass?.pointee.pw_dir {


### PR DESCRIPTION
Historically, Foundation has ensured a stable home directory for processes that call `seteuid` by falling back to `getuid()` when the EUID is the root user. This ensures that processes calling `seteuid(0)` maintain a stable home directory. In order to preserve compatibility with clients expecting this behavior, restore the behavior to the swift implementation.