### PR TITLE
Use ar_SA locale for tests expecting Arab-Indic numerals

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ByteCountFormatStyleTests.swift
@@ -120,7 +120,7 @@ final class ByteCountFormatStyleTests : XCTestCase {
     }
 
     func test_RTL() {
-        XCTAssertEqual(1024.formatted(.byteCount(style: ByteCountFormatStyle.Style.binary, includesActualByteCount: true).locale(.init(identifier: "ar"))), "١ كيلوبايت (١٬٠٢٤ بايت)")
+        XCTAssertEqual(1024.formatted(.byteCount(style: ByteCountFormatStyle.Style.binary, includesActualByteCount: true).locale(.init(identifier: "ar_SA"))), "١ كيلوبايت (١٬٠٢٤ بايت)")
     }
 
     func testAttributed() {


### PR DESCRIPTION
To account for underlying changes in ICU - we now use the `ar_SA` locale here to ensure that we get the expected arabic-indic numerals in the formatted output