### PR TITLE
FoundationEssentials: add missing import for numerics

### DIFF
--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 // MARK: - BinaryInteger + Numeric string representation


### PR DESCRIPTION
Add a missing import for the math routines that are required for the binary integer representation to be processed properly.