### PR TITLE
FoundationEssentials: add some missing imports for Windows

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -14,9 +14,7 @@
 internal import os
 #elseif canImport(Glibc)
 import Glibc
-#endif
-
-#if canImport(CRT)
+#elseif canImport(CRT)
 import CRT
 #endif
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -14,9 +14,7 @@
 internal import os
 #elseif canImport(Glibc)
 import Glibc
-#endif
-
-#if canImport(CRT)
+#elseif canImport(CRT)
 import CRT
 #endif
 

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -20,6 +20,8 @@ internal import _CShims
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 private func readExtendedAttributesFromFileDescriptor(_ fd: Int32, attrsToRead: [String]) -> [String : Data] {

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -21,6 +21,8 @@ internal import _CShims
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 #if !NO_FILESYSTEM

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -14,6 +14,8 @@
 import Glibc 
 #elseif canImport(Darwin)
 import Darwin
+#elseif os(Windows)
+import CRT
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 internal struct _FileManagerImpl {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -20,6 +20,9 @@ internal import os
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
+import WinSDK
 #endif
 
 internal import _CShims

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -20,6 +20,8 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 internal import _CShims
+#elseif os(Windows)
+import CRT
 #endif
 
 extension Date {

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 extension _FileManagerImpl {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -26,6 +26,8 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 internal import _CShims
+#elseif os(Windows)
+import CRT
 #endif
 
 extension stat {

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -15,6 +15,8 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 internal import _CShims
+#elseif os(Windows)
+import CRT
 #endif
 
 // MARK: Directory Iteration

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -14,6 +14,8 @@
 internal import os
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import WinSDK
 #endif
 
 internal import _CShims


### PR DESCRIPTION
This allows us to get further into building FoundationEssentials once again on Windows. Much of the file system work has resulted in this module no longer being viable on Windows and will need to be replaced to allow building on Windows which does not have the `fts` APIs.