### PR TITLE
FoundationEssentials: correct an off-by-one error on Windows

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -64,7 +64,7 @@ extension String {
 
             let dwLength = GetFullPathNameW(pwszPath, 0, nil, nil)
             let path = try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
-                guard GetFullPathNameW(pwszPath, DWORD($0.count), $0.baseAddress, nil) == dwLength else {
+                guard GetFullPathNameW(pwszPath, DWORD($0.count), $0.baseAddress, nil) == dwLength - 1 else {
                     throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
                 }
                 return String(decodingCString: $0.baseAddress!, as: UTF16.self)


### PR DESCRIPTION
The returned value in the success case does not account for the terminating nul character, resulting in the value being 1 less than the allocation required. This was causing a spurious failure and thus unable to compute the location of the process.