### PR TITLE
Introduce Cmake support for SwiftFoundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+cmake_minimum_required(VERSION 3.24)
+
+if(POLICY CMP0156)
+    # Deduplicate linked libraries where appropriate
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
+if(POLICY CMP0157)
+    # New Swift build model: improved incremental build performance and LSP support
+    cmake_policy(SET CMP0157 NEW)
+endif()
+
+project(SwiftFoundation
+    LANGUAGES C Swift)
+
+if(NOT SWIFT_SYSTEM_NAME)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(SWIFT_SYSTEM_NAME macosx)
+  else()
+    set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  endif()
+endif()
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+set(BUILD_TESTING NO)
+
+set(COLLECTIONS_SINGLE_MODULE YES)
+set(COLLECTIONS_FOUNDATION_TOOLCHAIN_MODULE YES)
+
+# Make sure our dependencies exists
+include(FetchContent)
+if (_SwiftFoundationICU_SourceDIR)
+    FetchContent_Declare(SwiftFoundationICU
+        SOURCE_DIR ${_SwiftFoundationICU_SourceDIR})
+else()
+    FetchContent_Declare(SwiftFoundationICU
+        GIT_REPOSITORY https://github.com/apple/swift-foundation-icu.git
+        GIT_TAG 0.0.8)
+endif()
+
+if (_SwiftCollections_SourceDIR)
+    FetchContent_Declare(SwiftCollections
+        SOURCE_DIR ${_SwiftCollections_SourceDIR})
+else()
+    FetchContent_Declare(SwiftCollections
+        GIT_REPOSITORY https://github.com/apple/swift-collections.git
+        GIT_TAG 1.1.1)
+endif()
+FetchContent_MakeAvailable(SwiftFoundationICU SwiftCollections)
+
+list(APPEND CMAKE_MODULE_PATH ${SwiftFoundation_SOURCE_DIR}/cmake/modules)
+
+# Availability Macros (only applies to FoundationEssentials and FoundationInternationalization)
+set(_SwiftFoundation_availability_macros)
+list(APPEND _SwiftFoundation_availability_macros
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPreview 0.1:macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPreview 0.2:macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPreview 0.3:macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPreview 0.4:macOS 13.3, iOS 16.4, tvOS 16.4, watchOS 9.4\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicate 0.1:macOS 14, iOS 17, tvOS 17, watchOS 10\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicate 0.2:macOS 14, iOS 17, tvOS 17, watchOS 10\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicate 0.3:macOS 14, iOS 17, tvOS 17, watchOS 10\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicate 0.4:macOS 14, iOS 17, tvOS 17, watchOS 10\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.1:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.2:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.3:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.4:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">")
+
+include(SwiftFoundationSwiftSupport)
+
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Package.swift
+++ b/Package.swift
@@ -56,10 +56,10 @@ let package = Package(
             from: "1.1.0"),
         .package(
             url: "https://github.com/apple/swift-foundation-icu",
-            exact: "0.0.7"),
+            exact: "0.0.8"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "510.0.0")
+            from: "600.0.0-latest")
     ],
     targets: [
         // Foundation (umbrella)
@@ -91,6 +91,24 @@ let package = Package(
             .product(name: "_RopeModule", package: "swift-collections"),
             .product(name: "OrderedCollections", package: "swift-collections"),
           ],
+          exclude: [
+            "Formatting/CMakeLists.txt",
+            "PropertyList/CMakeLists.txt",
+            "Decimal/CMakeLists.txt",
+            "String/CMakeLists.txt",
+            "Error/CMakeLists.txt",
+            "Locale/CMakeLists.txt",
+            "Data/CMakeLists.txt",
+            "TimeZone/CMakeLists.txt",
+            "JSON/CMakeLists.txt",
+            "AttributedString/CMakeLists.txt",
+            "Calendar/CMakeLists.txt",
+            "Predicate/CMakeLists.txt",
+            "CMakeLists.txt",
+            "ProcessInfo/CMakeLists.txt",
+            "FileManager/CMakeLists.txt",
+            "URL/CMakeLists.txt"
+          ],
           cSettings: [
             .define("_GNU_SOURCE", .when(platforms: [.linux]))
           ],
@@ -119,6 +137,16 @@ let package = Package(
                 .target(name: "_CShims"),
                 .product(name: "_FoundationICU", package: "swift-foundation-icu")
             ],
+            exclude: [
+                "String/CMakeLists.txt",
+                "TimeZone/CMakeLists.txt",
+                "ICU/CMakeLists.txt",
+                "Formatting/CMakeLists.txt",
+                "Locale/CMakeLists.txt",
+                "Calendar/CMakeLists.txt",
+                "CMakeLists.txt",
+                "Predicate/CMakeLists.txt"
+            ],
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
             ] + availabilityMacros + concurrencyChecking
