### PR TITLE
Update FoundationICU to fix broken unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
             from: "1.1.0"),
         .package(
             url: "https://github.com/apple/swift-foundation-icu",
-            exact: "0.0.5"),
+            revision: "40b9706c92a690e94424a711e6bb45b3dc8e9628"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
             from: "509.0.2")


### PR DESCRIPTION
Many of `FoundationInternationalization`'s unit tests are failing and we traced it down to an issue in ICU (not *caused by* ICU... see https://github.com/apple/swift-foundation-icu/pull/19 for details). Pin `swift-foundation-icu` to this specific commit until we tag a new version (likely after ICU 74 upgrade).  