### PR TITLE
Use the #Expression macro instead of initializing Expression directly

### DIFF
--- a/Sources/FoundationMacros/FoundationMacros.swift
+++ b/Sources/FoundationMacros/FoundationMacros.swift
@@ -17,7 +17,7 @@ import SwiftCompilerPlugin
 
 @main
 struct FoundationMacros: CompilerPlugin {
-  var providingMacros: [Macro.Type] = [PredicateMacro.self]
+    var providingMacros: [Macro.Type] = [PredicateMacro.self, ExpressionMacro.self]
 }
 
 #endif

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -547,11 +547,8 @@ final class PredicateCodableTests: XCTestCase {
     }
     
     func testExpression() throws {
-        let expression = Expression<Object, Int>() {
-            PredicateExpressions.build_KeyPath(
-                root: PredicateExpressions.build_Arg($0),
-                keyPath: \.a
-            )
+        let expression = #Expression<Object, Int> {
+            $0.a
         }
         let decoded = try _encodeDecode(expression, for: StandardConfig.self)
         var object = Object.example

--- a/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateConversionTests.swift
@@ -448,11 +448,8 @@ final class NSPredicateConversionTests: XCTestCase {
     }
     
     func testExpression() {
-        let expression = Expression<ObjCObject, Int>() {
-            PredicateExpressions.build_KeyPath(
-                root: PredicateExpressions.build_Arg($0),
-                keyPath: \.a
-            )
+        let expression = #Expression<ObjCObject, Int> {
+            $0.a
         }
         let converted = convert(expression)
         XCTAssertEqual(converted, NSExpression(format: "a"))

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -458,12 +458,8 @@ final class PredicateTests: XCTestCase {
             throw XCTSkip("This test is not available on this OS version")
         }
         
-        let expression = Expression<Int, Int>() {
-            PredicateExpressions.build_Arithmetic(
-                lhs: PredicateExpressions.build_Arg($0),
-                rhs: PredicateExpressions.build_Arg(1),
-                op: .add
-            )
+        let expression = #Expression<Int, Int> {
+            $0 + 1
         }
         for i in 0 ..< 10 {
             XCTAssertEqual(try expression.evaluate(i), i + 1)


### PR DESCRIPTION
Now that blocking issues have been resolved, we can update our unit tests to invoke the `#Expression` macro directly instead of initializing an `Expression` without the macro