### PR TITLE
Add `Calendar.RecurrenceRule`

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -1059,7 +1059,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     }
 
     /// A hint to the search algorithm to control the method used for searching for dates.
-    public enum MatchingPolicy : Sendable {
+    public enum MatchingPolicy : Sendable, Equatable {
         /// If there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the algorithm will return the next existing time which exists.
         ///
         /// For example, during a daylight saving transition there may be no 2:37am. The result would then be 3:00am, if that does exist.
@@ -1477,6 +1477,39 @@ package struct WeekendRange: Equatable, Hashable {
     }
 }
 
+@available(FoundationPreview 0.4, *)
+extension Calendar.MatchingPolicy: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(Int.self) {
+        case 0:
+            self = .nextTime
+        case 1:
+            self = .nextTimePreservingSmallerComponents
+        case 2:
+            self = .previousTimePreservingSmallerComponents
+        case 3:
+            self = .strict
+        default: 
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unknown MatchingPolicy"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .nextTime:
+            try container.encode(0)
+        case .nextTimePreservingSmallerComponents:
+            try container.encode(1)
+        case .previousTimePreservingSmallerComponents:
+            try container.encode(2)
+        case .strict:
+            try container.encode(3)
+        }
+    }
+}
+
 // MARK: - Bridging
 #if FOUNDATION_FRAMEWORK
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
@@ -1518,4 +1551,5 @@ extension NSCalendar : _HasCustomAnyHashableRepresentation {
         return AnyHashable(self as Calendar)
     }
 }
