### PR TITLE
Fix build failures related to tz data file

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -389,7 +389,7 @@ extension TimeZone {
 }
 
 extension TimeZone {
-    private static func dataFromTZFile(_ name: String) -> Data {
+    internal static func dataFromTZFile(_ name: String) -> Data {
 #if NO_TZFILE
         return Data()
 #else

--- a/Sources/_CShims/include/_CStdlib.h
+++ b/Sources/_CShims/include/_CStdlib.h
@@ -138,11 +138,11 @@
 #include <stdint.h>
 #endif
 
-#if TARGET_OS_MAC
+#if __has_include(<tzfile.h>)
 
 #include <tzfile.h>
 
-#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
+#else
 
 #ifndef TZDIR
 #define TZDIR    "/usr/share/zoneinfo/" /* Time zone object file directory */


### PR DESCRIPTION
This fixes a few build failures (mainly on iOS) due to code that references the TZ data file