### PR TITLE
Implement ASCII encoding for String.data(using:)

### DIFF
--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -43,7 +43,7 @@ extension String {
                 var data = Data(count: self.utf8.count)
                 let allASCII = data.withUnsafeMutableBytes {
                     $0.withMemoryRebound(to: UInt8.self) { buffer in
-                        buffer.initializeAll(fromContentsOf: self.utf8)
+                        _ = buffer.initialize(fromContentsOf: self.utf8)
                         if let earlyCheckAllASCII {
                             return earlyCheckAllASCII
                         } else {

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -34,11 +34,21 @@ extension String {
                     }
                 }
             } else {
+                var earlyCheckAllASCII = self.utf8.withContiguousStorageIfAvailable {
+                    _allASCII($0)
+                }
+                if let earlyCheckAllASCII, !earlyCheckAllASCII {
+                    return nil
+                }
                 var data = Data(count: self.utf8.count)
                 let allASCII = data.withUnsafeMutableBytes {
                     $0.withMemoryRebound(to: UInt8.self) { buffer in
                         buffer.initializeAll(fromContentsOf: self.utf8)
-                        return _allASCII(UnsafeBufferPointer(buffer))
+                        if let earlyCheckAllASCII {
+                            return earlyCheckAllASCII
+                        } else {
+                            return _allASCII(UnsafeBufferPointer(buffer))
+                        }
                     }
                 }
                 return allASCII ? data : nil

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -21,6 +21,28 @@ extension String {
         switch encoding {
         case .utf8:
             return Data(self.utf8)
+        case .ascii, .nonLossyASCII:
+            if allowLossyConversion {
+                let lossyReplacement = (encoding == .ascii) ? 0xFF : UInt8(ascii: "?")
+                return Data(capacity: self.utf8.count) {
+                    for scalar in self.unicodeScalars {
+                        if scalar.isASCII {
+                            $0.append(fromContentsOf: scalar.utf8)
+                        } else {
+                            $0.appendElement(lossyReplacement)
+                        }
+                    }
+                }
+            } else {
+                var data = Data(count: self.utf8.count)
+                let allASCII = data.withUnsafeMutableBytes {
+                    $0.withMemoryRebound(to: UInt8.self) { buffer in
+                        buffer.initializeAll(fromContentsOf: self.utf8)
+                        return _allASCII(UnsafeBufferPointer(buffer))
+                    }
+                }
+                return allASCII ? data : nil
+            }
         default:
 #if FOUNDATION_FRAMEWORK
             // TODO: Implement data(using:allowLossyConversion:) in Swift

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -525,6 +525,17 @@ final class StringTests : XCTestCase {
         XCTAssertNil(utf32BEBOMStringMismatch)
     }
 
+    func test_dataUsingEncoding_ascii() {
+        XCTAssertEqual("abc".data(using: .ascii), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        XCTAssertEqual("abc".data(using: .nonLossyASCII), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: .ascii), nil)
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: .nonLossyASCII), nil)
+        
+        XCTAssertEqual("abc".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        XCTAssertEqual("abc".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "a"), UInt8(ascii: "b"), UInt8(ascii: "c")]))
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "e"), 0xFF, 0xFF, UInt8(ascii: "f")]))
+        XCTAssertEqual("e\u{301}\u{301}f".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "e"), UInt8(ascii: "?"), UInt8(ascii: "?"), UInt8(ascii: "f")]))
+    }
 }
 
 


### PR DESCRIPTION
This PR implements `String` to `Data` conversion for the `.ascii` and `.nonLossyAscii` encodings in Swift

Resolves rdar://123921236