### PR TITLE
_CShims: repair the Windows build

### DIFF
--- a/Sources/_CShims/platform_shims.c
+++ b/Sources/_CShims/platform_shims.c
@@ -14,7 +14,9 @@
 
 #if __has_include(<crt_externs.h>)
 #include <crt_externs.h>
-#else
+#elif defined(_WIN32)
+#include <stdlib.h>
+#elif defined(__unix__)
 #include <unistd.h>
 extern char **environ;
 #endif
@@ -38,7 +40,9 @@ _platform_shims_get_environ()
 {
 #if __has_include(<crt_externs.h>)
     return *_NSGetEnviron();
-#else
+#elif defined(_WIN32)
+    return _environ;
+#elif defined(__unix__)
     return environ;
 #endif
 }


### PR DESCRIPTION
This was obscuring the current foundation blocker for Windows: ICU. The last update to ICU broke the Windows build and there does not seem to be a clear repair for that. See apple/swift-foundation-icu#15 for more details on the ICU failure. In the meantime, repair the `environ` handling for Windows. `unistd.h` is the Unix standard header which must be available when `__unix__` is defined. Add an explicit check for that to avoid including the header on other platforms.