### PR TITLE
Enable ISO8601 encoding and decoding on top of new ISO8601 implementation

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
+++ b/Sources/FoundationEssentials/Calendar/Date+FormatStyle.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: Date Extensions
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+extension Date {
+    /// Converts `self` to its textual representation.
+    /// - Parameter format: The format for formatting `self`.
+    /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
+#if FOUNDATION_FRAMEWORK
+    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
+        format.format(self)
+    }
+#else
+    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
+        format.format(self)
+    }
+#endif // FOUNDATION_FRAMEWORK
+    
+    // Parsing
+    /// Creates a new `Date` by parsing the given representation.
+    /// - Parameter value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
+    /// - Parameters:
+    ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
+    ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `Date`.
+#if FOUNDATION_FRAMEWORK
+    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#else
+    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
+        self = try strategy.parse(value)
+    }
+#endif // FOUNDATION_FRAMEWORK
+    /// Creates a new `Date` by parsing the given string representation.
+#if FOUNDATION_FRAMEWORK
+    @_disfavoredOverload
+    public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+        self = try strategy.parse(String(value))
+    }
+#else
+    @_disfavoredOverload
+    public init<T: FoundationEssentials.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
+        self = try strategy.parse(String(value))
+    }
+#endif // FOUNDATION_FRAMEWORK
+}

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -58,12 +58,11 @@ open class JSONDecoder {
         /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
         case millisecondsSince1970
 
-#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
-        // TODO: Reenable once DateFormatStyle has been moved: https://github.com/apple/swift-foundation/issues/46
         /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
+#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
         /// Decode the `Date` as a string parsed by the given formatter.
         case formatted(DateFormatter)
 #endif // FOUNDATION_FRAMEWORK
@@ -643,8 +642,6 @@ extension JSONDecoderImpl: Decoder {
         case .millisecondsSince1970:
             let double = try self.unwrapFloatingPoint(from: mapValue, as: Double.self, for: codingPathNode, additionalKey)
             return Date(timeIntervalSince1970: double / 1000.0)
-#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
-            // TODO: Reenable once DateFormatStyle has been moved
         case .iso8601:
             let string = try self.unwrapString(from: mapValue, for: codingPathNode, additionalKey)
             guard let date = try? Date.ISO8601FormatStyle().parse(string) else {
@@ -652,6 +649,7 @@ extension JSONDecoderImpl: Decoder {
             }
             return date
 
+#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
         case .formatted(let formatter):
             let string = try self.unwrapString(from: mapValue, for: codingPathNode, additionalKey)
             guard let date = formatter.date(from: string) else {

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -67,12 +67,11 @@ open class JSONEncoder {
         /// Encode the `Date` as UNIX millisecond timestamp (as a JSON number).
         case millisecondsSince1970
 
-#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
-        // TODO: Reenable once DateFormatStyle has been ported: https://github.com/apple/swift-foundation/issues/46
         /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
+#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
         /// Encode the `Date` as a string formatted by the given formatter.
         case formatted(DateFormatter)
 #endif // FOUNDATION_FRAMEWORK
@@ -999,10 +998,10 @@ private extension __JSONEncoder {
         case .millisecondsSince1970:
             return try .number(from: 1000.0 * date.timeIntervalSince1970, with: .throw, for: codingPathNode, additionalKey)
 
-#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
         case .iso8601:
             return self.wrap(date.formatted(.iso8601))
 
+#if FOUNDATION_FRAMEWORK && !NO_FORMATTERS
         case .formatted(let formatter):
             return self.wrap(formatter.string(from: date))
 #endif

--- a/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/DateFormatStyle.swift
@@ -20,19 +20,6 @@ internal import FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Date {
-    /// Converts `self` to its textual representation.
-    /// - Parameter format: The format for formatting `self`.
-    /// - Returns: A representation of `self` using the given `format`. The type of the representation is specified by `FormatStyle.FormatOutput`.
-#if FOUNDATION_FRAMEWORK
-    public func formatted<F: Foundation.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
-        format.format(self)
-    }
-#else
-    public func formatted<F: FoundationEssentials.FormatStyle>(_ format: F) -> F.FormatOutput where F.FormatInput == Date {
-        format.format(self)
-    }
-#endif // FOUNDATION_FRAMEWORK
-
     /// Converts `self` to its textual representation that contains both the date and time parts. The exact format depends on the user's preferences.
     /// - Parameters:
     ///   - date: The style for describing the date part.
@@ -46,35 +33,6 @@ extension Date {
     public func formatted() -> String {
         self.formatted(Date.FormatStyle(date: .numeric, time: .shortened))
     }
-
-    // Parsing
-    /// Creates a new `Date` by parsing the given representation.
-    /// - Parameter value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
-    /// - Parameters:
-    ///   - value: A representation of a date. The type of the representation is specified by `ParseStrategy.ParseInput`.
-    ///   - strategy: The parse strategy to parse `value` whose `ParseOutput` is `Date`.
-#if FOUNDATION_FRAMEWORK
-    public init<T: Foundation.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
-        self = try strategy.parse(value)
-    }
-#else
-    public init<T: FoundationEssentials.ParseStrategy>(_ value: T.ParseInput, strategy: T) throws where T.ParseOutput == Self {
-        self = try strategy.parse(value)
-    }
-#endif // FOUNDATION_FRAMEWORK
-
-    /// Creates a new `Date` by parsing the given string representation.
-#if FOUNDATION_FRAMEWORK
-    @_disfavoredOverload
-    public init<T: Foundation.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
-        self = try strategy.parse(String(value))
-    }
-#else
-    @_disfavoredOverload
-    public init<T: FoundationEssentials.ParseStrategy, Value: StringProtocol>(_ value: Value, strategy: T) throws where T.ParseOutput == Self, T.ParseInput == String {
-        self = try strategy.parse(String(value))
-    }
-#endif // FOUNDATION_FRAMEWORK
 }
 
 // MARK: DateFieldCollection

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2491,19 +2491,10 @@ extension JSONEncoderTests {
 
     }
 
-}
-
-// MARK: - FoundationPreview Disabled Tests
-#if FOUNDATION_FRAMEWORK
-extension JSONEncoderTests {
-    // TODO: Reenable once .iso8601 formatter is moved
     func testEncodingDateISO8601() {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = .withInternetDateTime
-
         let timestamp = Date(timeIntervalSince1970: 1000)
-        let expectedJSON = "\"\(formatter.string(from: timestamp))\"".data(using: String._Encoding.utf8)!
-
+        let expectedJSON = "\"\(timestamp.formatted(.iso8601))\"".data(using: String._Encoding.utf8)!
+  
         _testRoundTrip(of: timestamp,
                        expectedJSON: expectedJSON,
                        dateEncodingStrategy: .iso8601,
@@ -2516,8 +2507,23 @@ extension JSONEncoderTests {
                        dateEncodingStrategy: .iso8601,
                        dateDecodingStrategy: .iso8601)
     }
+    
+    func testEncodingDataBase64() {
+        let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
 
-    // TODO: Reenable once DateFormatStyle is moved
+        let expectedJSON = "\"3q2+7w==\"".data(using: String._Encoding.utf8)!
+        _testRoundTrip(of: data, expectedJSON: expectedJSON)
+
+        // Optional data should encode the same way.
+        _testRoundTrip(of: Optional(data), expectedJSON: expectedJSON)
+    }
+}
+
+// MARK: - Framework-only tests
+
+#if FOUNDATION_FRAMEWORK
+extension JSONEncoderTests {
+    // This will remain a framework-only test due to dependence on `DateFormatter`.
     func testEncodingDateFormatted() {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
@@ -2536,18 +2542,6 @@ extension JSONEncoderTests {
                        expectedJSON: expectedJSON,
                        dateEncodingStrategy: .formatted(formatter),
                        dateDecodingStrategy: .formatted(formatter))
-    }
-
-
-    // TODO: Reenable once Data.base64EncodedString() is implemented
-    func testEncodingDataBase64() {
-        let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
-
-        let expectedJSON = "\"3q2+7w==\"".data(using: String._Encoding.utf8)!
-        _testRoundTrip(of: data, expectedJSON: expectedJSON)
-
-        // Optional data should encode the same way.
-        _testRoundTrip(of: Optional(data), expectedJSON: expectedJSON)
     }
 }
 


### PR DESCRIPTION
With #518 and #392 merged, we can now enable ISO8601 encoding/decoding for the FoundationEssentials `JSONEncoder` and `JSONDecoder`.

This also moves the fundamental `Date` formatting API down to Essentials, since it depends only on the `FormatStyle` type which is also in Essentials.