### PR TITLE
Do not include _CShims from the test project

### DIFF
--- a/Sources/_CShims/include/string_shims.h
+++ b/Sources/_CShims/include/string_shims.h
@@ -38,6 +38,4 @@ INTERNAL double _stringshims_strtod_l(const char * _Nullable restrict nptr, char
 
 INTERNAL float _stringshims_strtof_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
 
-INTERNAL int _stringshims_get_formatted_str_length(double value);
-
 #endif /* CSHIMS_STRING_H */

--- a/Sources/_CShims/string_shims.c
+++ b/Sources/_CShims/string_shims.c
@@ -100,9 +100,3 @@ float _stringshims_strtof_l(const char * _Nullable restrict nptr,
     return result;
 #endif
 }
-
-int _stringshims_get_formatted_str_length(double value)
-{
-    char empty[1];
-    return snprintf(empty, 0, "%0.*g", DBL_DECIMAL_DIG, value);
-}


### PR DESCRIPTION
The module is internal to Foundation's implementation only. In addition, the call site for it was a disabled test.