@@ -135,6 +163,7 @@ let package = Package(
                 .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ],
+            exclude: ["CMakeLists.txt"],
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
             ] + availabilityMacros + concurrencyChecking

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,18 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_subdirectory(_CShims)
+add_subdirectory(FoundationMacros)
+add_subdirectory(FoundationEssentials)
+add_subdirectory(FoundationInternationalization)

--- a/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
+++ b/Sources/FoundationEssentials/AttributedString/CMakeLists.txt
@@ -1,0 +1,37 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+target_sources(FoundationEssentials PRIVATE
+    AttributeContainer.swift
+    AttributeScope.swift
+    AttributedString+AttributeTransformation.swift
+    AttributedString+CharacterView.swift
+    AttributedString+Guts.swift
+    AttributedString+Runs+AttributeSlices.swift
+    AttributedString+Runs+Run.swift
+    AttributedString+Runs.swift
+    AttributedString+UnicodeScalarView.swift
+    AttributedString+_InternalRun.swift
+    AttributedString+_InternalRuns.swift
+    AttributedString+_InternalRunsSlice.swift
+    AttributedString.swift
+    AttributedStringAttribute.swift
+    AttributedStringAttributeConstrainingBehavior.swift
+    AttributedStringAttributeStorage.swift
+    AttributedStringCodable.swift
+    AttributedStringProtocol.swift
+    AttributedSubstring.swift
+    Collection\ Stdlib\ Defaults.swift
+    Conversion.swift
+    FoundationAttributes.swift
+    String.Index+ABI.swift)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -1,0 +1,77 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(FoundationEssentials
+    _ThreadLocal.swift
+    Bundle+Stub.swift
+    Codable.swift
+    CodableUtilities.swift
+    CodableWithConfiguration.swift
+    ComparisonResult.swift
+    Date.swift
+    DateInterval.swift
+    FoundationEssentials.swift
+    IndexPath.swift
+    LockedState.swift
+    Logging.swift
+    OutputBuffer.swift
+    Platform.swift
+    SortComparator.swift
+    UUID_Wrappers.swift
+    UUID.swift
+    WinSDK+Extensions.swift)
+
+add_subdirectory(AttributedString)
+add_subdirectory(Calendar)
+add_subdirectory(Data)
+add_subdirectory(Decimal)
+add_subdirectory(Error)
+add_subdirectory(FileManager)
+add_subdirectory(Formatting)
+add_subdirectory(JSON)
+add_subdirectory(Locale)
+add_subdirectory(Predicate)
+add_subdirectory(ProcessInfo)
+add_subdirectory(PropertyList)
+add_subdirectory(String)
+add_subdirectory(TimeZone)
+add_subdirectory(URL)
+
+# Depend on FoundationMacros
+add_dependencies(FoundationEssentials FoundationMacros)
+target_compile_options(FoundationEssentials PRIVATE -plugin-path ${CMAKE_BINARY_DIR}/lib)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -Xcc -Xfrontend -D_GNU_SOURCE>")
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+endif()
+
+target_compile_options(FoundationEssentials PRIVATE
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend VariadicGenerics>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_availability_macros})
+target_compile_options(FoundationEssentials PRIVATE -package-name "SwiftFoundation")
+
+target_link_libraries(FoundationEssentials PUBLIC
+    _CShims
+    _FoundationCollections)
+
+set_target_properties(FoundationEssentials PROPERTIES
+    INSTALL_RPATH "$ORIGIN")
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS FoundationEssentials)
+_swift_foundation_install_target(FoundationEssentials)

