### PR TITLE
attributesForItem(atPath:) uses FileAttributeType instead of String

### DIFF
--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -216,6 +216,7 @@ public typealias ComparisonResult = FoundationEssentials.ComparisonResult
 
 public typealias FileManager = FoundationEssentials.FileManager
 public typealias FileAttributeKey = FoundationEssentials.FileAttributeKey
+public typealias FileAttributeType = FoundationEssentials.FileAttributeType
 public typealias CocoaError = FoundationEssentials.CocoaError
 public typealias POSIXError = FoundationEssentials.POSIXError
 public typealias FileManagerDelegate = FoundationEssentials.FileManagerDelegate

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -643,7 +643,12 @@ final class FileManagerTests : XCTestCase {
             #if FOUNDATION_FRAMEWORK
             // Where we have NSNumber, ensure that we can get the value back as an unconventional Double value
             XCTAssertEqual(attributes[.posixPermissions] as? Double, Double(0o644))
+            // Ensure that the file type can be converted to a String when it is an ObjC enum
+            XCTAssertEqual(attributes[.type] as? String, FileAttributeType.typeRegular.rawValue)
             #endif
+            // Ensure that the file type can be converted to a FileAttributeType when it is an ObjC enum and in swift-foundation
+            XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeRegular)
+            
         }
     }
     


### PR DESCRIPTION
Previously when `attributesForItem(atPath:)` was written in Objective-C, the effective type of the value for the `.type` key was an `NSString`. In Swift, we added it to the dictionary as a `FileAttributeType` but to preserve compatibility with clients relying on `NSString` to `String` casting (ex. `attributesForItem(atPath: ...)[.type] as? String`) we will store the value as an `NSString` instead where `NSString` is available (in non-`FOUNDATION_FRAMEWORK` we continue storing it as a `FileAttributeType` since this promotes the best Swift interface rather than storing the raw value as a `String`)