### PR TITLE
`Calendar.startOfDay(for:)` preformance regression

### DIFF
--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -420,8 +420,12 @@ struct LocaleCache : Sendable {
     }
 
     func localeWithPreferences(identifier: String, prefs: LocalePreferences?) -> Locale {
-        let inner = LocaleCache.localeICUClass.init(identifier: identifier, prefs: prefs)
-        return Locale(inner: inner)
+        if let prefs {
+            let inner = LocaleCache.localeICUClass.init(identifier: identifier, prefs: prefs)
+            return Locale(inner: inner)
+        } else {
+            return Locale(inner: LocaleCache.cache.fixed(identifier))
+        }
     }
 
     func localeAsIfCurrentWithBundleLocalizations(_ availableLocalizations: [String], allowsMixedLocalizations: Bool) -> Locale? {

--- a/Tests/FoundationInternationalizationTests/CalendarTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarTests.swift
@@ -80,6 +80,14 @@ final class CalendarTests : XCTestCase {
         Calendar(identifier: .islamicUmmAlQura)
     ]
 
+    func test_localeIsCached() {
+        let c = Calendar(identifier: .gregorian)
+
+        let defaultLocale = Locale(identifier: "")
+        XCTAssertEqual(c.locale, defaultLocale)
+        XCTAssertIdentical(c.locale?._locale, defaultLocale._locale)
+    }
+
     func test_copyOnWrite() {
         var c = Calendar(identifier: .gregorian)
         let c2 = c


### PR DESCRIPTION
We re-construct a `Locale` everytime `calendar.locale` getter is called with `Locale(identifier:preferences:)`. When `preferences == nil`, this "preference-carried" `Locale` should behave exactly the same as a "fixed" locale.

Since we cache all fixed locale by their identifiers already, we should just return one from the cache instead of creating a brand new one. This allows us to reuse all precomputed values and avoid having to call into ICU repeatedly.

124868926