--- a/Sources/FoundationEssentials/Calendar/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Calendar/CMakeLists.txt
@@ -1,0 +1,26 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    Calendar.swift
+    Calendar_Autoupdating.swift
+    Calendar_Cache.swift
+    Calendar_Enumerate.swift
+    Calendar_Gregorian.swift
+    Calendar_Protocol.swift
+    Calendar_Recurrence.swift
+    Date+FormatStyle.swift
+    Date+Locale.swift
+    DateComponents.swift
+    RecurrenceRule.swift)

--- a/Sources/FoundationEssentials/Data/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Data/CMakeLists.txt
@@ -1,0 +1,25 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    Collections+DataProtocol.swift
+    ContiguousBytes.swift
+    Data+Base64.swift
+    Data+Error.swift
+    Data+Reading.swift
+    Data+Stub.swift
+    Data+Writing.swift
+    Data.swift
+    DataProtocol.swift
+    Pointers+DataProtocol.swift)

--- a/Sources/FoundationEssentials/Decimal/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Decimal/CMakeLists.txt
@@ -1,0 +1,16 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+target_sources(FoundationEssentials PRIVATE
+    Decimal.swift
+    Decimal+Conformances.swift)

--- a/Sources/FoundationEssentials/Error/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Error/CMakeLists.txt
@@ -1,0 +1,19 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+target_sources(FoundationEssentials PRIVATE
+    CocoaError+FilePath.swift
+    CocoaError.swift
+    ErrorCodes+POSIX.swift
+    ErrorCodes+Win32.swift
+    ErrorCodes.swift)

--- a/Sources/FoundationEssentials/FileManager/CMakeLists.txt
+++ b/Sources/FoundationEssentials/FileManager/CMakeLists.txt
@@ -1,0 +1,30 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    SearchPaths/FileManager+DarwinSearchPaths.swift
+    SearchPaths/FileManager+SearchPaths.swift
+    SearchPaths/FileManager+WindowsSearchPaths.swift
+    SearchPaths/FileManager+XDGSearchPaths.swift
+
+    FileManager+Basics.swift
+    FileManager+Bridge.swift
+    FileManager+Directories.swift
+    FileManager+Files.swift
+    FileManager+SymbolicLinks.swift
+    FileManager+Utilities.swift
+    FileOperations+Enumeration.swift
+    FileOperations.swift
+    SwiftFileManager.swift
+    SwiftFileManagerDelegate.swift)

--- a/Sources/FoundationEssentials/Formatting/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Formatting/CMakeLists.txt
@@ -1,0 +1,23 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    BinaryInteger+NumericStringRepresentation.swift
+    Date+ISO8601FormatStyle.swift
+    DiscreteFormatStyle.swift
+    FormatParsingUtilities.swift
+    FormatStyle.swift
+    FormatterCache.swift
+    ParseStrategy.swift
+    ParseableFormatStyle.swift)

--- a/Sources/FoundationEssentials/JSON/CMakeLists.txt
+++ b/Sources/FoundationEssentials/JSON/CMakeLists.txt
@@ -1,0 +1,24 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    BufferView.swift
+    BufferViewCompatibility.swift
+    BufferViewIndex.swift
+    BufferViewIterator.swift
+    JSON5Scanner.swift
+    JSONDecoder.swift
+    JSONEncoder.swift
+    JSONScanner.swift
+    JSONWriter.swift)

--- a/Sources/FoundationEssentials/Locale/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Locale/CMakeLists.txt
@@ -1,0 +1,23 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    Locale+Components.swift
+    Locale+Language.swift
+    Locale.swift
+    Locale_Autoupdating.swift
+    Locale_Cache.swift
+    Locale_Preferences.swift
+    Locale_Protocol.swift
+    Locale_Unlocalized.swift)

