### PR TITLE
FoundationEssentials: properly handle env duplication

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -90,7 +90,9 @@ final class _ProcessInfo: Sendable {
 
         var pwszEnvironmentEntry: LPWCH? = pwszEnvironmentBlock
         while let value = pwszEnvironmentEntry {
-            values.append(String(decodingCString: value, as: UTF16.self).withCString { _strdup($0)! })
+            let entry = String(decodingCString: value, as: UTF16.self)
+            if entry.isEmpty { break }
+            values.append(entry.withCString { _strdup($0)! })
             pwszEnvironmentEntry = pwszEnvironmentEntry?.advanced(by: wcslen(value) + 1)
         }
 #else


### PR DESCRIPTION
The terminator is a valid string and will give a valid pointer. However, the string itself is empty (`\0\0`) and indicates the termination of the process environment block. Handle this properly to avoid a buffer overrun.