### PR TITLE
FoundationEssentials: add `withNTPathRepresentation`

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -48,8 +48,10 @@ extension String {
         // Drop trailing slashes unless it follows a drive specification.  The
         // trailing arc separator after a drive specifier indicates the root as
         // opposed to a drive relative path.
+        let first = path.startIndex
+        let second = path.index(after: path.startIndex)
         while path.count > 1, path.last == "\\" {
-            if path.count == 3, path[0].isLetter, path[1] == ":" {
+            if path.count == 3, path[first].isLetter, path[second] == ":" {
                 break;
             }
             path.removeLast()
@@ -61,7 +63,7 @@ extension String {
             guard !path.hasPrefix(#"\\"#) else { return try body(pwszPath) }
 
             let dwLength = GetFullPathNameW(pwszPath, 0, nil, nil)
-            let path = withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
+            let path = try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
                 guard GetFullPathNameW(pwszPath, DWORD($0.count), $0.baseAddress, nil) == dwLength else {
                     throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
                 }

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -48,10 +48,10 @@ extension String {
         // Drop trailing slashes unless it follows a drive specification.  The
         // trailing arc separator after a drive specifier indicates the root as
         // opposed to a drive relative path.
-        while path.count > 1, path.last == "\\",
-                !(path.count == 3 &&
-                    path[path.index(path.endIndex, offsetBy: -2)] == ":" &&
-                    path[path.index(path.endIndex, offsetBy: -3)].isLetter) {
+        while path.count > 1, path.last == "\\" {
+            if path.count == 3, path[0].isLetter, path[1] == ":" {
+                break;
+            }
             path.removeLast()
         }
 

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -48,9 +48,9 @@ extension String {
         // Drop trailing slashes unless it follows a drive specification.  The
         // trailing arc separator after a drive specifier indicates the root as
         // opposed to a drive relative path.
-        let first = path.startIndex
-        let second = path.index(after: path.startIndex)
         while path.count > 1, path.last == "\\" {
+            let first = path.startIndex
+            let second = path.index(after: path.startIndex)
             if path.count == 3, path[first].isLetter, path[second] == ":" {
                 break;
             }

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -45,10 +45,10 @@ extension String {
         // the path.
         path = path.replacing("/", with: "\\")
 
-        // Droop trailing slashes unless it follows a drive specification.  The
+        // Drop trailing slashes unless it follows a drive specification.  The
         // trailing arc separator after a drive specifier indicates the root as
         // opposed to a drive relative path.
-        while path.count > 1, path[path.index(before: path.endIndex)] == "\\",
+        while path.count > 1, path.last == "\\",
                 !(path.count == 3 &&
                     path[path.index(path.endIndex, offsetBy: -2)] == ":" &&
                     path[path.index(path.endIndex, offsetBy: -3)].isLetter) {

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -33,7 +33,7 @@ extension String {
         var path = self
 
         // Strip the leading `/` on a RFC8089 path (`/[drive-letter]:/...` ).  A
-        // leading slash indicates a rooted path on the drive for teh current
+        // leading slash indicates a rooted path on the drive for the current
         // working directory.
         var iter = path.makeIterator()
         if iter.next() == "/", iter.next()?.isLetter ?? false, iter.next() == ":" {
@@ -46,7 +46,7 @@ extension String {
         path = path.replacing("/", with: "\\")
 
         // Droop trailing slashes unless it follows a drive specification.  The
-        // trailing arc separator after a drive specifier iindicates the root as
+        // trailing arc separator after a drive specifier indicates the root as
         // opposed to a drive relative path.
         while path.count > 1, path[path.index(before: path.endIndex)] == "\\",
                 !(path.count == 3 &&


### PR DESCRIPTION
This helper allows us to convert paths to the NT path representation. The NT Path representation is important for internal usage as it allows us to bypass the `MAX_PATH` (261) limit for Win32 APIs. In order to do this, we simply escape the string with the NT prefix (`\\?\`) which requires that the path is normalised (uses `\` rather than `/`) and generally should be an absolute path. Using the NT path allows us to use the fully supported 32k character path length of the NT kernel.