--- a/Sources/FoundationEssentials/Predicate/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Predicate/CMakeLists.txt
@@ -1,0 +1,51 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    Archiving/EncodingContainers+PredicateExpression.swift
+    Archiving/Predicate+Codable.swift
+    Archiving/PredicateCodableConfiguration.swift
+    Archiving/PredicateExpressionConstruction.swift
+    
+    Expressions/Aggregate.swift
+    Expressions/Arithmetic.swift
+    Expressions/Collection.swift
+    Expressions/Comparison.swift
+    Expressions/Conditional.swift
+    Expressions/Conjunction.swift
+    Expressions/Dictionary.swift
+    Expressions/Disjunction.swift
+    Expressions/Division.swift
+    Expressions/Equality.swift
+    Expressions/ExpressionEvaluation.swift
+    Expressions/Filter.swift
+    Expressions/Inequality.swift
+    Expressions/Negation.swift
+    Expressions/Optional.swift
+    Expressions/PredicateEvaluation.swift
+    Expressions/Range.swift
+    Expressions/Regex.swift
+    Expressions/Sequence.swift
+    Expressions/StringComparison.swift
+    Expressions/Types.swift
+    Expressions/UnaryMinus.swift
+    
+    Expression.swift
+    KeyPath+Inspection.swift
+    NSPredicateConversion.swift
+    Predicate+Description.swift
+    Predicate.swift
+    PredicateBindings.swift
+    PredicateExpression.swift)
+    

--- a/Sources/FoundationEssentials/ProcessInfo/CMakeLists.txt
+++ b/Sources/FoundationEssentials/ProcessInfo/CMakeLists.txt
@@ -1,0 +1,18 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    ProcessInfo+API.swift
+    ProcessInfo+ObjC.swift
+    ProcessInfo.swift)

--- a/Sources/FoundationEssentials/PropertyList/CMakeLists.txt
+++ b/Sources/FoundationEssentials/PropertyList/CMakeLists.txt
@@ -1,0 +1,28 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    BPlistDecodingFormat.swift
+    BPlistEncodingFormat.swift
+    BPlistScanner.swift
+    OpenStepPlist.swift
+    PlistDecoder.swift
+    PlistDecoderGeneric.swift
+    PlistDictionaryDecoder.swift
+    PlistDictionaryEncoder.swift
+    PlistEncoder.swift
+    PlistEncoderGeneric.swift
+    XMLPlistDecodingFormat.swift
+    XMLPlistEncodingFormat.swift
+    XMLPlistScanner.swift)

--- a/Sources/FoundationEssentials/String/CMakeLists.txt
+++ b/Sources/FoundationEssentials/String/CMakeLists.txt
@@ -1,0 +1,29 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    BidirectionalCollection.swift
+    BuiltInUnicodeScalarSet.swift
+    RegexPatternCache.swift
+    String+Comparison.swift
+    String+Encoding.swift
+    String+EndianAdaptorSequence.swift
+    String+Essentials.swift
+    String+IO.swift
+    String+Internals.swift
+    String+Path.swift
+    StringBlocks.swift
+    StringProtocol+Essentials.swift
+    StringProtocol+Stub.swift
+    UnicodeScalar.swift)

--- a/Sources/FoundationEssentials/TimeZone/CMakeLists.txt
+++ b/Sources/FoundationEssentials/TimeZone/CMakeLists.txt
@@ -1,0 +1,20 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    TimeZone.swift
+    TimeZone_Autoupdating.swift
+    TimeZone_Cache.swift
+    TimeZone_GMT.swift
+    TimeZone_Protocol.swift)

--- a/Sources/FoundationEssentials/URL/CMakeLists.txt
+++ b/Sources/FoundationEssentials/URL/CMakeLists.txt
@@ -1,0 +1,19 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_sources(FoundationEssentials PRIVATE
+    URL.swift
+    URLComponents.swift
+    URLComponents_ObjC.swift
+    URLParser.swift)

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -1,0 +1,46 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(FoundationInternationalization
+    BinaryFloatingPoint.swift
+    Date+ICU.swift
+    Duration+Utils.swift
+    RangeExpression.swift
+    TimeInterval+Utils.swift)
+
+add_subdirectory(Calendar)
+add_subdirectory(Formatting)
+add_subdirectory(ICU)
+add_subdirectory(Locale)
+add_subdirectory(Predicate)
+add_subdirectory(String)
+add_subdirectory(TimeZone)
+
+target_compile_options(FoundationInternationalization PRIVATE
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation_availability_macros})
+target_compile_options(FoundationInternationalization PRIVATE -package-name "SwiftFoundation")
+
+target_link_libraries(FoundationInternationalization PUBLIC
+    FoundationEssentials
+    _CShims
+    _FoundationICU)
+
+set_target_properties(FoundationInternationalization PROPERTIES
+    INSTALL_RPATH "$ORIGIN")
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS FoundationInternationalization)
+_swift_foundation_install_target(FoundationInternationalization)

