### PR TITLE
FoundationEssentials: clean up some Windows warnings

### DIFF
--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -412,7 +412,13 @@ extension TimeZone {
 #endif
 
         guard fd >= 0 else { return Data() }
-        defer { close(fd) }
+        defer {
+#if os(Windows)
+            _close(fd)
+#else
+            close(fd)
+#endif
+        }
 
 #if os(Windows)
         var stat: _stat64 = _stat64()


### PR DESCRIPTION
Use the Windows POSIX API spellings to avoid the warnings. Take the opportunity to change the environment handling to ensure that we are able to handle weird unicode environment variables which may not be rendered properly in the ASCII environment representation. Adjust some types to better match the implementation on Windows which is a minor uop to avoid unnecessary `trunc` and `sext` or `zext`.