### PR TITLE
`_SearchPaths` doesn't correctly mask invalid domains

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SearchPaths.swift
@@ -40,11 +40,27 @@ extension FileManager.SearchPathDomainMask {
     static var _partitionedSystemDomainMask: Self {
         Self(rawValue: NSSearchPathDomainMask_Private.partitionedSystemDomainMask.rawValue)
     }
+    
+    static var _appCryptexDomainMask: Self {
+        Self(rawValue: NSSearchPathDomainMask_Private.appCryptexDomainMask.rawValue)
+    }
+    
+    static var _osCryptexDomainMask: Self {
+        Self(rawValue: NSSearchPathDomainMask_Private.osCryptexDomainMask.rawValue)
+    }
     #endif
     
     fileprivate var firstMask: Self? {
         guard !self.isEmpty else { return nil }
         return Self(rawValue: 1 << self.rawValue.trailingZeroBitCount)
+    }
+    
+    fileprivate static var valid: Self {
+        #if FOUNDATION_FRAMEWORK
+        [.userDomainMask, .localDomainMask, .networkDomainMask, .systemDomainMask, ._appCryptexDomainMask, ._osCryptexDomainMask]
+        #else
+        [.userDomainMask, .localDomainMask, .networkDomainMask, .systemDomainMask]
+        #endif
     }
 }
 
@@ -207,7 +223,7 @@ extension String {
 #endif
 
 func _SearchPaths(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, expandTilde: Bool) -> some Sequence<String> {
-    let basic = _SearchPathsSequence(directory: directory, domainMask: domain).lazy.map {
+    let basic = _SearchPathsSequence(directory: directory, domainMask: domain.intersection(.valid)).lazy.map {
         if expandTilde {
             return $0.expandingTildeInPath
         } else {


### PR DESCRIPTION
The previous ObjC implementation masked the provided domains to a list of known, valid, public domains. For clients providing the "all domains" value, the new swift implementation doesn't appropriately drop bit values for domains not in this masking list resulting in unexpected behavior. This PR adds the masking behavior to the new Swift implementation