### PR TITLE
Remove SPI annotations from Expression

### DIFF
--- a/Sources/FoundationEssentials/Predicate/Expression.swift
+++ b/Sources/FoundationEssentials/Predicate/Expression.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public struct Expression<each Input, Output> : Sendable {
     public let expression : any StandardPredicateExpression<Output>
@@ -28,7 +27,6 @@ public struct Expression<each Input, Output> : Sendable {
     }
 }
 
-@_spi(Expression)
 @freestanding(expression)
 @available(FoundationPredicate 0.4, *)
 public macro Expression<each Input, Output>(_ body: (repeat each Input) -> Output) -> Expression<repeat each Input, Output> = #externalMacro(module: "FoundationMacros", type: "ExpressionMacro")

--- a/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
+++ b/Sources/FoundationEssentials/Predicate/Expressions/ExpressionEvaluation.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Expression)
 @available(FoundationPredicate 0.1, *)
 extension PredicateExpressions {
     @available(FoundationPredicate 0.4, *)
@@ -42,7 +41,6 @@ extension PredicateExpressions {
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : CustomStringConvertible {
     public var description: String {
@@ -50,11 +48,9 @@ extension PredicateExpressions.ExpressionEvaluate : CustomStringConvertible {
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : StandardPredicateExpression where Transformation : StandardPredicateExpression, repeat each Input : StandardPredicateExpression {}
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation : Codable, repeat each Input : Codable {
     public func encode(to encoder: Encoder) throws {
@@ -70,6 +66,5 @@ extension PredicateExpressions.ExpressionEvaluate : Codable where Transformation
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension PredicateExpressions.ExpressionEvaluate : Sendable where Transformation : Sendable, repeat each Input : Sendable {}

--- a/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
+++ b/Sources/FoundationEssentials/Predicate/NSPredicateConversion.swift
@@ -574,7 +574,6 @@ extension NSPredicate {
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension NSExpression {
     public convenience init?<Input, Output>(_ expression: Expression<Input, Output>) where Input : NSObject {

--- a/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate+Description.swift
@@ -455,7 +455,6 @@ extension Predicate : CustomStringConvertible {
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension Expression : CustomStringConvertible {
     public var description: String {
@@ -472,7 +471,6 @@ extension Predicate : CustomDebugStringConvertible {
     }
 }
 
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 extension Expression : CustomDebugStringConvertible {
     public var debugDescription: String {

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -15,7 +15,7 @@
 // See this issue for more info on this file: https://github.com/apple/swift-foundation/issues/40
 
 #if FOUNDATION_FRAMEWORK
-@_spi(Expression) @testable import Foundation
+@testable import Foundation
 
 public typealias Calendar = Foundation.Calendar
 public typealias TimeZone = Foundation.TimeZone
@@ -108,17 +108,16 @@ public typealias StandardPredicateExpression = Foundation.StandardPredicateExpre
 public typealias PredicateError = Foundation.PredicateError
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateCodableConfiguration = Foundation.PredicateCodableConfiguration
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public typealias Expression = Foundation.Expression
 #else
 
 #if DEBUG
-@_exported @testable @_spi(Expression) import FoundationEssentials
+@_exported @testable import FoundationEssentials
 @_exported @testable import FoundationInternationalization
 // XCTest implicitly imports Foundation
 #else
-@_exported @_spi(Expression) import FoundationEssentials
+@_exported import FoundationEssentials
 @_exported import FoundationInternationalization
 // XCTest implicitly imports Foundation
 #endif
@@ -210,7 +209,6 @@ public typealias PredicateExpressions = FoundationEssentials.PredicateExpression
 public typealias StandardPredicateExpression = FoundationEssentials.StandardPredicateExpression
 @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
 public typealias PredicateError = FoundationEssentials.PredicateError
-@_spi(Expression)
 @available(FoundationPredicate 0.4, *)
 public typealias Expression = FoundationEssentials.Expression
 

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -11,12 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(TestSupport)
-@_spi(Expression) import TestSupport
+import TestSupport
 #endif
 
 #if FOUNDATION_FRAMEWORK
-
-@_spi(Expression) import Foundation
 
 fileprivate protocol PredicateCodingConfigurationProviding : EncodingConfigurationProviding, DecodingConfigurationProviding where EncodingConfiguration == PredicateCodableConfiguration, DecodingConfiguration == PredicateCodableConfiguration {
     static var config: PredicateCodableConfiguration { get }

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -12,8 +12,6 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@_spi(Expression) import Foundation
-
 final class NSPredicateConversionTests: XCTestCase {
     private func convert<T: NSObject>(_ predicate: Predicate<T>) -> NSPredicate? {
         NSPredicate(predicate)

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -11,15 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(TestSupport)
-@_spi(Expression) import TestSupport
+import TestSupport
 #endif
 
 #if canImport(RegexBuilder)
 import RegexBuilder
-#endif
-
-#if FOUNDATION_FRAMEWORK
-@_spi(Expression) import Foundation
 #endif
 
 #if !FOUNDATION_FRAMEWORK
@@ -455,6 +451,7 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(try predicateB.evaluate(Object(a: 2, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
         XCTAssertFalse(try predicateB.evaluate(Object(a: 4, b: "abc", c: 0.0, d: 0, e: "c", f: true, g: [1, 3])))
     }
+    #endif
     
     func testExpression() throws {
         guard #available(FoundationPredicate 0.4, *) else {
@@ -472,5 +469,4 @@ final class PredicateTests: XCTestCase {
             XCTAssertEqual(try expression.evaluate(i), i + 1)
         }
     }
-    #endif
 }


### PR DESCRIPTION
Now that the previous build issues are resolved, we can remove the `@_spi` annotations from `Expression` and its related types