--- a/Sources/FoundationInternationalization/Calendar/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/Calendar/CMakeLists.txt
@@ -1,0 +1,19 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    Calendar_Bridge.swift
+    Calendar_ICU.swift
+    Calendar_ObjC.swift)

--- a/Sources/FoundationInternationalization/Formatting/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/Formatting/CMakeLists.txt
@@ -1,0 +1,49 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    Date/Date+AnchoredRelativeFormatStyle.swift
+    Date/Date+ComponentsFormatStyle+Stub.swift
+    Date/Date+IntervalFormatStyle.swift
+    Date/Date+RelativeFormatStyle.swift
+    Date/Date+VerbatimFormatStyle.swift
+    Date/DateFieldSymbol.swift
+    Date/DateFormatString.swift
+    Date/DateFormatStyle.swift
+    Date/DateParseStrategy.swift
+    Date/ICUDateFormatter.swift
+    Date/ICUDateIntervalFormatter.swift
+    Date/ICURelativeDateFormatter.swift
+    
+    Number/BinaryFloatingPoint+FormatStyle.swift
+    Number/BinaryInteger+FormatStyle.swift
+    Number/Decimal+FormatStyle.swift
+    Number/Decimal+ParseStrategy.swift
+    Number/FloatingPointFormatStyle.swift
+    Number/FloatingPointParseStrategy.swift
+    Number/ICULegacyNumberFormatter.swift
+    Number/ICUNumberFormatter.swift
+    Number/IntegerFormatStyle.swift
+    Number/IntegerParseStrategy.swift
+    Number/NumberAttributedFormat.swift
+    Number/NumberFormatStyleConfiguration.swift
+    
+    ByteCountFormatStyle.swift
+    Duration+Formatting.swift
+    Duration+TimeFormatStyle.swift
+    Duration+UnitsFormatStyle.swift
+    ICUListFormatter.swift
+    ListFormatStyle.swift
+    Measurement+FormatStyle+Stub.swift)

--- a/Sources/FoundationInternationalization/ICU/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/ICU/CMakeLists.txt
@@ -1,0 +1,22 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    ICU+CaseMap.swift
+    ICU+Enumeration.swift
+    ICU+Enums.swift
+    ICU+FieldPositer.swift
+    ICU+Foundation.swift
+    ICUPatternGenerator.swift)

--- a/Sources/FoundationInternationalization/Locale/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/Locale/CMakeLists.txt
@@ -1,0 +1,20 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    Locale+Components_ICU.swift
+    Locale_Bridge.swift
+    Locale_ICU.swift
+    Locale_ObjC.swift)

--- a/Sources/FoundationInternationalization/Predicate/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/Predicate/CMakeLists.txt
@@ -1,0 +1,16 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE LocalizedString.swift)

--- a/Sources/FoundationInternationalization/String/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/String/CMakeLists.txt
@@ -1,0 +1,21 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    KeyPathComparator.swift
+    SortDescriptor.swift
+    String+Locale.swift
+    String+SortComparator.swift
+    StringProtocol+Locale.swift)

