### PR TITLE
Upgrade FoundationICU to 0.0.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
             from: "1.1.0"),
         .package(
             url: "https://github.com/apple/swift-foundation-icu",
-            revision: "40b9706c92a690e94424a711e6bb45b3dc8e9628"),
+            exact: "0.0.6"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
             from: "510.0.0")


### PR DESCRIPTION
This patch upgrades `FoundationICU` to `0.0.6` which contains two important fixes:
- Temporary fix for failing Unit tests on macOS
- Fix building on Windows.