### PR TITLE
FoundationEssentials: squelch some warnings

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -310,7 +310,7 @@ internal final class __DataStorage : @unchecked Sendable {
             }
 
             if origLength < newLength && clear && !allocateCleared {
-                memset(newBytes!.advanced(by: origLength), 0, newLength - origLength)
+                _ = memset(newBytes!.advanced(by: origLength), 0, newLength - origLength)
             }
 
             /* _length set by caller */
@@ -347,7 +347,7 @@ internal final class __DataStorage : @unchecked Sendable {
         if _capacity < newLength || _bytes == nil {
             ensureUniqueBufferReference(growingTo: newLength, clear: true)
         } else if origLength < newLength && _needToZero {
-            memset(_bytes! + origLength, 0, newLength - origLength)
+            _ = memset(_bytes! + origLength, 0, newLength - origLength)
         } else if newLength < origLength {
             _needToZero = true
         }
@@ -412,7 +412,7 @@ internal final class __DataStorage : @unchecked Sendable {
             if let replacementBytes = replacementBytes {
                 memmove(mutableBytes + start, replacementBytes, replacementLength)
             } else {
-                memset(mutableBytes + start, 0, replacementLength)
+                _ = memset(mutableBytes + start, 0, replacementLength)
             }
         }
 
@@ -433,7 +433,7 @@ internal final class __DataStorage : @unchecked Sendable {
         } else {
             ensureUniqueBufferReference()
         }
-        memset(_bytes!.advanced(by: range.lowerBound), 0, range.upperBound - range.lowerBound)
+        _ = memset(_bytes!.advanced(by: range.lowerBound), 0, range.upperBound - range.lowerBound)
     }
 
     @usableFromInline // This is not @inlinable as a non-trivial, non-convenience initializer.
@@ -1906,7 +1906,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     public init(repeating repeatedValue: UInt8, count: Int) {
         self.init(count: count)
         withUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) -> Void in
-            memset(buffer.baseAddress!, Int32(repeatedValue), buffer.count)
+            _ = memset(buffer.baseAddress!, Int32(repeatedValue), buffer.count)
         }
     }
 

--- a/Sources/FoundationEssentials/Data/DataProtocol.swift
+++ b/Sources/FoundationEssentials/Data/DataProtocol.swift
@@ -215,7 +215,7 @@ extension DataProtocol where Self : ContiguousBytes {
         withUnsafeBytes { fullBuffer in
             let adv = distance(from: startIndex, to: concreteRange.lowerBound)
             let delta = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
-            memcpy(ptr.baseAddress!, fullBuffer.baseAddress!.advanced(by: adv), delta)
+            _ = memcpy(ptr.baseAddress!, fullBuffer.baseAddress!.advanced(by: adv), delta)
         }
     }
 }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -158,7 +158,7 @@ internal struct _FileManagerImpl {
             
             let len = strlen(ptr) + 1
             let newPtr = UnsafeMutablePointer<CChar>.allocate(capacity: len)
-            memcpy(newPtr, ptr, len)
+            _ = memcpy(newPtr, ptr, len)
             return UnsafePointer(newPtr)
         }
     }
@@ -177,7 +177,7 @@ internal struct _FileManagerImpl {
                 return false
             }
             
-            memcpy(buffer, ptr, lengthOfData)
+            _ = memcpy(buffer, ptr, lengthOfData)
             return true
         }
     }


### PR DESCRIPTION
When trying to revive the Windows port, these warnings clutter the current set of things to resolve still. Silence the warnings by explicitly ignoring the results.