### PR TITLE
Use URL in JSON/Data APIs

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Stub.swift
+++ b/Sources/FoundationEssentials/Data/Data+Stub.swift
@@ -52,7 +52,7 @@ internal enum PathOrURL {
     var path: String {
         switch self {
         case .path(let p): return p
-        case .url(let u): return u.fileSystemPath
+        case .url(let u): return u.path
         }
     }
 }

--- a/Sources/FoundationEssentials/Data/Data+Stub.swift
+++ b/Sources/FoundationEssentials/Data/Data+Stub.swift
@@ -52,7 +52,7 @@ internal enum PathOrURL {
     var path: String {
         switch self {
         case .path(let p): return p
-        case .url(let u): return u.path
+        case .url(let u): return u.path(percentEncoded: false)
         }
     }
 }

--- a/Sources/FoundationEssentials/Data/Data+Stub.swift
+++ b/Sources/FoundationEssentials/Data/Data+Stub.swift
@@ -52,7 +52,7 @@ internal enum PathOrURL {
     var path: String {
         switch self {
         case .path(let p): return p
-        case .url(let u): return u.path(percentEncoded: false)
+        case .url(let u): return u.fileSystemPath
         }
     }
 }

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -603,10 +603,10 @@ extension JSONDecoderImpl: Decoder {
         if type == Data.self {
             return try self.unwrapData(from: mapValue, for: codingPathNode, additionalKey) as! T
         }
-#if FOUNDATION_FRAMEWORK // TODO: Reenable once URL and Decimal are moved
         if type == URL.self {
             return try self.unwrapURL(from: mapValue, for: codingPathNode, additionalKey) as! T
         }
+#if FOUNDATION_FRAMEWORK // TODO: Reenable once Decimal is moved
         if type == Decimal.self {
             return try self.unwrapDecimal(from: mapValue, for: codingPathNode, additionalKey) as! T
         }
@@ -688,7 +688,6 @@ extension JSONDecoderImpl: Decoder {
         }
     }
 
