### PR TITLE
Temporarily mark Expression as SPI

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public struct Expression<each Input, Output> : Sendable {
     public let expression : any StandardPredicateExpression<Output>
@@ -27,6 +28,7 @@ public struct Expression<each Input, Output> : Sendable {
     }
 }
 
+@_spi(Expression)
 @freestanding(expression)
 @available(FoundationPredicate 0.4, *)
 public macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")

--- a/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(Expression)
 @available(FoundationPredicate 0.1, *)
 extension PredicateExpressions {
     @available(FoundationPredicate 0.4, *)
@@ -41,6 +42,7 @@ extension PredicateExpressions {
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : CustomStringConvertible {
     public var description: String {
@@ -48,9 +50,11 @@ extension PredicateExpressions.ExpressionEvaluate : CustomStringConvertible {
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : StandardPredicateExpression where Transformation : StandardPredicateExpression, repeat each Input : StandardPredicateExpression {}
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation : Codable, repeat each Input : Codable {
     public func encode(to encoder: Encoder) throws {
@@ -66,5 +70,6 @@ extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : Sendable where Transformation : Sendable, repeat each Input : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -574,6 +574,7 @@ extension NSPredicate {
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension NSExpression {
     public convenience init?<Input, Output>(_ expression: Expression<Input, Output>) where Input : NSObject {

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -455,6 +455,7 @@ extension Predicate : CustomStringConvertible {
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension Expression : CustomStringConvertible {
     public var description: String {
@@ -471,6 +472,7 @@ extension Predicate : CustomDebugStringConvertible {
     }
 }
 
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension Expression : CustomDebugStringConvertible {
     public var debugDescription: String {

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -15,7 +15,7 @@
 // See this issue for more info on this file: https://github.com/apple/swift-foundation/issues/40
 
 #if FOUNDATION_FRAMEWORK
-@testable import Foundation
+@_spi(Expression) @testable import Foundation
 
 public typealias Calendar = Foundation.Calendar
 public typealias TimeZone = Foundation.TimeZone
@@ -108,16 +108,17 @@ public typealias StandardPredicateExpression = Foundation.StandardPredicateExpre
 public typealias PredicateError = Foundation.PredicateError
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateCodableConfiguration = Foundation.PredicateCodableConfiguration
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public typealias Expression = Foundation.Expression
 #else
 
 #if DEBUG
-@_exported @testable import FoundationEssentials
+@_exported @testable @_spi(Expression) import FoundationEssentials
 @_exported @testable import FoundationInternationalization
 // XCTest implicitly imports Foundation
 #else
-@_exported import FoundationEssentials
+@_exported @_spi(Expression) import FoundationEssentials
 @_exported import FoundationInternationalization
 // XCTest implicitly imports Foundation
 #endif
@@ -209,6 +210,7 @@ public typealias PredicateExpressions = FoundationEssentials.PredicateExpression
 public typealias StandardPredicateExpression = FoundationEssentials.StandardPredicateExpression
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateError = FoundationEssentials.PredicateError
+@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public typealias Expression = FoundationEssentials.Expression
 

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(TestSupport)
-import TestSupport
+@_spi(Expression) import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
+
+@_spi(Expression) import Foundation
 
 fileprivate protocol PredicateCodingConfigurationProviding : EncodingConfigurationProviding, DecodingConfigurationProviding where EncodingConfiguration == PredicateCodableConfiguration, DecodingConfiguration == PredicateCodableConfiguration {
     static var config: PredicateCodableConfiguration { get }

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -12,6 +12,8 @@
 
 #if FOUNDATION_FRAMEWORK
 
+@_spi(Expression) import Foundation
+
 final class NSPredicateConversionTests: XCTestCase {
     private func convert<T: NSObject>(_ predicate: Predicate<T>) -> NSPredicate? {
         NSPredicate(predicate)

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -11,11 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(TestSupport)
-import TestSupport
+@_spi(Expression) import TestSupport
 #endif
 
 #if canImport(RegexBuilder)
 import RegexBuilder
+#endif
+
+#if FOUNDATION_FRAMEWORK
+@_spi(Expression) import Foundation
 #endif
 
 #if !FOUNDATION_FRAMEWORK
@@ -451,7 +455,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
         XCTAssertFalse(try predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
     }
-    #endif
     
     func testExpression() throws {
         guard #available(FoundationPredicate 0.4, *) else {
@@ -469,4 +472,5 @@ final class PredicateTests: XCTestCase {
             XCTAssertEqual(try expression.evaluate(i), i + 1)
         }
     }
+    #endif
 }


### PR DESCRIPTION
Temporarily mark the `Expression` type and associated types as `@_spi` while I work out some downstream build issues