--- a/Sources/FoundationInternationalization/TimeZone/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/TimeZone/CMakeLists.txt
@@ -1,0 +1,20 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+target_include_directories(FoundationInternationalization PRIVATE .)
+target_sources(FoundationInternationalization PRIVATE
+    TimeZone_Bridge.swift
+    TimeZone_GMTICU.swift
+    TimeZone_ICU.swift
+    TimeZone_ObjC.swift)

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -1,0 +1,55 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# SwiftSyntax Dependency
+include(FetchContent)
+find_package(SwiftSyntax)
+if(NOT SwiftSyntax_FOUND)
+    # If building at desk, check out and link against the SwiftSyntax repo's targets
+    FetchContent_Declare(SwiftSyntax
+        GIT_REPOSITORY https://github.com/apple/swift-syntax.git
+        GIT_TAG 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c) # 600.0.0-prerelease-2024-06-12
+    FetchContent_MakeAvailable(SwiftSyntax)
+endif()
+
+add_library(FoundationMacros SHARED
+    FoundationMacros.swift
+    PredicateMacro.swift)
+    
+target_compile_definitions(FoundationMacros PRIVATE FOUNDATION_MACROS_LIBRARY)
+
+set_target_properties(FoundationMacros
+    PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/lib
+)
+
+target_link_libraries(FoundationMacros PUBLIC
+    SwiftSyntax::SwiftSyntax
+    SwiftSyntax::SwiftSyntaxMacros
+    SwiftSyntax::SwiftDiagnostics
+    SwiftSyntax::SwiftSyntaxBuilder
+)
+
+target_compile_options(FoundationMacros PRIVATE -parse-as-library)
+target_compile_options(FoundationMacros PRIVATE
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
+
+install(TARGETS FoundationMacros
+    ARCHIVE DESTINATION lib/swift/host/plugins
+    LIBRARY DESTINATION lib/swift/host/plugins
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Sources/_CShims/CMakeLists.txt
+++ b/Sources/_CShims/CMakeLists.txt
@@ -1,0 +1,35 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+add_library(_CShims STATIC
+    platform_shims.c
+    string_shims.c
+    uuid.c)
+
+target_include_directories(_CShims PUBLIC include)
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _CShims)
+
+if(BUILD_SHARED_LIBS)
+    set(install_directory swift)
+else()
+    set(install_directory swift_static)
+endif()
+
+# Install headers
+install(DIRECTORY
+            include/
+        DESTINATION
+            lib/${install_directory}/_CShims)
+

--- a/Sources/_CShims/include/_CShims.h
+++ b/Sources/_CShims/include/_CShims.h
@@ -10,14 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !FOUNDATION_FRAMEWORK && !FOUNDATION_MACROS_LIBRARY
+#ifndef _CShims_h
+#define _CShims_h
 
-import SwiftSyntaxMacros
-import SwiftCompilerPlugin
+#include "_CShimsTargetConditionals.h"
+#include "_CStdlib.h"
+#include "CFUniCharBitmapData.inc.h"
+#include "CFUniCharBitmapData.h"
+#include "string_shims.h"
+#include "bplist_shims.h"
+#include "io_shims.h"
+#include "platform_shims.h"
+#include "filemanager_shims.h"
+#include "uuid.h"
 
-@main
-struct FoundationMacros: CompilerPlugin {
-    var providingMacros: [Macro.Type] = [PredicateMacro.self, ExpressionMacro.self]
-}
-
+#if FOUNDATION_FRAMEWORK && !TARGET_OS_EXCLAVEKIT
+#include "sandbox_shims.h"
 #endif
+
+#endif /* _CShims_h */

--- a/Sources/_CShims/include/module.modulemap
+++ b/Sources/_CShims/include/module.modulemap
@@ -1,0 +1,5 @@
+module _CShims {
+    header "_CShims.h"
+
+    export *
+}

--- a/Sources/_CShims/include/string_shims.h
+++ b/Sources/_CShims/include/string_shims.h
@@ -24,6 +24,10 @@
 #include <xlocale.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_WIN32)
 #define locale_t _locale_t
 #endif
@@ -34,8 +38,12 @@
 
 INTERNAL int _stringshims_strncasecmp_l(const char * _Nullable s1, const char * _Nullable s2, size_t n, locale_t _Nullable loc);
 
-INTERNAL double _stringshims_strtod_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+INTERNAL double _stringshims_strtod_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
 
-INTERNAL float _stringshims_strtof_l(const char * _Nullable restrict nptr, char * _Nullable * _Nullable restrict endptr, locale_t _Nullable loc);
+INTERNAL float _stringshims_strtof_l(const char * _Nullable __restrict nptr, char * _Nullable * _Nullable __restrict endptr, locale_t _Nullable loc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CSHIMS_STRING_H */

--- a/Sources/_CShims/include/uuid.h
+++ b/Sources/_CShims/include/uuid.h
@@ -30,8 +30,8 @@
  * %End-Header%
  */
 
-#ifndef _UUID_UUID_H
-#define _UUID_UUID_H
+#ifndef _CSHIMS_UUID_UUID_H
+#define _CSHIMS_UUID_UUID_H
 
 #include "_CShimsTargetConditionals.h"
 #include "_CShimsMacros.h"
@@ -78,4 +78,4 @@ INTERNAL void _foundation_uuid_unparse_upper(const uuid_t uu, uuid_string_t out)
 }
 #endif
 
-#endif /* _UUID_UUID_H */
+#endif /* _CSHIMS_UUID_UUID_H */

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,26 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set(SWIFT_FOUNDATION_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftFoundationExports.cmake)
+set(SWIFT_FOUNDATION_ICU_EXPORTS_FILE ${SwiftFoundationICU_BINARY_DIR}/cmake/modules/SwiftFoundationICUExports.cmake)
+set(SWIFT_COLLECTIONS_EXPORTS_FILE ${SwiftCollections_BINARY_DIR}/cmake/modules/SwiftCollectionsExports.cmake)
+
+configure_file(SwiftFoundationConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/SwiftFoundationConfig.cmake)
+
+get_property(SWIFT_FOUNDATION_EXPORTS GLOBAL PROPERTY SWIFT_FOUNDATION_EXPORTS)
+export(TARGETS ${SWIFT_FOUNDATION_EXPORTS}
+    NAMESPACE SwiftFoundation::
+    FILE ${SWIFT_FOUNDATION_EXPORTS_FILE}
+    EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/cmake/modules/SwiftFoundationConfig.cmake.in
+++ b/cmake/modules/SwiftFoundationConfig.cmake.in
@@ -1,0 +1,19 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+if(NOT TARGET SwiftFoundation)
+    include(@SWIFT_FOUNDATION_ICU_EXPORTS_FILE@)
+    include(@SWIFT_COLLECTIONS_EXPORTS_FILE@)
+    include(@SWIFT_FOUNDATION_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/SwiftFoundationSwiftSupport.cmake
+++ b/cmake/modules/SwiftFoundationSwiftSupport.cmake
@@ -1,0 +1,54 @@
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  set(${result_var_name} ${SWIFT_SYSTEM_NAME} PARENT_SCOPE)
+endfunction()
+
+function(_swift_foundation_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(NOT SwiftFoundation_MODULE_TRIPLE)
+    set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+    if(CMAKE_Swift_COMPILER_TARGET)
+      list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+    endif()
+    execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+    string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+    set(SwiftFoundation_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+    mark_as_advanced(SwiftFoundation_MODULE_TRIPLE)
+  endif()
+
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftFoundation_MODULE_TRIPLE}.swiftdoc)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftFoundation_MODULE_TRIPLE}.swiftmodule)
+
+endfunction()


### PR DESCRIPTION
Add Cmake support for SwiftFoundation which includes
- Adding CMakeLists.txt in major directories;
- Adding `module.modulemap` for `_CShims`

Note: I had to change `uuid.h`'s header guard because it's somehow conflicting with system ones while using Cmake to build.

---
# Testing Notes

In order to build `SwiftFoundation` with Cmake you will need to install `cmake` and `ninja`: `brew install cmake && brew install ninja`

Currently the Cmake build for `SwiftFoundationICU` (`SwiftFoundation`'s dependency) is hitting two compiler crashes. To work around these issues, first download the nightly Swift snapshot **newer than 4/25's build**. Then add the following lines in the main `CMakeLists.txt` file, right after `cmake_minimum_required`:

```cmake
set(CMAKE_BUILD_TYPE "RelWithDebInfo")
set(CMAKE_Swift_COMPILER "/Library/Developer/Toolchains/<Toolchain you downloaded>/usr/bin/swiftc")
```

As of now, the main `CMakeLists.txt` does not fetch dependencies for you (yet). You'll have to manually checkout `SwiftFoundation`'s two dependencies:
- https://github.com/iCharlesHu/swift-foundation-icu.git (branch `charles/cmake-support`)
- https://github.com/apple/swift-collections.git (branch `release/1.1`)

Next, go to each directory and manually build them: `cmake -S . -B ./build -G Ninja && cd ./build && ninja`

Finally, add these two lines to `SwiftFoundation`'s main `CMakeLists.txt`, right below the two lines you just added:
```cmake
set(SwiftCollections_DIR "/path/to/SwiftCollections/build/cmake/modules")
set(SwiftFoundationICU_DIR "/path/to/SwiftFoundationICU/build/cmake/modules")
```
**Make sure to use the `build` folder above**. This will instruct Cmake to use the dependencies you just checked out.

Now you can finally build SwiftFoundation with Cmake:
```
cmake -S . -B ./build -G Ninja && cd ./build && ninja
```