### PR TITLE
FoundationEssentials: provide typed overloads for constants from WinSDK

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -140,39 +140,39 @@ extension CocoaError {
 
     static func errorWithFilePath(_ path: String? = nil, win32 dwError: DWORD, reading: Bool, variant: String? = nil, userInfo: [String : AnyHashable] = [:]) -> CocoaError {
         let code: CocoaError.Code = switch (reading, dwError) {
-            case (true, DWORD(ERROR_FILE_NOT_FOUND)), (true, DWORD(ERROR_PATH_NOT_FOUND)):
+            case (true, ERROR_FILE_NOT_FOUND), (true, ERROR_PATH_NOT_FOUND):
                 // Windows will return ERROR_FILE_NOT_FOUND or ERROR_PATH_NOT_FOUND
                 // for empty paths.
                 (path?.isEmpty ?? false) ? .fileReadInvalidFileName : .fileReadNoSuchFile
-            case (true, DWORD(ERROR_ACCESS_DENIED)): .fileReadNoPermission
-            case (true, DWORD(ERROR_INVALID_ACCESS)): .fileReadNoPermission
-            case (true, DWORD(ERROR_INVALID_DRIVE)): .fileReadNoSuchFile
-            case (true, DWORD(ERROR_SHARING_VIOLATION)): .fileReadNoPermission
-            case (true, DWORD(ERROR_INVALID_NAME)): .fileReadInvalidFileName
-            case (true, DWORD(ERROR_LABEL_TOO_LONG)): .fileReadInvalidFileName
-            case (true, DWORD(ERROR_BAD_PATHNAME)): .fileReadInvalidFileName
-            case (true, DWORD(ERROR_FILENAME_EXCED_RANGE)): .fileReadInvalidFileName
-            case (true, DWORD(ERROR_DIRECTORY)): .fileReadInvalidFileName
+            case (true, ERROR_ACCESS_DENIED): .fileReadNoPermission
+            case (true, ERROR_INVALID_ACCESS): .fileReadNoPermission
+            case (true, ERROR_INVALID_DRIVE): .fileReadNoSuchFile
+            case (true, ERROR_SHARING_VIOLATION): .fileReadNoPermission
+            case (true, ERROR_INVALID_NAME): .fileReadInvalidFileName
+            case (true, ERROR_LABEL_TOO_LONG): .fileReadInvalidFileName
+            case (true, ERROR_BAD_PATHNAME): .fileReadInvalidFileName
+            case (true, ERROR_FILENAME_EXCED_RANGE): .fileReadInvalidFileName
+            case (true, ERROR_DIRECTORY): .fileReadInvalidFileName
             case (true, _): .fileReadUnknown
 
-            case (false, DWORD(ERROR_FILE_NOT_FOUND)), (false, DWORD(ERROR_PATH_NOT_FOUND)):
+            case (false, ERROR_FILE_NOT_FOUND), (false, ERROR_PATH_NOT_FOUND):
                 // Windows will return ERROR_FILE_NOT_FOUND or ERROR_PATH_NOT_FOUND
                 // for empty paths.
                 (path?.isEmpty ?? false) ? .fileWriteInvalidFileName : .fileNoSuchFile
-            case (false, DWORD(ERROR_ACCESS_DENIED)): .fileWriteNoPermission
-            case (false, DWORD(ERROR_INVALID_ACCESS)): .fileWriteNoPermission
-            case (false, DWORD(ERROR_INVALID_DRIVE)): .fileNoSuchFile
-            case (false, DWORD(ERROR_WRITE_FAULT)): .fileWriteVolumeReadOnly
-            case (false, DWORD(ERROR_SHARING_VIOLATION)): .fileWriteNoPermission
-            case (false, DWORD(ERROR_FILE_EXISTS)): .fileWriteFileExists
-            case (false, DWORD(ERROR_DISK_FULL)): .fileWriteOutOfSpace
-            case (false, DWORD(ERROR_INVALID_NAME)): .fileWriteInvalidFileName
-            case (false, DWORD(ERROR_LABEL_TOO_LONG)): .fileWriteInvalidFileName
-            case (false, DWORD(ERROR_BAD_PATHNAME)): .fileWriteInvalidFileName
-            case (false, DWORD(ERROR_ALREADY_EXISTS)): .fileWriteFileExists
-            case (false, DWORD(ERROR_FILENAME_EXCED_RANGE)): .fileWriteInvalidFileName
-            case (false, DWORD(ERROR_DIRECTORY)): .fileWriteInvalidFileName
-            case (false, DWORD(ERROR_DISK_RESOURCES_EXHAUSTED)): .fileWriteOutOfSpace
+            case (false, ERROR_ACCESS_DENIED): .fileWriteNoPermission
+            case (false, ERROR_INVALID_ACCESS): .fileWriteNoPermission
+            case (false, ERROR_INVALID_DRIVE): .fileNoSuchFile
+            case (false, ERROR_WRITE_FAULT): .fileWriteVolumeReadOnly
+            case (false, ERROR_SHARING_VIOLATION): .fileWriteNoPermission
+            case (false, ERROR_FILE_EXISTS): .fileWriteFileExists
+            case (false, ERROR_DISK_FULL): .fileWriteOutOfSpace
+            case (false, ERROR_INVALID_NAME): .fileWriteInvalidFileName
+            case (false, ERROR_LABEL_TOO_LONG): .fileWriteInvalidFileName
+            case (false, ERROR_BAD_PATHNAME): .fileWriteInvalidFileName
+            case (false, ERROR_ALREADY_EXISTS): .fileWriteFileExists
+            case (false, ERROR_FILENAME_EXCED_RANGE): .fileWriteInvalidFileName
+            case (false, ERROR_DIRECTORY): .fileWriteInvalidFileName
+            case (false, ERROR_DISK_RESOURCES_EXHAUSTED): .fileWriteOutOfSpace
             case (false, _): .fileWriteUnknown
         }
 

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -347,7 +347,7 @@ extension _FileManagerImpl {
             guard GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) else {
                 return (false, false)
             }
-            return (true, faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY))
+            return (true, faAttributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY)
         }) ?? (false, false)
 #else
         path.withFileSystemRepresentation { rep -> (Bool, Bool) in
@@ -406,7 +406,7 @@ extension _FileManagerImpl {
             guard GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) else {
                 return false
             }
-            return faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) != DWORD(FILE_ATTRIBUTE_READONLY)
+            return faAttributes.dwFileAttributes & FILE_ATTRIBUTE_READONLY != FILE_ATTRIBUTE_READONLY
         }) ?? false
 #else
         _fileAccessibleForMode(path, W_OK)
