### PR TITLE
FoundationEssentials: tweak FileManager utilities for Windows

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -35,6 +35,9 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     /// The number of seconds from 1 January 1970 to the reference date, 1 January 2001.
     public static let timeIntervalBetween1970AndReferenceDate : TimeInterval = 978307200.0
 
+    /// The number of seconds from 1 January 1601 to the reference date, 1 January 2001.
+    internal static let timeIntervalBetween1601AndReferenceDate: TimeInterval = 12622780800.0
+
     /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time.
     public static var timeIntervalSinceReferenceDate : TimeInterval {
         return Self.getCurrentAbsoluteTime()
@@ -118,6 +121,10 @@ public struct Date : Comparable, Hashable, Equatable, Sendable {
     */
     public var timeIntervalSince1970: TimeInterval {
         return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
+    }
+
+    internal var timeIntervalSince1601: TimeInterval {
+        return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1601AndReferenceDate
     }
 
     /// Return a new `Date` by adding a `TimeInterval` to this `Date`.

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -28,8 +28,18 @@ import Glibc
 internal import _CShims
 #elseif os(Windows)
 import CRT
+import WinSDK
 #endif
 
+#if os(Windows)
+extension FILETIME {
+    package var interval: TimeInterval {
+        Double((self.dwHighDateTime << 32) | self.dwLowDateTime) - Date.timeIntervalBetween1970AndReferenceDate
+    }
+}
+#endif
+
+#if !os(Windows)
 extension stat {
     var isDirectory: Bool {
         (self.st_mode & S_IFMT) == S_IFDIR
@@ -48,6 +58,7 @@ extension stat {
         return type == S_IFBLK || type == S_IFCHR
     }
 }
+#endif
 
 #if FOUNDATION_FRAMEWORK && os(macOS)
 extension URLResourceKey {
@@ -148,7 +159,8 @@ extension _FileManagerImpl {
         try url.setResourceValues(URLResourceValues(values: urlAttributes))
         #endif
     }
-    
+
+#if !os(Windows)
     static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
         try value.withUnsafeBytes { buffer in
             #if canImport(Darwin)
@@ -173,7 +185,7 @@ extension _FileManagerImpl {
             }
         }
     }
-    
+
     static func _setAttributes(_ attributes: [String : Data], at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
         for (key, value) in attributes {
             try key.withCString {
@@ -181,7 +193,8 @@ extension _FileManagerImpl {
             }
         }
     }
-    
+#endif
+
     #if FOUNDATION_FRAMEWORK
     static func _fileProtectionValueForPath(_ fileSystemRepresentation: UnsafePointer<CChar>) -> Int32? {
         var attrList = attrlist()
@@ -244,7 +257,8 @@ extension _FileManagerImpl {
         }
     }
     #endif
-    
+
+#if !os(Windows)
     static func _userAccountNameToNumber(_ name: String) -> uid_t? {
         name.withCString { ptr in
             getpwnam(ptr)?.pointee.pw_uid
@@ -256,6 +270,7 @@ extension _FileManagerImpl {
             getgrnam(ptr)?.pointee.gr_gid
         }
     }
+#endif
 }
 
 extension FileManager {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -33,8 +33,10 @@ import WinSDK
 
 #if os(Windows)
 extension FILETIME {
-    package var interval: TimeInterval {
-        Double((self.dwHighDateTime << 32) | self.dwLowDateTime) - Date.timeIntervalBetween1970AndReferenceDate
+    package var timeIntervalSince1970: TimeInterval {
+        var count: Double = Double((UInt64(self.dwHighDateTime) << 32) | UInt64(self.dwLowDateTime))
+        count /= 1e7 // 100 nanoseconds to seconds
+        return count - Date.timeIntervalBetween1601AndReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
     }
 }
 #endif

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(Windows)
+
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
 internal import _CShims
-#elseif os(Windows)
-import CRT
 #endif
 
 // MARK: Directory Iteration
@@ -353,3 +353,5 @@ struct _POSIXDirectoryContentsSequence: Sequence {
         Iterator(path: path, appendSlashForDirectory: appendSlashForDirectory, prefix: prefix)
     }
 }
+
+#endif


### PR DESCRIPTION
Add a helper for time conversion and remove some functions which do not make sense on Windows - users are not identified by integral IDs but rather by SIDs. This helps reduce the error diagnostics when building FoundationEssentials on Windows.