### PR TITLE
Calendar.dateComponents(:) performance issues

### DIFF
--- a/Benchmarks/Benchmarks/Calendar/Calendar.swift
+++ b/Benchmarks/Benchmarks/Calendar/Calendar.swift
@@ -28,6 +28,7 @@ let benchmarks = {
     
     let thanksgivingComponents = DateComponents(month: 11, weekday: 5, weekOfMonth: 4)
     let cal = Calendar(identifier: .gregorian)
+    let currentCalendar = Calendar.current
     let thanksgivingStart = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
     
     Benchmark("nextThousandThanksgivings") { benchmark in
@@ -39,7 +40,18 @@ let benchmarks = {
             }
         }
     }
-    
+
+    Benchmark("CurrentDateComponentsFromThanksgivings") { benchmark in
+        var count = 1000
+        currentCalendar.enumerateDates(startingAfter: thanksgivingStart, matching: thanksgivingComponents, matchingPolicy: .nextTime) { result, exactMatch, stop in
+            count -= 1
+            _ = currentCalendar.dateComponents([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .calendar, .timeZone], from: result!)
+            if count == 0 {
+                stop = true
+            }
+        }
+    }
+
     let reference = Date(timeIntervalSinceReferenceDate: 496359355.795410) //2016-09-23T14:35:55-0700
     
     Benchmark("allocationsForFixedCalendars", configuration: .init(scalingFactor: .mega)) { benchmark in

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -360,7 +360,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     /// The locale of the calendar.
     public var locale : Locale? {
         get {
-            _calendar.locale
+            _calendar.locale ?? Locale(identifier: "")
         }
         set {
             guard newValue != _calendar.locale else {

--- a/Sources/FoundationEssentials/Calendar/Calendar_Autoupdating.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Autoupdating.swift
@@ -22,10 +22,6 @@ internal final class _CalendarAutoupdating: _CalendarProtocol, @unchecked Sendab
         CalendarCache.cache.current.identifier
     }
     
-    var localeIdentifier: String {
-        CalendarCache.cache.current.localeIdentifier
-    }
-    
     var debugDescription: String {
         "autoupdating \(identifier)"
     }

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -198,14 +198,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
             self.gregorianStartDate = Date(timeIntervalSince1970: -12219292800) // 1582-10-15T00:00:00Z
         }
 
-        // We do not store the Locale here, as Locale stores a Calendar. We only keep the values we need that affect Calendar's operation.
-        if let locale {
-            localeIdentifier = locale.identifier
-            localePrefs = locale.prefs
-        } else {
-            localeIdentifier = ""
-            localePrefs = nil
-        }
+        self.locale = locale
 
         if let firstWeekday, (firstWeekday >= 1 && firstWeekday <= 7) {
             _firstWeekday = firstWeekday
@@ -224,20 +217,8 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
     var identifier: Calendar.Identifier {
         .gregorian
     }
-    // Custom user preferences of any locale used (current locale or current locale imitation only). We need to store this to correctly rebuild a Locale that has been stored inside Calendar as an identifier.
-    private var localePrefs: LocalePreferences?
 
-    var locale: Locale? {
-        get {
-            Locale(identifier: localeIdentifier, preferences: localePrefs)
-        }
-        set {
-            localeIdentifier = newValue?.identifier ?? ""
-            localePrefs = newValue?.prefs
-        }
-    }
-
-    var localeIdentifier: String
+    var locale: Locale?
 
     var timeZone: TimeZone
 
@@ -275,6 +256,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
             if let _minimumDaysInFirstWeek {
                 return _minimumDaysInFirstWeek
             } else if let locale {
+                // Do not call into `locale` if the value is straightforward
                 return locale.minimumDaysInFirstWeek
             } else {
                 return 1
@@ -920,7 +902,7 @@ internal final class _CalendarGregorian: _CalendarProtocol, @unchecked Sendable 
         } catch {
             preconditionFailure("Unrecognized calendar error")
         }
-        
+
         return result
     }
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Protocol.swift
@@ -64,4 +64,10 @@ extension _CalendarProtocol {
     
     package var gregorianStartDate: Date? { nil }
     package var debugDescription: String { "\(identifier)" }
+    
+    package var localeIdentifier: String {
+        // We use this to provide a consistent answer for hashing and equality -- null is equal to an empty string
+        locale?.identifier ?? ""
+    }
 }
+

--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -292,8 +292,10 @@ public struct Locale : Hashable, Equatable, Sendable {
     /// Returns the calendar for the locale, or the Gregorian calendar as a fallback.
     public var calendar: Calendar {
         var cal = _locale.calendar
-        // TODO: This is a fairly expensive operation, because it recreates the Calendar's backing ICU object. However, we can't cache the value or we risk creating a retain cycle between _Calendar/_Locale. We'll need to sort out some way around this.
-        // TODO: Calendar doesn't store a Locale anymore!
+        // This is a fairly expensive operation, because it recreates the Calendar's backing ICU object.
+        // However, we can't cache `struct Calendar` because it would create a retain cycle between _Calendar/_Locale:
+        // struct Calendar -> inner _Calendar: any _CalendarProtocol -> struct Locale -> inner _Locale: any _LocaleProtocol -> struct Calendar...
+        // _Calendar holds a Locale for performance reasons
         cal.locale = self
         return cal
     }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -442,9 +442,11 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                 components.collation = .init(id)
             }
 
-            let calendarID = _lockedCalendarIdentifier(&state)
-            if let weekdayNumber = prefs.firstWeekday?[calendarID], let weekday = Locale.Weekday(Int32(weekdayNumber)) {
-                components.firstDayOfWeek = weekday
+            if let firstWeekdayPrefs = prefs.firstWeekday {
+                let calendarID = _lockedCalendarIdentifier(&state)
+                if let weekdayNumber = firstWeekdayPrefs[calendarID], let weekday = Locale.Weekday(Int32(weekdayNumber)) {
+                    components.firstDayOfWeek = weekday
+                }
             }
 
             if let measurementSystem = prefs.measurementSystem {
@@ -1219,9 +1221,13 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                 }
 
                 // Check prefs
-                if let first = forceFirstWeekday(_lockedCalendarIdentifier(&state)) {
-                    state.firstDayOfWeek = first
-                    return first
+                if let firstWeekdayPref = prefs?.firstWeekday {
+                    // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
+                    let calendarId = _lockedCalendarIdentifier(&state)
+                    if let first = forceFirstWeekday(calendarId) {
+                        state.firstDayOfWeek = first
+                        return first
+                    }
                 }
 
                 // Fall back to the calendar's default value
@@ -1363,9 +1369,13 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
             }
 
             // Check prefs
-            if let minDays = forceMinDaysInFirstWeek(_lockedCalendarIdentifier(&state)) {
-                state.minimalDaysInFirstWeek = minDays
-                return minDays
+            if prefs != nil {
+                // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
+                let calendarId = _lockedCalendarIdentifier(&state)
+                if let minDays = forceMinDaysInFirstWeek(calendarId) {
+                    state.minimalDaysInFirstWeek = minDays
+                    return minDays
+                }
             }
 
             // Use locale's value


### PR DESCRIPTION
CalendarGregorian currently decomposes `Locale` into its identifer plus preferences, stores the two properties separately, and recreates everytime a `Locale` when needed. This results in us always creating new locales, and calling ICU whenever requesting its properties. While we do have cache in place for `Locale.init(identifier:preferences:)` for nil `preferences`, we are not hitting the cache because `preferences` is always non-nil when calendar is `.current`.

Fix this by storing a `Locale` inside calendar so we always hit the cache. This also allows `Locale.autoupdatingCurrent` to work properly -- previously you would not get the right locale back if you set `calendar.locale = Locale.autoupdatingCurrent`. This change fixes that as the identity of the `Locale` is now preserved.

Resolves 125169335