### PR TITLE
Update swift-syntax dependency to 510.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
             revision: "40b9706c92a690e94424a711e6bb45b3dc8e9628"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.2")
+            from: "510.0.0")
     ],
     targets: [
         // Foundation (umbrella)

--- a/Sources/FoundationMacros/PredicateMacro.swift
+++ b/Sources/FoundationMacros/PredicateMacro.swift
@@ -1170,11 +1170,11 @@ private enum ExpansionKind {
 private func predicateExpansion(of node: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext, kind: ExpansionKind) throws -> ExprSyntax {
     guard let closure = node.trailingClosure else {
         let fixIts: [FixIt]
-        if let argument = node.argumentList.first?.expression.as(ClosureExprSyntax.self) {
+        if let argument = node.arguments.first?.expression.as(ClosureExprSyntax.self) {
             var newNode = node.with(\.leftParen, nil)
                 .with(\.rightParen, nil)
                 .with(\.trailingClosure, argument.with(\.leadingTrivia, [.spaces(1)]).with(\.trailingTrivia, []))
-            newNode.argumentList = []
+            newNode.arguments = []
             fixIts = [
                 FixIt(message: PredicateExpansionDiagnostic("Use a trailing closure instead of a function parameter", severity: .note), changes: [
                     .replace(oldNode: Syntax(node), newNode: Syntax(newNode))


### PR DESCRIPTION
This updates our dependency on swift-syntax to 510.0.0 now that Swift 5.10 has been released. The code change is due to a new deprecation warning on `argumentsList` which was replaced by `arguments` in SwiftSyntax 510.