@@ -722,7 +722,7 @@ extension _FileManagerImpl {
                 ftTime.dwLowDateTime = uiTime.LowPart
                 ftTime.dwHighDateTime = uiTime.HighPart
 
-                let hFile: HANDLE = CreateFileW($0, DWORD(GENERIC_WRITE), DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), 0, nil)
+                let hFile: HANDLE = CreateFileW($0, GENERIC_WRITE, FILE_SHARE_WRITE, nil, OPEN_EXISTING, 0, nil)
                 if hFile == INVALID_HANDLE_VALUE {
                     throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
                 }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -148,12 +148,12 @@ struct TimeZoneCache : Sendable {
 
 #if os(Windows)
             let hFile = TimeZone.TZDEFAULT.withCString(encodedAs: UTF16.self) {
-                CreateFileW($0, GENERIC_READ, DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE), nil, DWORD(OPEN_EXISTING), 0, nil)
+                CreateFileW($0, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil, OPEN_EXISTING, 0, nil)
             }
             defer { CloseHandle(hFile) }
-            let dwSize = GetFinalPathNameByHandleW(hFile, nil, 0, DWORD(VOLUME_NAME_DOS))
+            let dwSize = GetFinalPathNameByHandleW(hFile, nil, 0, VOLUME_NAME_DOS)
             let path = withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwSize)) {
-                _ = GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwSize, DWORD(VOLUME_NAME_DOS))
+                _ = GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwSize, VOLUME_NAME_DOS)
                 return String(decodingCString: $0.baseAddress!, as: UTF16.self)
             }
             if let rangeOfZoneInfo = path._range(of: "\(TimeZone.TZDIR)\\", anchored: false, backwards: false) {

--- a/Sources/FoundationEssentials/WinSDK+Extensions.swift
+++ b/Sources/FoundationEssentials/WinSDK+Extensions.swift
@@ -1,0 +1,132 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+
+import WinSDK
+
+package var ERROR_ACCESS_DENIED: DWORD {
+    DWORD(WinSDK.ERROR_ACCESS_DENIED)
+}
+
+package var ERROR_ALREADY_EXISTS: DWORD {
+    DWORD(WinSDK.ERROR_ALREADY_EXISTS)
+}
+
+package var ERROR_BAD_PATHNAME: DWORD {
+    DWORD(WinSDK.ERROR_BAD_PATHNAME)
+}
+
+package var ERROR_DIRECTORY: DWORD {
+    DWORD(WinSDK.ERROR_DIRECTORY)
+}
+
+package var ERROR_DISK_FULL: DWORD {
+    DWORD(WinSDK.ERROR_DISK_FULL)
+}
+
+package var ERROR_DISK_RESOURCES_EXHAUSTED: DWORD {
+    DWORD(WinSDK.ERROR_DISK_RESOURCES_EXHAUSTED)
+}
+
+package var ERROR_FILE_EXISTS: DWORD {
+    DWORD(WinSDK.ERROR_FILE_EXISTS)
+}
+
+package var ERROR_FILE_NOT_FOUND: DWORD {
+    DWORD(WinSDK.ERROR_FILE_NOT_FOUND)
+}
+
+package var ERROR_FILENAME_EXCED_RANGE: DWORD {
+    DWORD(WinSDK.ERROR_FILENAME_EXCED_RANGE)
+}
+
+package var ERROR_INVALID_ACCESS: DWORD {
+    DWORD(WinSDK.ERROR_INVALID_ACCESS)
+}
+
+package var ERROR_INVALID_DRIVE: DWORD {
+    DWORD(WinSDK.ERROR_INVALID_DRIVE)
+}
+
+package var ERROR_INVALID_NAME: DWORD {
+    DWORD(WinSDK.ERROR_INVALID_NAME)
+}
+
+package var ERROR_LABEL_TOO_LONG: DWORD {
+    DWORD(WinSDK.ERROR_LABEL_TOO_LONG)
+}
+
+package var ERROR_PATH_NOT_FOUND: DWORD {
+    DWORD(WinSDK.ERROR_PATH_NOT_FOUND)
+}
+
+package var ERROR_SHARING_VIOLATION: DWORD {
+    DWORD(WinSDK.ERROR_SHARING_VIOLATION)
+}
+
+package var ERROR_WRITE_FAULT: DWORD {
+    DWORD(WinSDK.ERROR_WRITE_FAULT)
+}
+
+package var FILE_ATTRIBUTE_DIRECTORY: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_DIRECTORY)
+}
+
+package var FILE_ATTRIBUTE_NORMAL: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_NORMAL)
+}
+
+package var FILE_ATTRIBUTE_READONLY: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_READONLY)
+}
+
+package var FILE_ATTRIBUTE_REPARSE_POINT: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_REPARSE_POINT)
+}
+
+package var FILE_MAP_READ: DWORD {
+    DWORD(WinSDK.FILE_MAP_READ)
+}
+
+package var FILE_SHARE_DELETE: DWORD {
+    DWORD(WinSDK.FILE_SHARE_DELETE)
+}
+
+package var FILE_SHARE_READ: DWORD {
+    DWORD(WinSDK.FILE_SHARE_READ)
+}
+
+package var FILE_SHARE_WRITE: DWORD {
+    DWORD(WinSDK.FILE_SHARE_WRITE)
+}
+
+package var GENERIC_READ: DWORD {
+    DWORD(WinSDK.GENERIC_READ)
+}
+
+package var GENERIC_WRITE: DWORD {
+    DWORD(WinSDK.GENERIC_WRITE)
+}
+
+package var OPEN_EXISTING: DWORD {
+    DWORD(WinSDK.OPEN_EXISTING)
+}
+
+package var PAGE_READONLY: DWORD {
+    DWORD(WinSDK.PAGE_READONLY)
+}
+
+package var VOLUME_NAME_DOS: DWORD {
+    DWORD(WinSDK.VOLUME_NAME_DOS)
+}
+
+#endif


### PR DESCRIPTION
This allows for us to use the constants without explicitly casting the type to `DWORD` on each site of use. By providing the shadowing overload we can simply use the constants without impacting the readability of the surrounding code.