### PR TITLE
Avoid filling file system representation with partial scalars on failure

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -165,13 +165,12 @@ extension UnsafeBufferPointer {
         var decoder = T()
         var iterator = self.makeIterator()
         
-        func appendOutput(_ values: some Sequence<UInt8>) throws {
+        func appendOutput(_ values: some Collection<UInt8>) throws {
             let bufferPortion = UnsafeMutableBufferPointer(start: buffer.baseAddress!.advanced(by: bufferIdx), count: bufferLength - bufferIdx)
-            var (leftOver, idx) = bufferPortion.initialize(from: values)
-            bufferIdx += idx
-            if bufferIdx == bufferLength && leftOver.next() != nil {
+            guard bufferPortion.count >= values.count else {
                 throw DecompositionError.insufficientSpace
             }
+            bufferIdx += bufferPortion.initialize(fromContentsOf: values)
         }
         
         func appendOutput(_ value: UInt8) throws {


### PR DESCRIPTION
Filling a file system representation into a buffer currently partially fills the buffer in the failure case, and the buffer can be filled with a partial unicode scalar (i.e. only the first UTF-8 scalar out of 3 in a unicode scalar) before failing. Previously the ObjC implementation ensured that while we partially fill the buffer during failure we never partially fill it with incomplete UTF-8 so this adjusts the swift implementation to behave the same way.

This doesn't impact the `withFileSystemRepresentation` function our swift implementations use as we never use the partial buffer in the failure case.