### PR TITLE
Enable sortedKeys in JSONEncoder in swift-foundation

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -39,14 +39,9 @@ open class JSONEncoder {
         /// Produce human-readable JSON with indented output.
         public static let prettyPrinted = OutputFormatting(rawValue: 1 << 0)
 
-#if FOUNDATION_FRAMEWORK
-        // TODO: Reenable once String.compare is implemented
-        // https://github.com/apple/swift-foundation/issues/284
-
         /// Produce JSON with dictionary keys sorted in lexicographic order.
         @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
         public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
-#endif // FOUNDATION_FRAMEWORK
 
         /// By default slashes get escaped ("/" → "\/", "http://apple.com/" → "http:\/\/apple.com\/")
         /// for security reasons, allowing outputted JSON to be safely embedded within HTML/XML.

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2544,9 +2544,9 @@ extension JSONEncoderTests {
                        dateDecodingStrategy: .formatted(formatter))
     }
 }
+#endif
 
 // MARK: - .sortedKeys Tests
-// TODO: Reenable these tests once .sortedKeys is implemented
 extension JSONEncoderTests {
     func testEncodingTopLevelStructuredClass() {
         // Person is a class with multiple fields.
@@ -2589,7 +2589,7 @@ extension JSONEncoderTests {
             "bar" : 10
         ]
 
-        _testRoundTrip(of: dict, expectedJSON: "{\"bar\":10,\"foo\":3,\"Foo\":1,\"FOO\":2,\"føo\":9,\"foo1\":4,\"Foo2\":5,\"foo3\":6,\"Foo11\":8,\"foo12\":7}".data(using: String._Encoding.utf8)!, outputFormatting: [.sortedKeys])
+        _testRoundTrip(of: dict, expectedJSON: #"{"FOO":2,"Foo":1,"Foo11":8,"Foo2":5,"bar":10,"foo":3,"foo1":4,"foo12":7,"foo3":6,"føo":9}"#.data(using: String._Encoding.utf8)!, outputFormatting: [.sortedKeys])
     }
 
     func testEncodingSortedKeysStableOrdering() {
@@ -2615,15 +2615,15 @@ extension JSONEncoderTests {
             dict["key\(N)"] = N
         }
 
-        for i in 0 ..< testSize {
-            let insertedKeyJSON = ",\"key\(i)\":\(i)"
+        let numberKeys = (0 ..< testSize).map { "\($0)" }.sorted()
+        for key in numberKeys {
+            let insertedKeyJSON = ",\"key\(key)\":\(key)"
             expectedJSONString.insert(contentsOf: insertedKeyJSON, at: expectedJSONString.index(before: expectedJSONString.endIndex))
         }
 
         _testRoundTrip(of: dict, expectedJSON: expectedJSONString.data(using: String._Encoding.utf8)!, outputFormatting: [.sortedKeys])
     }
 
-    // TODO: Reenable once .sortedKeys is implemented
     func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
         struct Model : Codable, Equatable {
             let first: String
@@ -2731,6 +2731,7 @@ extension JSONEncoderTests {
     }
 }
 
+#if FOUNDATION_FRAMEWORK
 // MARK: - Decimal Tests
 // TODO: Reenable these tests once Decimal is moved
 extension JSONEncoderTests {

--- a/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
@@ -569,11 +569,7 @@ final class LocaleCodableTests: XCTestCase {
         XCTAssertEqual(Locale.Script("Hant"), Locale.Script("hant"))
         XCTAssertEqual(Locale.LanguageCode("EN"), Locale.LanguageCode("en"))
     }
-}
-
-// MARK: - FoundationPreview Disabled Tests
-#if FOUNDATION_FRAMEWORK
-extension LocaleCodableTests {
+    
     func _encodeAsJSON<T: Codable>(_ t: T) -> String? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [ .sortedKeys ]
@@ -708,4 +704,3 @@ extension LocaleCodableTests {
         """)
     }
 }
-#endif


### PR DESCRIPTION
This updates `JSONEncoder` to use an unlocalized sort for its `sortedKeys` option which allows us to enable it in FoundationEssentials