### PR TITLE
Support data writing to special files on linux

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -236,7 +236,16 @@ private func write(buffer: UnsafeRawBufferPointer, toFileDescriptor fd: Int32, p
     
     if !buffer.isEmpty {
         if fsync(fd) < 0 {
-            throw CocoaError.errorWithFilePath(path, errno: errno, reading: false)
+            let savedErrno = errno
+            let error = CocoaError.errorWithFilePath(path, errno: savedErrno, reading: false)
+            #if os(Linux)
+            // Linux returns -1 and errno == EINVAL if trying to sync a special file, eg a fifo, character device etc which can be ignored.
+            if savedErrno != EINVAL {
+                throw error
+            }
+            #else
+            throw error
+            #endif
         }
     }
 }

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -237,15 +237,10 @@ private func write(buffer: UnsafeRawBufferPointer, toFileDescriptor fd: Int32, p
     if !buffer.isEmpty {
         if fsync(fd) < 0 {
             let savedErrno = errno
-            let error = CocoaError.errorWithFilePath(path, errno: savedErrno, reading: false)
-            #if os(Linux)
-            // Linux returns -1 and errno == EINVAL if trying to sync a special file, eg a fifo, character device etc which can be ignored.
             if savedErrno != EINVAL {
-                throw error
+                // Linux and some versions of macOS returns -1 and errno == EINVAL if trying to sync a special file, eg a fifo, character device etc which can be ignored.
+                throw CocoaError.errorWithFilePath(path, errno: savedErrno, reading: false)
             }
-            #else
-            throw error
-            #endif
         }
     }
 }

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -238,6 +238,15 @@ class DataIOTests : XCTestCase {
         cleanup(at: url)
 #endif
     }
+    
+    func test_writeToSpecialFile() {
+#if os(Windows)
+        let path = "CON"
+#else
+        let path = "/dev/stdout"
+#endif
+        XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: path))
+    }
 
     // MARK: - String Path Tests
     func testStringDeletingLastPathComponent() {

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -239,21 +239,17 @@ class DataIOTests : XCTestCase {
 #endif
     }
     
-    func test_writeToSpecialFile() {
-#if os(Windows)
+    func test_writeToSpecialFile() throws {
+        #if !os(Linux) && !os(Windows)
+        throw XCTSkip("This test is only supported on Linux and Windows")
+        #else
+        #if os(Windows)
         let path = "CON"
-#else
+        #else
         let path = "/dev/stdout"
-#endif
-        do {
-            try Data("Output to STDOUT\n".utf8).write(to: path)
-        } catch {
-            print("Caught unexpected errror: \(error)")
-            let underlying = (error as? CocoaError)?.underlying
-            print("Underlying error: \(underlying)")
-            print("Underlying POSIX errno: \((underlying as? POSIXError)?.code.rawValue)")
-            XCTFail("Underlying POSIX errno: \((underlying as? POSIXError)?.code.rawValue)")
-        }
+        #endif
+        XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: path))
+        #endif
     }
 
     // MARK: - String Path Tests

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -245,7 +245,15 @@ class DataIOTests : XCTestCase {
 #else
         let path = "/dev/stdout"
 #endif
-        XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: path))
+        do {
+            try Data("Output to STDOUT\n".utf8).write(to: path)
+        } catch {
+            print("Caught unexpected errror: \(error)")
+            let underlying = (error as? CocoaError)?.underlying
+            print("Underlying error: \(underlying)")
+            print("Underlying POSIX errno: \((underlying as? POSIXError)?.code.rawValue)")
+            XCTFail("Underlying POSIX errno: \((underlying as? POSIXError)?.code.rawValue)")
+        }
     }
 
     // MARK: - String Path Tests


### PR DESCRIPTION
Calling `Data.write(to:)` invokes a call to `fsync` on the file descriptor before returning. On Linux, `fsync` will return `-1` and set `errno` to `EINVAL` for special files (such as `/dev/stdout`) but this is safe to ignore. This change pulls in a test case originally in swift-corelibs-foundation to test this and suppresses this error only on Linux (the `fsync` call on macOS succeeds)