### PR TITLE
FoundationInternationalization: add missing import for Windows

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -18,6 +18,8 @@ import FoundationEssentials
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(Windows)
+import CRT
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)


### PR DESCRIPTION
Add the missing import for Windows which is required for the type-generic math routines to function.