### PR TITLE
Fix some typos

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -64,7 +64,7 @@ enum ResolvedDateComponents {
     case weekOfYear(year: Int, weekOfYear: Int?, weekday: Int?)
     case weekOfMonth(year: Int, month: Int, weekOfMonth: Int, weekday: Int?)
 
-    // Pick the year field between yearForWeekOfYear and year and resovles era
+    // Pick the year field between yearForWeekOfYear and year and resolves era
     static func yearOrYearForWOYAdjustingEra(from components: DateComponents) -> (year: Int, month: Int) {
         var rawYear: Int
         // Don't adjust for era if week is also specified

--- a/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+UnitsFormatStyle.swift
@@ -157,8 +157,8 @@ extension Duration {
             public var roundingRule: FloatingPointRoundingRule
             public var roundingIncrement: Double?
 
-            init(mininumLength: Int, maximumLength: Int, roundingRule: FloatingPointRoundingRule, roundingIncrement: Double?) {
-                self.minimumLength = mininumLength
+            init(minimumLength: Int, maximumLength: Int, roundingRule: FloatingPointRoundingRule, roundingIncrement: Double?) {
+                self.minimumLength = minimumLength
                 self.maximumLength = maximumLength
                 self.roundingRule = roundingRule
                 self.roundingIncrement = roundingIncrement
@@ -171,7 +171,7 @@ extension Duration {
             ///   - roundingIncrement: Rounding increment for the remaining value.
             public init<Range: RangeExpression>(lengthLimits: Range, roundingRule: FloatingPointRoundingRule = .toNearestOrEven, roundingIncrement: Double? = nil) where Range.Bound == Int {
                 let (lower, upper) = lengthLimits.clampedLowerAndUpperBounds(0..<Int.max)
-                self.init(mininumLength: lower ?? 0, maximumLength: upper ?? Int.max, roundingRule: roundingRule, roundingIncrement: roundingIncrement)
+                self.init(minimumLength: lower ?? 0, maximumLength: upper ?? Int.max, roundingRule: roundingRule, roundingIncrement: roundingIncrement)
             }
 
             /// Displays the remaining part as the fractional part of the smallest unit.
@@ -180,18 +180,18 @@ extension Duration {
             ///   - rule: Rounding rule for the remaining value.
             ///   - increment: Rounding increment for the remaining value.
             public static func show(length: Int, rounded rule: FloatingPointRoundingRule = .toNearestOrEven, increment: Double? = nil) -> FractionalPartDisplayStrategy {
-                .init(mininumLength: length, maximumLength: length, roundingRule: rule, roundingIncrement: increment)
+                .init(minimumLength: length, maximumLength: length, roundingRule: rule, roundingIncrement: increment)
             }
 
             /// Excludes the remaining part.
             public static var hide: FractionalPartDisplayStrategy {
-                .init(mininumLength: 0, maximumLength: 0, roundingRule: .toNearestOrEven, roundingIncrement: nil)
+                .init(minimumLength: 0, maximumLength: 0, roundingRule: .toNearestOrEven, roundingIncrement: nil)
             }
 
             /// Excludes the remaining part with the specified rounding rule.
             /// - Parameter rounded: Rounding rule for the remaining value.
             public static func hide(rounded: FloatingPointRoundingRule = .toNearestOrEven) -> FractionalPartDisplayStrategy {
-                .init(mininumLength: 0, maximumLength: 0, roundingRule: rounded, roundingIncrement: nil)
+                .init(minimumLength: 0, maximumLength: 0, roundingRule: rounded, roundingIncrement: nil)
             }
 
         }

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -629,7 +629,7 @@ extension NumberFormatStyleConfiguration.Precision {
 
     private func integerAndFractionalLengthSkeleton(minInt: Int?, maxInt: Int?, minFrac: Int?, maxFrac: Int?) -> String {
         var stem: String = ""
-        // Construct skeleton for fractonal part
+        // Construct skeleton for fractional part
         if minFrac != nil || maxFrac != nil {
             if maxFrac == 0 {
                 stem += "precision-integer"

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -931,7 +931,7 @@ extension NSSortDescriptor {
         // This `init` used to unconditionally accept all `SortDescriptor`s,
         // which were guaranteed to have a valid `keyString` property because
         // the `Compared` value is an `NSObject`. This `init` was deprecated
-        // becasue we introduced ways to create `SortDescriptor` values that do
+        // because we introduced ways to create `SortDescriptor` values that do
         // not have such valid properties. At the deprecation, we introduced an
         // replacement `init` that requires `Compared: NSObject`, providing the
         // same level of always-valid-conversion to existing users.

--- a/Sources/FoundationInternationalization/String/String+SortComparator.swift
+++ b/Sources/FoundationInternationalization/String/String+SortComparator.swift
@@ -74,7 +74,7 @@ extension String {
         var associatedSelector: Selector {
             guard let selector = Self.validAlgorithms[self] else {
                 fatalError("""
-                Attempted to retreive selector from a \
+                Attempted to retrieve selector from a \
                 String.StandardSortComparator with an invalid configuration.
                 """)
             }

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -158,7 +158,7 @@ class DataIOTests : XCTestCase {
     }
     
 #if FOUNDATION_FRAMEWORK
-    // Progress is curently stubbed out for FoundationPreview
+    // Progress is currently stubbed out for FoundationPreview
     func test_writeWithProgress() throws {
         let url = testURL()
         

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -20,7 +20,7 @@ import TestSupport
 
 final class ISO8601FormatStyleParsingTests: XCTestCase {
 
-    /// See also the format-only tests in DateISO8601ForamtStyleEssentialsTests
+    /// See also the format-only tests in DateISO8601FormatStyleEssentialsTests
     func test_ISO8601Parse() throws {
         let iso8601 = Date.ISO8601FormatStyle()
 

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -131,7 +131,7 @@ final class TimeZoneTests : XCTestCase {
         testAbbreviation("UTC", 0, "GMT")
     }
 
-    func testSeondsFromGMT_RemoteDates() {
+    func testSecondsFromGMT_RemoteDates() {
         let date = Date(timeIntervalSinceReferenceDate: -5001243627) // "1842-07-09T05:39:33+0000"
         let europeRome = TimeZone(identifier: "Europe/Rome")!
         let secondsFromGMT = europeRome.secondsFromGMT(for: date)


### PR DESCRIPTION
1. reso `vl` es -> resolves
2. mini `n` umLength -> minimumLength
3. fract ` ` onal -> fractional
4. beca `su` e -> because
5. retr `ei` ve -> retrieve
6. cur ` ` ently -> currently
7. For `am` tStyle -> FormatStyle
8. Se ` ` onds -> Seconds