### PR TITLE
FoundationEssentials: perform explicit conversion of `mode_t`

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -209,7 +209,7 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
     }
     
     let fileSize = min(Int(clamping: filestat.st_size), maxLength ?? Int.max)
-    let fileType = filestat.st_mode & S_IFMT
+    let fileType = mode_t(filestat.st_mode) & mode_t(S_IFMT)
     let preferredChunkSize = filestat.st_blksize
 #if !NO_FILESYSTEM
     let shouldMap = shouldMapFileDescriptor(fd, path: inPath, options: options)
@@ -217,9 +217,9 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
     let shouldMap = false
 #endif
         
-    if fileType != S_IFREG {
+    if fileType != mode_t(S_IFREG) {
         // EACCES is still an odd choice, but at least we have a better error for directories.
-        let code = (fileType == S_IFDIR) ? EISDIR : EACCES
+        let code = (fileType == mode_t(S_IFDIR)) ? EISDIR : EACCES
         throw CocoaError.errorWithFilePath(inPath, errno: code, reading: true)
     }
     

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -15,7 +15,8 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)
-import CRT
+import ucrt
+internal import _CShims
 #endif
 
 internal struct _FileManagerImpl {
@@ -64,7 +65,7 @@ internal struct _FileManagerImpl {
             var statBuf = stat()
             let fd = open(path, 0, 0)
             guard fd >= 0 else { return nil }
-            if fstat(fd, &statBuf) < 0 || statBuf.st_mode & S_IFMT == S_IFDIR {
+            if fstat(fd, &statBuf) < 0 || mode_t(statBuf.st_mode) & mode_t(S_IFMT) == mode_t(S_IFDIR) {
                 close(fd)
                 return nil
             }
@@ -83,7 +84,7 @@ internal struct _FileManagerImpl {
         }
         
         /* check for being same type */
-        if myInfo.st_mode & S_IFMT != otherInfo.st_mode & S_IFMT {
+        if myInfo.st_mode & mode_t(S_IFMT) != otherInfo.st_mode & mode_t(S_IFMT) {
             return false
         }
         

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -22,6 +22,7 @@ import Glibc
 internal import _CShims
 #elseif os(Windows)
 import CRT
+internal import _CShims
 #endif
 
 extension Date {
@@ -46,13 +47,13 @@ private func _nameFor(gid: gid_t) -> String? {
 
 extension mode_t {
     private var _fileType: FileAttributeType {
-        switch self & S_IFMT {
-        case S_IFCHR: .typeCharacterSpecial
-        case S_IFDIR: .typeDirectory
-        case S_IFBLK: .typeBlockSpecial
-        case S_IFREG: .typeRegular
-        case S_IFLNK: .typeSymbolicLink
-        case S_IFSOCK: .typeSocket
+        switch self & mode_t(S_IFMT) {
+        case mode_t(S_IFCHR): .typeCharacterSpecial
+        case mode_t(S_IFDIR): .typeDirectory
+        case mode_t(S_IFBLK): .typeBlockSpecial
+        case mode_t(S_IFREG): .typeRegular
+        case mode_t(S_IFLNK): .typeSymbolicLink
+        case mode_t(S_IFSOCK): .typeSocket
         default: .typeUnknown
         }
     }
@@ -344,7 +345,7 @@ extension _FileManagerImpl {
             guard stat(rep, &fileInfo) == 0 else {
                 return (false, false)
             }
-            let isDir = (fileInfo.st_mode & S_IFMT) == S_IFDIR
+            let isDir = (mode_t(fileInfo.st_mode) & mode_t(S_IFMT)) == mode_t(S_IFDIR)
             return (true, isDir)
         }
     }
@@ -644,7 +645,7 @@ extension _FileManagerImpl {
                     }
                 }
                 
-                if mode_t(mode) & S_IWUSR != 0 {
+                if mode_t(mode) & mode_t(S_IWUSR) != 0 {
                     try setMode?()
                     setMode = nil
                 }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -27,25 +27,28 @@ import Darwin
 import Glibc
 internal import _CShims
 #elseif os(Windows)
-import CRT
+import ucrt
+internal import _CShims
 #endif
 
 extension stat {
     var isDirectory: Bool {
-        (self.st_mode & S_IFMT) == S_IFDIR
+        (mode_t(self.st_mode) & mode_t(S_IFMT)) == mode_t(S_IFDIR)
     }
     
     var isRegular: Bool {
-        (self.st_mode & S_IFMT) == S_IFREG
+        (mode_t(self.st_mode) & mode_t(S_IFMT)) == mode_t(S_IFREG)
     }
-    
+
+#if !os(Windows)
     var isSymbolicLink: Bool {
-        (self.st_mode & S_IFMT) == S_IFLNK
+        (mode_t(self.st_mode) & mode_t(S_IFMT)) == mode_t(S_IFLNK)
     }
-    
+#endif
+
     var isSpecial: Bool {
-        let type = self.st_mode & S_IFMT
-        return type == S_IFBLK || type == S_IFCHR
+        let type = mode_t(self.st_mode) & mode_t(S_IFMT)
+        return type == mode_t(S_IFBLK) || type == mode_t(S_IFCHR)
     }
 }
 

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -17,6 +17,7 @@ import Glibc
 internal import _CShims
 #elseif os(Windows)
 import CRT
+internal import _CShims
 #endif
 
 // MARK: Directory Iteration
@@ -266,7 +267,7 @@ struct _POSIXDirectoryContentsSequence: Sequence {
                         let statDir = directoryPath + "/" + fileName
                         if stat(statDir, &statBuf) == 0 {
                             // #define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
-                            if (statBuf.st_mode & S_IFMT) == S_IFDIR {
+                            if (mode_t(statBuf.st_mode) & mode_t(S_IFMT)) == mode_t(S_IFDIR) {
                                 isDirectory = true
                             }
                         }

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -556,7 +556,7 @@ enum _FileOperations {
         defer { close(dstfd) }
 
         // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
-        let permissions = fileInfo.st_mode & ~S_IFMT
+        let permissions = mode_t(fileInfo.st_mode) & ~mode_t(S_IFMT)
         guard fchmod(dstfd, permissions) == 0 else {
             try delegate.throwIfNecessary(errno, srcPtr, dstPtr)
             return

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -406,7 +406,7 @@ extension String {
                         if lstat(buffer.baseAddress!, &statBuf) < 0 {
                             return nil
                         }
-                        if statBuf.st_mode & S_IFMT == S_IFLNK {
+                        if st_mode(statBuf.st_mode) & st_mode(S_IFMT) == st_mode(S_IFLNK) {
                             /* Examples:
                              *   fspath == /foo/bar0baz/quux/froboz
                              *   linkx == /tic/tac/toe

--- a/Sources/_CShims/include/platform_shims.h
+++ b/Sources/_CShims/include/platform_shims.h
@@ -24,6 +24,10 @@
 #include <libkern/OSThermalNotification.h>
 #endif
 
+#if defined(_WIN32)
+typedef int mode_t;
+#endif
+
 INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ();
 
 INTERNAL void _platform_shims_lock_environ();


### PR DESCRIPTION
Windows uses `int` instead of a `mode_t` type. Create a shim alias in `_CShims` and use explicit type conversions to allow sharing of code paths across platforms. This helps reduce some of the build errors enabling further work to re-enable building FoundationEssentials on Windows.