-#if FOUNDATION_FRAMEWORK // TODO: Reenable once URL and Decimal has been moved
     private func unwrapURL(from mapValue: JSONMap.Value, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> URL {
         try checkNotNull(mapValue, expectedType: URL.self, for: codingPathNode, additionalKey)
 
@@ -700,6 +699,7 @@ extension JSONDecoderImpl: Decoder {
         return url
     }
 
+#if FOUNDATION_FRAMEWORK // TODO: Reenable once Decimal has been moved
     private func unwrapDecimal(from mapValue: JSONMap.Value, for codingPathNode: _CodingPathNode, _ additionalKey: (some CodingKey)? = nil) throws -> Decimal {
         try checkNotNull(mapValue, expectedType: Decimal.self, for: codingPathNode, additionalKey)
 

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -1111,11 +1111,11 @@ private extension __JSONEncoder {
         case is Data.Type:
             // Respect Data encoding strategy
             return try self.wrap(value as! Data, for: node, additionalKey)
-#if FOUNDATION_FRAMEWORK // TODO: Reenable once URL and Decimal are moved
         case is URL.Type:
             // Encode URLs as single strings.
             let url = value as! URL
             return self.wrap(url.absoluteString)
+#if FOUNDATION_FRAMEWORK // TODO: Reenable once Decimal is moved
         case is Decimal.Type:
             let decimal = value as! Decimal
             return .number(decimal.description)

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -466,12 +466,12 @@ extension _ProcessInfo {
 #if os(Linux)
     // Support for CFS quotas for cpu count as used by Docker.
     // Based on swift-nio code, https://github.com/apple/swift-nio/pull/1518
-    private static let cfsQuotaPath = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_quota_us", directoryHint: .notDirectory)
-    private static let cfsPeriodPath = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_period_us", directoryHint: .notDirectory)
-    private static let cpuSetPath = URL(filePath: "/sys/fs/cgroup/cpuset/cpuset.cpus", directoryHint: .notDirectory)
+    private static let cfsQuotaURL = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_quota_us", directoryHint: .notDirectory)
+    private static let cfsPeriodURL = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_period_us", directoryHint: .notDirectory)
+    private static let cpuSetURL = URL(filePath: "/sys/fs/cgroup/cpuset/cpuset.cpus", directoryHint: .notDirectory)
 
-    private static func firstLineOfFile(path: URL) throws -> Substring {
-        let data = try Data(contentsOf: path)
+    private static func firstLineOfFile(_ url: URL) throws -> Substring {
+        let data = try Data(contentsOf: url)
         if let string = String(data: data, encoding: .utf8), let line = string.split(separator: "\n").first {
             return line
         } else {
@@ -490,8 +490,8 @@ extension _ProcessInfo {
         return 1 + last - first
     }
 
-    private static func coreCount(cpuset cpusetPath: URL) -> Int? {
-        guard let cpuset = try? firstLineOfFile(path: cpusetPath).split(separator: ","),
+    private static func coreCount(cpuset cpusetURL: URL) -> Int? {
+        guard let cpuset = try? firstLineOfFile(cpusetURL).split(separator: ","),
               !cpuset.isEmpty
         else { return nil }
         if let first = cpuset.first, let count = countCoreIds(cores: first) {
@@ -501,11 +501,11 @@ extension _ProcessInfo {
         }
     }
 
-    private static func coreCount(quota quotaPath: URL,  period periodPath: URL) -> Int? {
-        guard let quota = try? Int(firstLineOfFile(path: quotaPath)),
+    private static func coreCount(quota quotaURL: URL,  period periodURL: URL) -> Int? {
+        guard let quota = try? Int(firstLineOfFile(quotaURL)),
               quota > 0
         else { return nil }
-        guard let period = try? Int(firstLineOfFile(path: periodPath)),
+        guard let period = try? Int(firstLineOfFile(periodURL)),
               period > 0
         else { return nil }
 
@@ -513,9 +513,9 @@ extension _ProcessInfo {
     }
 
     private static func fsCoreCount() -> Int? {
-        if let quota = coreCount(quota: cfsQuotaPath, period: cfsPeriodPath) {
+        if let quota = coreCount(quota: cfsQuotaURL, period: cfsPeriodURL) {
             return quota
-        } else if let cpusetCount = coreCount(cpuset: cpuSetPath) {
+        } else if let cpusetCount = coreCount(cpuset: cpuSetURL) {
             return cpusetCount
         } else {
             return nil

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -262,7 +262,7 @@ extension _ProcessInfo {
 #if os(macOS)
         var versionString = "macOS"
 #elseif os(Linux)
-        if let osReleaseContents = try? Data(contentsOf: "/etc/os-release") {
+        if let osReleaseContents = try? Data(contentsOf: URL(filePath: "/etc/os-release", directoryHint: .notDirectory)) {
             let strContents = String(decoding: osReleaseContents, as: UTF8.self)
             if let name = strContents.split(separator: "\n").first(where: { $0.hasPrefix("PRETTY_NAME=") }) {
                 // This is extremely simplistic but manages to work for all known cases.
@@ -466,12 +466,11 @@ extension _ProcessInfo {
 #if os(Linux)
     // Support for CFS quotas for cpu count as used by Docker.
     // Based on swift-nio code, https://github.com/apple/swift-nio/pull/1518
-    private static let cfsQuotaPath = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-    private static let cfsPeriodPath = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-    private static let cpuSetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+    private static let cfsQuotaPath = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_quota_us", directoryHint: .notDirectory)
+    private static let cfsPeriodPath = URL(filePath: "/sys/fs/cgroup/cpu/cpu.cfs_period_us", directoryHint: .notDirectory)
+    private static let cpuSetPath = URL(filePath: "/sys/fs/cgroup/cpuset/cpuset.cpus", directoryHint: .notDirectory)
 
-    private static func firstLineOfFile(path: String) throws -> Substring {
-        // TODO: Replace with URL version once that is available in FoundationEssentials
+    private static func firstLineOfFile(path: URL) throws -> Substring {
         let data = try Data(contentsOf: path)
         if let string = String(data: data, encoding: .utf8), let line = string.split(separator: "\n").first {
             return line
@@ -491,7 +490,7 @@ extension _ProcessInfo {
         return 1 + last - first
     }
 
-    private static func coreCount(cpuset cpusetPath: String) -> Int? {
+    private static func coreCount(cpuset cpusetPath: URL) -> Int? {
         guard let cpuset = try? firstLineOfFile(path: cpusetPath).split(separator: ","),
               !cpuset.isEmpty
         else { return nil }
@@ -502,7 +501,7 @@ extension _ProcessInfo {
         }
     }
 
-    private static func coreCount(quota quotaPath: String,  period periodPath: String) -> Int? {
+    private static func coreCount(quota quotaPath: URL,  period periodPath: URL) -> Int? {
         guard let quota = try? Int(firstLineOfFile(path: quotaPath)),
               quota > 0
         else { return nil }

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1304,7 +1304,7 @@ public struct URL: Equatable, Sendable, Hashable {
         return Parser.percentDecode(result, excluding: charsToLeaveEncoded) ?? ""
     }
 
-    private var fileSystemPath: String {
+    var fileSystemPath: String {
         return fileSystemPath(for: path())
     }
 

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -28,18 +28,10 @@ class DataIOTests : XCTestCase {
     
     // MARK: - Helpers
     
-#if FOUNDATION_FRAMEWORK
     func testURL() -> URL {
         // Generate a random file name
         URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("testfile-\(UUID().uuidString)")
     }
-#else
-    /// Temporary helper until we port `URL` to swift-foundation.
-    func testURL() -> String {
-        // Generate a random file name
-        String.temporaryDirectoryPath.appendingPathComponent("testfile-\(UUID().uuidString)")
-    }
-#endif
     
     func generateTestData() -> Data {
         // 16 MB file, big enough to trigger things like chunking
@@ -59,7 +51,6 @@ class DataIOTests : XCTestCase {
         return Data(bytesNoCopy: ptr, count: count, deallocator: .free)
     }
             
-#if FOUNDATION_FRAMEWORK
     func writeAndVerifyTestData(to url: URL, writeOptions: Data.WritingOptions = [], readOptions: Data.ReadingOptions = []) throws {
         let data = generateTestData()
         try data.write(to: url, options: writeOptions)
@@ -74,19 +65,6 @@ class DataIOTests : XCTestCase {
             // Ignore
         }
     }
-#else
-    func writeAndVerifyTestData(to path: String, writeOptions: Data.WritingOptions = [], readOptions: Data.ReadingOptions = []) throws {
-        let data = generateTestData()
-        try data.write(to: path, options: writeOptions)
-        let readData = try Data(contentsOf: path, options: readOptions)
-        XCTAssertEqual(data, readData)
-    }
-
-    func cleanup(at path: String) {
-        _ = unlink(path)
-        // Ignore any errors
-    }
-#endif
     
     
     // MARK: - Tests
@@ -244,9 +222,9 @@ class DataIOTests : XCTestCase {
         throw XCTSkip("This test is only supported on Linux and Windows")
         #else
         #if os(Windows)
-        let path = "CON"
+        let path = URL(filePath: "CON", directoryHint: .notDirectory)
         #else
-        let path = "/dev/stdout"
+        let path = URL(filePath: "/dev/stdout", directoryHint: .notDirectory)
         #endif
         XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: path))
         #endif

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -2768,9 +2768,9 @@ extension JSONEncoderTests {
         _testRoundTrip(of: testBigDecimal)
     }
 }
+#endif // FOUNDATION_FRAMEWORK
 
 // MARK: - URL Tests
-// TODO: Reenable these tests once URL is moved
 extension JSONEncoderTests {
     func testInterceptURL() {
         // Want to make sure JSONEncoder writes out single-value URLs, not the keyed encoding.
@@ -2792,7 +2792,6 @@ extension JSONEncoderTests {
         _testRoundTrip(of: Optional(url), expectedJSON: expectedJSON, outputFormatting: [.withoutEscapingSlashes])
     }
 }
-#endif // FOUNDATION_FRAMEWORK
 
 // MARK: - Helper Global Functions
 func expectEqualPaths(_ lhs: [CodingKey], _ rhs: [CodingKey], _ prefix: String) {
@@ -2942,7 +2941,6 @@ fileprivate struct Address : Codable, Equatable {
 fileprivate class Person : Codable, Equatable {
   let name: String
   let email: String
-#if FOUNDATION_FRAMEWORK
   let website: URL?
 
 
@@ -2951,22 +2949,11 @@ fileprivate class Person : Codable, Equatable {
     self.email = email
     self.website = website
   }
-#else
-  init(name: String, email: String) {
-    self.name = name
-    self.email = email
-  }
-#endif
 
   func isEqual(_ other: Person) -> Bool {
-#if FOUNDATION_FRAMEWORK
     return self.name == other.name &&
            self.email == other.email &&
            self.website == other.website
-#else
-    return self.name == other.name &&
-           self.email == other.email
-#endif
   }
 
   static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
@@ -2982,17 +2969,10 @@ fileprivate class Person : Codable, Equatable {
 fileprivate class Employee : Person {
   let id: Int
 
-#if FOUNDATION_FRAMEWORK
   init(name: String, email: String, website: URL? = nil, id: Int) {
     self.id = id
     super.init(name: name, email: email, website: website)
   }
-#else
-  init(name: String, email: String, id: Int) {
-    self.id = id
-    super.init(name: name, email: email)
-  }
-#endif
 
   enum CodingKeys : String, CodingKey {
     case id
@@ -3721,9 +3701,7 @@ extension JSONPass {
             let array : [String]
             let object : [String:String]
             let address : String
-            #if FOUNDATION_FRAMEWORK
             let url : URL
-            #endif
             let comment : String
             let special_sequences_key : String
             let spaced : [Int]
@@ -3757,9 +3735,7 @@ extension JSONPass {
                 case array
                 case object
                 case address
-                #if FOUNDATION_FRAMEWORK
                 case url
-                #endif
                 case comment
                 case special_sequences_key = "# -- --> */"
                 case spaced = " s p a c e d "

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -48,17 +48,22 @@ func testData(forResource resource: String, withExtension ext: String, subdirect
     guard let url = Bundle.module.url(forResource: resource, withExtension: ext, subdirectory: subdir) else {
         return nil
     }
+    
+    let essentialsURL = FoundationEssentials.URL(filePath: url.path(percentEncoded: false))
 
-    return try? Data(contentsOf: url.path(percentEncoded: false))
+    return try? Data(contentsOf: essentialsURL)
 #else
     // swiftpm drops the resources next to the executable, at:
     // ./FoundationPreview_FoundationEssentialsTests.resources/Resources/
     // Hard-coding the path is unfortunate, but a temporary need until we have a better way to handle this
-    var path = ProcessInfo.processInfo.arguments[0].deletingLastPathComponent() + "/FoundationPreview_FoundationEssentialsTests.resources/Resources/"
+    var path = URL(filePath: ProcessInfo.processInfo.arguments[0])
+        .deletingLastPathComponent()
+        .appending(component: "FoundationPreview_FoundationEssentialsTests.resources", directoryHint: .isDirectory)
+        .appending(component: "Resources", directoryHint: .isDirectory)
     if let subdirectory {
-        path += subdirectory + "/"
+        path.append(component: subdirectory, directoryHint: .isDirectory)
     }
-    path += resource + "." + ext
+    path.append(component: resource + "." + ext, directoryHint: .notDirectory)
     return try? Data(contentsOf: path)
 #endif
 #endif

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -49,7 +49,7 @@ func testData(forResource resource: String, withExtension ext: String, subdirect
         return nil
     }
     
-    let essentialsURL = FoundationEssentials.URL(filePath: url.path(percentEncoded: false))
+    let essentialsURL = FoundationEssentials.URL(filePath: url.fileSystemPath)
 
     return try? Data(contentsOf: essentialsURL)
 #else

--- a/Tests/FoundationEssentialsTests/ResourceUtilities.swift
+++ b/Tests/FoundationEssentialsTests/ResourceUtilities.swift
@@ -49,7 +49,7 @@ func testData(forResource resource: String, withExtension ext: String, subdirect
         return nil
     }
     
-    let essentialsURL = FoundationEssentials.URL(filePath: url.fileSystemPath)
+    let essentialsURL = FoundationEssentials.URL(filePath: url.path)
 
     return try? Data(contentsOf: essentialsURL)
 #else
@@ -61,7 +61,7 @@ func testData(forResource resource: String, withExtension ext: String, subdirect
         .appending(component: "FoundationPreview_FoundationEssentialsTests.resources", directoryHint: .isDirectory)
         .appending(component: "Resources", directoryHint: .isDirectory)
     if let subdirectory {
-        path.append(component: subdirectory, directoryHint: .isDirectory)
+        path.append(path: subdirectory, directoryHint: .isDirectory)
     }
     path.append(component: resource + "." + ext, directoryHint: .notDirectory)
     return try? Data(contentsOf: path)


### PR DESCRIPTION
Now that we have the `URL` type ported to swift-foundation, we can begin adopting it in our other APIs. This PR removes the `FOUNDATION_FRAMEWORK` blocks around usages of `URL` in `JSONEncoder`/`JSONDecoder` and the `Data` reading/writing APIs. I'll followup with a change for `FileManager`, but this should bring Data/JSON APIs on-par with what Foundation provides for URL-related behavior and APIs (and removes some of the temporary `String`-based APIs we added