### PR TITLE
Add ProcessInfo implementations for other platforms

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+API.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+API.swift
@@ -84,6 +84,16 @@ public struct OperatingSystemVersion: Hashable, Codable, Sendable {
     public let majorVersion: Int
     public let minorVersion: Int
     public let patchVersion: Int
+    
+    public init() {
+        self.init(majorVersion: 0, minorVersion: 0, patchVersion: 0)
+    }
+    
+    public init(majorVersion: Int, minorVersion: Int, patchVersion: Int) {
+        self.majorVersion = majorVersion
+        self.minorVersion = minorVersion
+        self.patchVersion = patchVersion
+    }
 }
 
 // MARK: - Getting Computer Information

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -262,23 +262,24 @@ extension _ProcessInfo {
         // do our best here to construct something consistent. Unfortunately, to provide a useful result, this requires
         // hardcoding several of the somewhat ambiguous values in the table provided here:
         //  https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw#remarks
-        switch (osVersionInfo.dwMajorVersion, osVersionInfo.dwMinorVersion) {
-            case (5, 0): versionString += " 2000"
-            case (5, 1): versionString += " XP"
-            case (5, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " XP Professional x64"
-            case (5, 2) where osVersionInfo.wSuiteMask == VER_SUITE_WH_SERVER: versionString += " Home Server"
-            case (5, 2): versionString += " Server 2003"
-            case (6, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " Vista"
-            case (6, 0): versionString += " Server 2008"
-            case (6, 1) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 7"
-            case (6, 1): versionString += " Server 2008 R2"
-            case (6, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 8"
-            case (6, 2): versionString += " Server 2012"
-            case (6, 3) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 8.1"
-            case (6, 3): versionString += " Server 2012 R2" // We assume the "10,0" numbers in the table for this are a typo
-            case (10, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 10"
-            case (10, 0): versionString += " Server 2019" // The table gives identical values for 2016 and 2019, so we just assume 2019 here
-            case let (maj, min): versionString += " \(maj).\(min)" // If all else fails, just give the raw version number
+        versionString += " "
+        versionString += switch (osVersionInfo.dwMajorVersion, osVersionInfo.dwMinorVersion) {
+            case (5, 0): "2000"
+            case (5, 1): "XP"
+            case (5, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "XP Professional x64"
+            case (5, 2) where osVersionInfo.wSuiteMask == VER_SUITE_WH_SERVER: "Home Server"
+            case (5, 2): "Server 2003"
+            case (6, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "Vista"
+            case (6, 0): "Server 2008"
+            case (6, 1) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "7"
+            case (6, 1): "Server 2008 R2"
+            case (6, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "8"
+            case (6, 2): "Server 2012"
+            case (6, 3) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "8.1"
+            case (6, 3): "Server 2012 R2" // We assume the "10,0" numbers in the table for this are a typo
+            case (10, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: "10"
+            case (10, 0): "Server 2019" // The table gives identical values for 2016 and 2019, so we just assume 2019 here
+            case let (maj, min): "\(maj).\(min)" // If all else fails, just give the raw version number
         }
         versionString += " (build \(osVersionInfo.dwBuildNumber))"
         // For now we ignore the `szCSDVersion`, `wServicePackMajor`, and `wServicePackMinor` values.

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -103,7 +103,7 @@ final class _ProcessInfo: Sendable {
 
     var globallyUniqueString: String {
         let uuid = UUID().uuidString
-        let pid = UInt64(getpid())
+        let pid = processIdentifier
 #if canImport(Darwin)
         let time: UInt64 = mach_absolute_time()
 #else
@@ -117,7 +117,11 @@ final class _ProcessInfo: Sendable {
     }
 
     var processIdentifier: Int32 {
-        return getpid()
+#if os(Windows)
+        return Int32(GetProcessId(GetCurrentProcess()))
+#else
+        return Int32(getpid())
+#endif
     }
 
     var processName: String {
@@ -140,9 +144,28 @@ final class _ProcessInfo: Sendable {
             return username
         }
         return ""
-#else
-        // TODO: Windows
+#elseif os(WASI)
+        // WASI does not have user concept
         return ""
+#elseif os(Windows)
+        return withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: 1040) { usernameBuffer in
+            usernameBuffer[0] = 0
+            var size: DWORD = 1040
+            if GetUserNameW(usernameBuffer.baseAddress!, &size) {
+                // discount the extra NULL by decrementing the size
+                return String(decoding: usernameBuffer.prefix(size - 1), as: UTF16.self)
+            } else {
+                return "USERNAME".withCString(encodedAs: UTF16.self) { pwszName in
+                    let dwLength = GetEnvironmentVariableW(pwszName, nil, 0)
+                    return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) { lpBuffer in
+                        guard GetEnvironmentVariableW(pwszName, lpBuffer.baseAddress, dwLength) == dwLength - 1 else {
+                            return ""
+                        }
+                        return String(decodingCString: lpBuffer.baseAddress!, as: UTF16.self)
+                    }
+                }
+            }
+        }
 #endif
     }
 
@@ -154,8 +177,16 @@ final class _ProcessInfo: Sendable {
             return String(cString: fullname)
         }
         return ""
-#else
+#elseif os(WASI)
         return ""
+#elseif os(Windows)
+        var ulLength: ULONG = 0
+        GetUserNameExW(NameDisplay, NULL, &ulLength)
+
+        return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: ulLength + 1) { wszBuffer in
+            GetUserNameExW(NameDisplay, wszBuffer.baseAddress!, &ulLength)
+            return String(decoding: wszBuffer.prefix(ulLength), as: UTF16.self)
+        }
 #endif
     }
 
@@ -182,17 +213,117 @@ extension _ProcessInfo {
             return $0!
         }
     }
+    
+#if os(Windows)
+    internal var _rawOperatingSystemVersionInfo: RTL_OSVERSIONINFOEXW? {
+        guard let ntdll = ("ntdll.dll".withCString(encodedAs: UTF16.self) {
+            LoadLibraryExW($0, nil, DWORD(LOAD_LIBRARY_SEARCH_SYSTEM32))
+        }) else {
+            return nil
+        }
+        defer { FreeLibrary(ntdll) }
+        typealias RTLGetVersionTy = @convention(c) (UnsafeMutablePointer<RTL_OSVERSIONINFOEXW>) -> NTSTATUS
+        guard let pfnRTLGetVersion = unsafeBitCast(GetProcAddress(ntdll, "RtlGetVersion"), to: Optional<RTLGetVersionTy>.self) else {
+            return nil
+        }
+        var osVersionInfo = RTL_OSVERSIONINFOEXW()
+        osVersionInfo.dwOSVersionInfoSize = DWORD(MemoryLayout<RTL_OSVERSIONINFOEXW>.size)
+        guard pfnRTLGetVersion(&osVersionInfo) == 0 else {
+            return nil
+        }
+        return osVersionInfo
+    }
+#endif
 
     var operatingSystemVersionString: String {
         // TODO: Check for `/etc/os-release` for Linux once DataIO is ready
         // https://github.com/apple/swift-foundation/issues/221
-        #if os(macOS)
+#if os(macOS)
         var versionString = "macOS"
-        #elseif os(Linux)
+#elseif os(Linux)
+        if let osReleaseContents = try? Data(contentsOf: "/etc/os-release") {
+            let strContents = String(decoding: osReleaseContents, as: UTF8.self)
+            if let name = strContents.split(separator: "\n").first(where: { $0.hasPrefix("PRETTY_NAME=") }) {
+                // This is extremely simplistic but manages to work for all known cases.
+                return String(name.dropFirst("PRETTY_NAME=".count)._trimmingCharacters(while: { $0 == "\"" }))
+            }
+        }
+        
+        // Okay, we can't get a distro name, so try for generic info.
         var versionString = "Linux"
-        #else
-        var versionString = ""
-        #endif
+#elseif os(Windows)
+        var versionString = "Windows"
+        
+        guard let osVersionInfo = self._rawOperatingSystemVersionInfo else {
+            return versionString
+        }
+
+        // Windows has no canonical way to turn the fairly complex `RTL_OSVERSIONINFOW` version info into a string. We
+        // do our best here to construct something consistent. Unfortunately, to provide a useful result, this requires
+        // hardcoding several of the somewhat ambiguous values in the table provided here:
+        //  https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw#remarks
+        switch (osVersionInfo.dwMajorVersion, osVersionInfo.dwMinorVersion) {
+            case (5, 0): versionString += " 2000"
+            case (5, 1): versionString += " XP"
+            case (5, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " XP Professional x64"
+            case (5, 2) where osVersionInfo.wSuiteMask == VER_SUITE_WH_SERVER: versionString += " Home Server"
+            case (5, 2): versionString += " Server 2003"
+            case (6, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " Vista"
+            case (6, 0): versionString += " Server 2008"
+            case (6, 1) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 7"
+            case (6, 1): versionString += " Server 2008 R2"
+            case (6, 2) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 8"
+            case (6, 2): versionString += " Server 2012"
+            case (6, 3) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 8.1"
+            case (6, 3): versionString += " Server 2012 R2" // We assume the "10,0" numbers in the table for this are a typo
+            case (10, 0) where osVersionInfo.wProductType == VER_NT_WORKSTATION: versionString += " 10"
+            case (10, 0): versionString += " Server 2019" // The table gives identical values for 2016 and 2019, so we just assume 2019 here
+            case let (maj, min): versionString += " \(maj).\(min)" // If all else fails, just give the raw version number
+        }
+        versionString += " (build \(osVersionInfo.dwBuildNumber))"
+        // For now we ignore the `szCSDVersion`, `wServicePackMajor`, and `wServicePackMinor` values.
+        return versionString
+#elseif os(FreeBSD)
+        // Try to get a release version from `uname -r`.
+        var versionString = "FreeBSD"
+        var utsNameBuffer = utsname()
+        if uname(&utsNameBuffer) == 0 {
+            let release = withUnsafePointer(to: &utsNameBuffer.release.0) { String(cString: $0) }
+            if !release.isEmpty {
+                versionString += " \(release)"
+            }
+        }
+        return versionString
+#elseif os(OpenBSD)
+        // TODO: `uname -r` probably works here too.
+        return "OpenBSD"
+#elseif os(Android)
+        /// In theory, we need to do something like this:
+        ///
+        ///     var versionString = "Android"
+        ///     let property = String(unsafeUninitializedCapacity: PROP_VALUE_MAX) { buf in
+        ///         __system_property_get("ro.build.description", buf.baseAddress!)
+        ///     }
+        ///     if !property.isEmpty {
+        ///         versionString += " \(property)"
+        ///     }
+        ///     return versionString
+        return "Android"
+#elseif os(PS4)
+        return "PS4"
+#elseif os(Cygwin)
+        // TODO: `uname -r` probably works here too.
+        return "Cygwin"
+#elseif os(Haiku)
+        return "Haiku"
+#elseif os(WASI)
+        return "WASI"
+#else
+        // On other systems at least return something.
+        return "Unknown"
+#endif
+        
+#if canImport(Darwin) || os(Linux)
         var uts: utsname = utsname()
         if uname(&uts) == 0 {
             let versionValue = withUnsafePointer(
@@ -204,9 +335,11 @@ extension _ProcessInfo {
         }
 
         return versionString
+#endif
     }
 
     var operatingSystemVersion: (major: Int, minor: Int, patch: Int) {
+#if canImport(Darwin) || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
         var uts: utsname = utsname()
         guard uname(&uts) == 0 else {
             return (major: -1, minor: 0, patch: 0)
@@ -223,6 +356,19 @@ extension _ProcessInfo {
         let minor = version.count >= 2 ? version[1] : 0
         let patch = version.count >= 3 ? version[2] : 0
         return (major: major, minor: minor, patch: patch)
+#elseif os(Windows)
+        guard let osVersionInfo = self._rawOperatingSystemVersionInfo else {
+            return OperatingSystemVersion(majorVersion: -1, minorVersion: 0, patchVersion: 0)
+        }
+
+        return OperatingSystemVersion(
+            majorVersion: Int(osVersionInfo.dwMajorVersion),
+            minorVersion: Int(osVersionInfo.dwMinorVersion),
+            patchVersion: Int(osVersionInfo.dwBuildNumber)
+        )
+#else
+        return OperatingSystemVersion(majorVersion: -1, minorVersion: 0, patchVersion: 0)
+#endif
     }
 
     func isOperatingSystemAtLeast(_ version: (major: Int, minor: Int, patch: Int)) -> Bool {
@@ -261,8 +407,10 @@ extension _ProcessInfo {
             return 0
         }
         return Int(count)
-#else
+#elseif os(Linux) || os(FreeBSD)
         return Int(sysconf(Int32(_SC_NPROCESSORS_CONF)))
+#else
+        return 1
 #endif
     }
 
@@ -276,8 +424,20 @@ extension _ProcessInfo {
             return 0
         }
         return Int(count)
-#else
+#elseif os(Linux) || os(FreeBSD)
         return Int(sysconf(Int32(_SC_NPROCESSORS_ONLN)))
+#elseif os(Windows)
+        var sysInfo = SYSTEM_INFO()
+        GetSystemInfo(&sysInfo)
+        let activeProcessorMask = sysInfo.dwActiveProcessorMask
+        // assumes sizeof(DWORD_PTR) is 64 bits or less
+        var v = activeProcessorMask
+        v = v - ((v >> 1) & 0x5555555555555555)
+        v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
+        v = (v + (v >> 4)) & 0xf0f0f0f0f0f0f0f
+        return (v * 0x0101010101010101) >> ((sizeof(v) - 1) * 8)
+#else
+        return 0
 #endif
     }
 
@@ -293,10 +453,12 @@ extension _ProcessInfo {
             }
             return 0
         }
-#else
+#elseif os(Linux) || os(FreeBSD)
         var memory = sysconf(Int32(_SC_PHYS_PAGES))
         memory *= sysconf(Int32(_SC_PAGESIZE))
         return UInt64(memory)
+#else
+        return 0
 #endif
     }
 
@@ -305,6 +467,8 @@ extension _ProcessInfo {
         let (_, secondsPerTick) = _systemClockTickRate
         let time = mach_absolute_time()
         return TimeInterval(time) * secondsPerTick
+#elseif os(Windows)
+        return TimeInterval(GetTickCount64()) / 1000.0
 #else
         var ts = timespec()
         guard clock_gettime(CLOCK_MONOTONIC, &ts) == 0 else {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -430,13 +430,7 @@ extension _ProcessInfo {
 #elseif os(Windows)
         var sysInfo = SYSTEM_INFO()
         GetSystemInfo(&sysInfo)
-        let activeProcessorMask = sysInfo.dwActiveProcessorMask
-        // assumes sizeof(DWORD_PTR) is 64 bits or less
-        var v = activeProcessorMask
-        v = v - ((v >> 1) & 0x5555555555555555)
-        v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
-        v = (v + (v >> 4)) & 0xf0f0f0f0f0f0f0f
-        return (v * 0x0101010101010101) >> ((sizeof(v) - 1) * 8)
+        return sysInfo.dwActiveProcessorMask.nonzeroBitCount
 #else
         return 0
 #endif

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -408,6 +408,10 @@ extension _ProcessInfo {
             return 0
         }
         return Int(count)
+#elseif os(Windows)
+        var siInfo = SYSTEM_INFO()
+        GetSystemInfo(&siInfo)
+        return Int(siInfo.dwNumberOfProcessors)
 #elseif os(Linux) || os(FreeBSD)
         return Int(sysconf(Int32(_SC_NPROCESSORS_CONF)))
 #else
@@ -514,6 +518,12 @@ extension _ProcessInfo {
             }
             return 0
         }
+#elseif os(Windows)
+        var TotalMemoryKB: ULONGLONG = 0
+        guard GetPhysicallyInstalledSystemMemory(&TotalMemoryKB) else {
+            return 0
+        }
+        return TotalMemoryKB * 1024
 #elseif os(Linux) || os(FreeBSD)
         var memory = sysconf(Int32(_SC_PHYS_PAGES))
         memory *= sysconf(Int32(_SC_PAGESIZE))

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -522,11 +522,11 @@ extension _ProcessInfo {
             return 0
         }
 #elseif os(Windows)
-        var TotalMemoryKB: ULONGLONG = 0
-        guard GetPhysicallyInstalledSystemMemory(&TotalMemoryKB) else {
+        var totalMemoryKB: ULONGLONG = 0
+        guard GetPhysicallyInstalledSystemMemory(&totalMemoryKB) else {
             return 0
         }
-        return TotalMemoryKB * 1024
+        return totalMemoryKB * 1024
 #elseif os(Linux) || os(FreeBSD)
         var memory = sysconf(Int32(_SC_PHYS_PAGES))
         memory *= sysconf(Int32(_SC_PAGESIZE))

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -327,7 +327,7 @@ extension _ProcessInfo {
         return "Unknown"
 #endif
         
-#if canImport(Darwin) || os(Linux)
+#if os(macOS) || os(Linux)
         var uts: utsname = utsname()
         if uname(&uts) == 0 {
             let versionValue = withUnsafePointer(

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -224,6 +224,7 @@ public typealias CocoaError = FoundationEssentials.CocoaError
 public typealias POSIXError = FoundationEssentials.POSIXError
 public typealias FileManagerDelegate = FoundationEssentials.FileManagerDelegate
 public typealias ProcessInfo = FoundationEssentials.ProcessInfo
+public typealias OperatingSystemVersion = FoundationEssentials.OperatingSystemVersion
 public typealias IndexPath = FoundationEssentials.IndexPath
 
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/_CShims/platform_shims.c
+++ b/Sources/_CShims/platform_shims.c
@@ -42,6 +42,8 @@ _platform_shims_get_environ()
     return *_NSGetEnviron();
 #elif defined(_WIN32)
     return _environ;
+#elif TARGET_OS_WASI
+    return __wasilibc_get_environ();
 #elif __has_include(<unistd.h>)
     return environ;
 #endif

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -170,7 +170,9 @@ final class ProcessInfoTests : XCTestCase {
 #endif
     
     func testProcessName() {
-#if os(Windows)
+#if FOUNDATION_FRAMEWORK
+        let targetName = "TestHost"
+#elseif os(Windows)
         let targetName = "swift-foundationPackageTests.exe"
 #elseif os(Linux)
         let targetName = "FoundationPreviewPackageTests.xctest"


### PR DESCRIPTION
This adds the implementations of `ProcessInfo` APIs for other platforms such as Windows and WASI (copied from swift-corelibs-foundation) so that this type can fully replace the `ProcessInfo` present in swift-corelibs-foundation