### PR TITLE
Correct non-Darwin PropertyListFormat raw values

### DIFF
--- a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift
@@ -30,9 +30,9 @@ open class PropertyListDecoder {
     public typealias PropertyListFormat = PropertyListSerialization.PropertyListFormat
 #else
     public enum PropertyListFormat : UInt, Sendable  {
-        case xml
-        case binary
-        case openStep
+        case xml = 100
+        case binary = 200
+        case openStep = 1
     }
 #endif
     // MARK: Options


### PR DESCRIPTION
This aligns the raw values of this enum with those on Darwin and those in swift-corelibs-foundation which will make swift-corelibs-foundation adoption of `PropertyListDecoder` easier