+
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
+++ b/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
@@ -1,0 +1,428 @@
+extension Calendar {
+    /// A rule which specifies how often an event should repeat in the future
+    @available(FoundationPreview 0.4, *)
+    public struct RecurrenceRule: Sendable, Equatable {
+        /// The calendar in which the recurrence occurs
+        public var calendar: Calendar
+        /// What to do when a recurrence is not a valid date
+        ///
+        /// An occurrence may not be a valid date if it falls on a leap day or a
+        /// leap hour when there is not one. When that happens, we can choose to
+        /// ignore the occurrence (`.strict`), choose a later time which has the
+        /// same components (`.nextTimePreservingSmallerComponents`), or find an
+        /// earlier time (`.previousTimePreservingSmallerComponents`).
+        ///
+        /// For example, consider an event happening every year, starting on the
+        /// 29th of February 2020. When the matching policy is set to `.strict`,
+        /// it yields the following recurrences:
+        /// - 2020-02-29
+        /// - 2024-02-29
+        /// - 2028-02-29
+        /// - ...
+        ///
+        /// With `matchingPolicy` of `.previousTimePreservingSmallerComponents`,
+        /// we get a result for each year:
+        /// - 2020-02-29
+        /// - 2021-02-28
+        /// - 2022-02-28
+        /// - 2023-02-28
+        /// - 2024-02-29
+        ///
+        /// Lastly, a `matchingPolicy` of `.nextTimePreservingSmallerComponents`
+        /// moves invalid occurrences to the day after February 29:
+        /// - 2020-02-29
+        /// - 2021-03-01
+        /// - 2022-03-01
+        /// - 2023-03-01
+        /// - 2024-02-29
+        ///
+        /// The same logic applies for missing leap hours during daylight saving
+        /// time switches. For example, consider an event repeating daily, which
+        /// starts at March 9 2024, 01:30 PST. With a `.strict` matching policy,
+        /// the event repeats on the following dates, and skips a day:
+        /// - 2024-03-09 01:30 PST (09:30 UTC)
+        ///   (on 2024-03-10, there is a missing hour between 1am and 2am)
+        /// - 2024-03-11 01:30 PDT (08:30 UTC)
+        /// - 2024-03-12 01:30 PDT (08:30 UTC)
+        /// With `matchingPolicy` of `.previousTimePreservingSmallerComponents`,
+        /// we get a result for each day:
+        /// - 2024-03-09 01:30 PST (09:30 UTC)
+        /// - 2024-03-10 02:30 PST (10:30 UTC)
+        ///   (on 2024-03-10, there is a missing hour between 1am and 2am)
+        /// - 2024-03-11 01:30 PDT (08:30 UTC)
+        /// - 2024-03-12 01:30 PDT (08:30 UTC)
+        /// Lastly, a `matchingPolicy` of `.nextTimePreservingSmallerComponents`
+        /// moves invalid occurrences an hour forward:
+        /// - 2024-03-09 01:30 PST (09:30 UTC)
+        /// - 2024-03-10 00:30 PST (08:30 UTC)
+        ///   (on 2024-03-10, there is a missing hour between 1am and 2am)
+        /// - 2024-03-11 01:30 PDT (08:30 UTC)
+        /// - 2024-03-12 01:30 PDT (08:30 UTC)
+        ///
+        /// Default value is `.nextTimePreservingSmallerComponents`
+        public var matchingPolicy: Calendar.MatchingPolicy
+        /// Which dates to consider when two dates occur at the same time during
+        /// the day, but in different time zones due to a daylight saving switch
+        public enum RepeatedTimePolicy: Int, Codable, Sendable, Equatable {
+            /// Consider only the earlier date
+            case onlyFirst = 1
+            /// Consider only the later date
+            case onlyLast = 2
+            /// Consider both dates
+            case both = 3
+        }
+        /// What to do when there are multiple recurrences occurring at the same
+        /// time of the day but in different time zones due to a daylight saving
+        /// transition.
+        ///
+        /// For example, an event with daily recurrence rule that starts at 1 am
+        /// on November 2 in PDT will repeat on:
+        ///
+        /// - 2024-11-02 01:00 PDT (08:00 UTC)
+        /// - 2024-11-03 01:00 PDT (08:00 UTC)
+        ///   (Time zone switches from PST to PDT - clock jumps back one hour at
+        ///    02:00 PDT)
+        /// - 2024-11-03 01:00 PST (09:00 UTC)
+        /// - 2024-11-04 01:00 PST (09:00 UTC)
+        ///
+        /// Due to the time zone switch on November 3, there are different times
+        /// when the event might repeat.
+        ///
+        /// Default value is `.onlyFirst`
+        public var repeatedTimePolicy: RepeatedTimePolicy
+        /// How often a recurring event repeats
+        public enum Frequency: Int, Sendable, Codable, Equatable {
+            case minutely = 1
+            case hourly = 2
+            case daily = 3
+            case weekly = 4
+            case monthly = 5
+            case yearly = 6
+        }
+        /// How often the event repeats
+        public var frequency: Frequency
+        /// At what interval to repeat
+        ///
+        /// Default value is `1`
+        public var interval: Int
+        /// When a recurring event stops recurring
+        public struct End: Sendable, Equatable {
+            internal enum _End: Equatable {
+                case never
+                case afterDate(Date)
+                case afterOccurrences(Int)
+            }
+            var _guts: _End
+            internal init(_guts: _End) {
+                self._guts = _guts
+            }
+            /// The event stops repeating after a given number of times
+            /// - Parameter count: how many times to repeat the event, including
+            ///                    the first occurrence. `count` must be greater
+            ///                    than `0`
+            public static func afterOccurrences(_ count: Int) -> Self {
+                .init(_guts: .afterOccurrences(count))
+            }
+            /// The event stops repeating after a given date
+            /// - Parameter date: the date on which the event may last occur. No
+            ///                   further occurrences will be found after that
+            public static func afterDate(_ date: Date) -> Self {
+                .init(_guts: .afterDate(date))
+            }
+            /// The event repeats indefinitely
+            public static var never: Self {
+                .init(_guts: .never)
+            }
+        }
+        /// For how long the event repeats
+        ///
+        /// Default value is `.never`
+        public var end: End
+        
+        public enum Weekday: Sendable, Equatable {
+            /// Repeat on every weekday
+            case every(Locale.Weekday)
+            /// Repeat on the n-th instance of the specified weekday in a month,
+            /// if the recurrence has a monthly frequency. If the recurrence has
+            /// a yearly frequency, repeat on the n-th week of the year.
+            ///
+            /// If n is negative, repeat on the n-to-last of the given weekday.
+            case nth(Int, Locale.Weekday)
+        }
+        
+        /// Uniquely identifies a month in any calendar system
+        public struct Month: Sendable, ExpressibleByIntegerLiteral, Equatable {
+            public typealias IntegerLiteralType = Int
+            
+            public var index: Int
+            public var isLeap: Bool
+            
+            public init(_ index: Int, isLeap: Bool = false) {
+                self.index = index
+                self.isLeap = isLeap
+            }
+            
+            public init(integerLiteral value: Int) {
+                self.index = value
+                self.isLeap = false
+            }
+        }
+        
+        /// On which seconds of the minute the event should repeat. Valid values
+        /// between 0 and 60
+        public var seconds: [Int]
+        /// On which minutes of the hour the event should repeat. Accepts values
+        /// between 0 and 59
+        public var minutes: [Int]
+        /// On which hours of a 24-hour day the event should repeat.
+        public var hours: [Int]
+        /// On which days of the week the event should occur
+        public var weekdays: [Weekday]
+        /// On which days in the month the event should occur
+        /// - 1 signifies the first day of the month.
+        /// - Negative values point to a day counted backwards from the last day
+        ///   of the month
+        /// This field is unused when `frequency` is `.weekly`.
+        public var daysOfTheMonth: [Int]
+        /// On which days of the year the event may occur.
+        /// - 1 signifies the first day of the year.
+        /// - Negative values point to a day counted backwards from the last day
+        ///   of the year
+        /// This field is unused when `frequency` is any of `.daily`, `.weekly`,
+        /// or `.monthly`.
+        public var daysOfTheYear: [Int]
+        /// On which months the event should occur.
+        /// - 1 is the first month of the year (January in Gregorian calendars)
+        public var months: [Month]
+        /// On which weeks of the year the event should occur.
+        /// - 1 is the first week of the year. `calendar.minimumDaysInFirstWeek`
+        ///   defines which week is considered first.
+        /// - Negative values refer to weeks if counting backwards from the last
+        ///   week of the year. -1 is the last week of the year.
+        /// This field is unused when `frequency` is other than `.yearly`.
+        public var weeks: [Int]
+        /// Which occurrences within every interval should be returned
+        public var setPositions: [Int]
+        
+        public init(calendar: Calendar,
+                    frequency: Frequency,
+                    interval: Int = 1,
+                    end: End = .never,
+                    matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents,
+                    repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst,
+                    months: [Month] = [],
+                    daysOfTheYear: [Int] = [],
+                    daysOfTheMonth: [Int] = [],
+                    weeks: [Int] = [],
+                    weekdays: [Weekday] = [],
+                    hours: [Int] = [],
+                    minutes: [Int] = [],
+                    seconds: [Int] = [],
+                    setPositions: [Int] = []) {
+            self.calendar = calendar
+            self.frequency = frequency
+            self.interval = interval
+            self.end = end
+            self.matchingPolicy = matchingPolicy
+            self.repeatedTimePolicy = repeatedTimePolicy
+            self.months = months
+            self.daysOfTheYear = daysOfTheYear
+            self.daysOfTheMonth = daysOfTheMonth
+            self.weeks = weeks
+            self.weekdays = weekdays
+            self.hours = hours
+            self.minutes = minutes
+            self.seconds = seconds
+            self.setPositions = setPositions
+        }
+        
+        
+        /// Find recurrences of the given date
+        ///
+        /// The calculations are implemented according to RFC-5545 and RFC-7529.
+        ///
+        /// - Parameter start: the date which defines the starting point for the
+        ///   recurrence rule.
+        /// - Parameter range: a range of dates which to search for recurrences.
+        ///   If `nil`, return all recurrences of the event.
+        /// - Returns: a sequence of dates conforming to the recurrence rule, in
+        ///   the given `range`. An empty sequence if the rule doesn't match any
+        ///   dates.
+        /* public */ private func recurrences(of start: Date,
+                                in range: Range<Date>? = nil
+        ) -> some (Sequence<Date> & Sendable) {
+            // To be implemented in rdar://123337748 (Enumerate recurrences in Calendar.RecurrenceRule)
+            fatalError("Not implemented")
+            return []
+        }
+        
+        /// A recurrence that repeats every `interval` minutes
+        public static func minutely(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], daysOfTheYear: [Int] = [], daysOfTheMonth: [Int] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self {
+            .init(calendar: calendar, frequency: .minutely, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, daysOfTheYear: daysOfTheYear, daysOfTheMonth: daysOfTheMonth, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+        /// A recurrence that repeats every `interval` hours
+        public static func hourly(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], daysOfTheYear: [Int] = [], daysOfTheMonth: [Int] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self {
+            .init(calendar: calendar, frequency: .hourly, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, daysOfTheYear: daysOfTheYear, daysOfTheMonth: daysOfTheMonth, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+        /// A recurrence that repeats every `interval` days
+        public static func daily(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], daysOfTheMonth: [Int] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self {
+            .init(calendar: calendar, frequency: .daily, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, daysOfTheMonth: daysOfTheMonth, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+        /// A recurrence that repeats every `interval` weeks
+        public static func weekly(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self {
+            .init(calendar: calendar, frequency: .weekly, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+        /// A recurrence that repeats every `interval` months
+        public static func monthly(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], daysOfTheMonth: [Int] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self {
+            .init(calendar: calendar, frequency: .monthly, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, daysOfTheMonth: daysOfTheMonth, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+        /// A recurrence that repeats every `interval` years
+        public static func yearly(calendar: Calendar, interval: Int = 1, end: End = .never, matchingPolicy: Calendar.MatchingPolicy = .nextTimePreservingSmallerComponents, repeatedTimePolicy: RepeatedTimePolicy = .onlyFirst, months: [Month] = [], daysOfTheYear: [Int] = [], daysOfTheMonth: [Int] = [], weeks: [Int] = [], weekdays: [Weekday] = [], hours: [Int] = [], minutes: [Int] = [], seconds: [Int] = [], setPositions: [Int] = []) -> Self{
+            .init(calendar: calendar, frequency: .yearly, interval: interval, end: end, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, months: months, daysOfTheYear: daysOfTheYear, daysOfTheMonth: daysOfTheMonth, weeks: weeks, weekdays: weekdays, hours: hours, minutes: minutes, seconds: seconds, setPositions: setPositions)
+        }
+    }
+}
+
+@available(FoundationPreview 0.4, *)
+extension Calendar.RecurrenceRule.End: Codable {
+    enum CodingKeys: String, CodingKey {
+        case count
+        case until
+    }
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let date = try container.decodeIfPresent(Date.self, forKey: .until) {
+            self._guts = .afterDate(date) 
+        } else if let count = try container.decodeIfPresent(Int.self,forKey: .count) {
+            self._guts = .afterOccurrences(count) 
+        } else {
+            self._guts = .never
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self._guts {
+            case let .afterDate(date):
+            try container.encode(date, forKey: .until)
+            case let .afterOccurrences(count):
+            try container.encode(count, forKey: .count)
+            case .never:
+            () // An empty object implies .never
+        }
+    }
+}
+@available(FoundationPreview 0.4, *)
+extension Calendar.RecurrenceRule.Weekday: Codable {
+    enum CodingKeys: String, CodingKey {
+        case weekday
+        case n
+    }
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let weekday = try container.decode(Locale.Weekday.self,forKey: .weekday)
+        if let n = try container.decodeIfPresent(Int.self,forKey: .n) {
+            self = .nth(n, weekday)
+        } else {
+            self = .every(weekday)
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+            case let .nth(n, weekday):
+            try container.encode(n, forKey: .n)
+            try container.encode(weekday, forKey: .weekday)
+            case let .every(weekday):
+            try container.encode(weekday, forKey: .weekday)
+        }
+    }
+}
+@available(FoundationPreview 0.4, *)
+extension Calendar.RecurrenceRule.Month: Codable {
+    enum CodingKeys: String, CodingKey {
+        case month
+        case leap
+    }
+    public init(from decoder: any Decoder) throws {
+        // Most months are not leap months, so we can save some space if we only
+        // serialize the month number when it's not a leap month
+        if let month = try? decoder.singleValueContainer().decode(Int.self) {
+            self.index = month
+            self.isLeap = false
+        } else {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.index = try container.decode(Int.self, forKey: .month)
+            self.isLeap = try container.decode(Bool.self, forKey: .leap)
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        if isLeap {
+            var container = encoder.container(keyedBy: CodingKeys.self) 
+            try container.encode(self.index, forKey: .month)
+            try container.encode(self.isLeap, forKey: .leap)
+        } else {
+            var container = encoder.singleValueContainer()
+            try container.encode(self.index)
+        }
+    }
+}
+@available(FoundationPreview 0.4, *)
+extension Calendar.RecurrenceRule: Codable {
+    enum CodingKeys: String, CodingKey {
+        case calendar
+        case frequency
+        case interval
+        case end
+        case matchingPolicy
+        case repeatedTimePolicy
+        case months
+        case daysOfTheYear
+        case daysOfTheMonth
+        case weeks
+        case weekdays
+        case hours
+        case minutes
+        case seconds
+        case setPositions
+    }
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.calendar = try container.decode(Calendar.self, forKey: .calendar) 
+        self.frequency = try container.decode(Frequency.self, forKey: .frequency) 
+        self.interval = try container.decode(Int.self, forKey: .interval) 
+        self.end = try container.decode(End.self, forKey: .end) 
+        self.matchingPolicy = try container.decode(Calendar.MatchingPolicy.self, forKey: .matchingPolicy) 
+        self.repeatedTimePolicy = try container.decode(RepeatedTimePolicy.self, forKey: .repeatedTimePolicy) 
+        
+        self.months       = try container.decode([Month].self, forKey: .months)
+        self.daysOfTheYear  = try container.decode([Int].self, forKey: .daysOfTheYear)
+        self.daysOfTheMonth = try container.decode([Int].self, forKey: .daysOfTheMonth)
+        self.weeks          = try container.decode([Int].self, forKey: .weeks)
+        self.weekdays       = try container.decode([Weekday].self, forKey: .weekdays)
+        
+        self.seconds = try container.decode([Int].self, forKey: .seconds)
+        self.minutes = try container.decode([Int].self, forKey: .minutes)
+        self.hours   = try container.decode([Int].self, forKey: .hours)
+        self.setPositions = try container.decode([Int].self, forKey: .setPositions)
+    } 
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(calendar, forKey: .calendar)
+        try container.encode(frequency, forKey: .frequency)
+        try container.encode(interval, forKey: .interval)
+        try container.encode(end, forKey: .end)
+        try container.encode(matchingPolicy, forKey: .matchingPolicy)
+        try container.encode(repeatedTimePolicy, forKey: .repeatedTimePolicy)
+        try container.encode(months, forKey: .months)
+        try container.encode(daysOfTheYear, forKey: .daysOfTheYear)
+        try container.encode(daysOfTheMonth, forKey: .daysOfTheMonth)
+        try container.encode(weeks, forKey: .weeks)
+        try container.encode(weekdays, forKey: .weekdays)
+        try container.encode(hours, forKey: .hours)
+        try container.encode(minutes, forKey: .minutes)
+        try container.encode(seconds, forKey: .seconds)
+        try container.encode(setPositions, forKey: .setPositions)
+    }
+}

--- a/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
+++ b/Tests/FoundationInternationalizationTests/CalendarRecurrenceRuleTests.swift
@@ -1,0 +1,54 @@
+//
+//  CalendarRecurrenceRuleTests.swift
+//  Unit
+//
+//  Copyright (c) 2024, Apple Inc.
+//  All rights reserved.
+//
+
+#if canImport(TestSupport)
+import TestSupport
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@testable import Foundation
+#else
+@testable import FoundationInternationalization
+@testable import FoundationEssentials
+#endif // FOUNDATION_FRAMEWORK
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
+final class CalendarRecurrenceRuleTests: XCTestCase {
+
+    func testRoundtripEncoding() throws {
+        // These are not necessarily valid recurrence rule, they are constructed
+        // in a way to test all encoding paths
+        var recurrenceRule1 = Calendar.RecurrenceRule(calendar: .current, frequency: .daily)
+        recurrenceRule1.interval = 2
+        recurrenceRule1.months = [1, 2, Calendar.RecurrenceRule.Month(4, isLeap: true)]
+        recurrenceRule1.weeks = [2, 3]
+        recurrenceRule1.weekdays = [.every(.monday), .nth(1, .wednesday)]
+        recurrenceRule1.end = .afterOccurrences(5)
+        
+        var recurrenceRule2 = Calendar.RecurrenceRule(calendar: .init(identifier: .gregorian), frequency: .daily)
+        recurrenceRule2.months = [2, 10]
+        recurrenceRule2.weeks = [1, -1]
+        recurrenceRule2.setPositions = [1]
+        recurrenceRule2.hours = [14]
+        recurrenceRule2.minutes = [30]
+        recurrenceRule2.seconds = [0]
+        recurrenceRule2.daysOfTheYear = [1]
+        recurrenceRule2.daysOfTheMonth = [4]
+        recurrenceRule2.weekdays = [.every(.monday), .nth(1, .wednesday)]
+        recurrenceRule2.end = .afterDate(.distantFuture)
+        
+        let recurrenceRule1JSON = try JSONEncoder().encode(recurrenceRule1)
+        let recurrenceRule2JSON = try JSONEncoder().encode(recurrenceRule2)
+        let decoded1 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule1JSON)
+        let decoded2 = try JSONDecoder().decode(Calendar.RecurrenceRule.self, from: recurrenceRule2JSON)
+        
+        XCTAssertEqual(recurrenceRule1, decoded1)
+        XCTAssertEqual(recurrenceRule2, decoded2)
+        XCTAssertNotEqual(recurrenceRule1, recurrenceRule2)
+    }
+}


### PR DESCRIPTION
This commit adds the new `Calendar.RecurrenceRule` struct that was introduced in
SF-0009. It doesn't implement enumeration of recurrences, that will be done in a
separate commit. Resolves rdar://120559017.