### PR TITLE
Utilize URL in FileManager

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -51,6 +51,7 @@ extension _FileManagerImpl {
         URL(filePath: String.temporaryDirectoryPath, directoryHint: .isDirectory)
     }
     
+    #if canImport(Darwin)
     func url(
         for directory: FileManager.SearchPathDirectory,
         in domain: FileManager.SearchPathDomainMask,
@@ -114,6 +115,7 @@ extension _FileManagerImpl {
             URL(fileURLWithPath: $0, isDirectory: true)
         }
     }
+    #endif
     
     #if FOUNDATION_FRAMEWORK
     func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -51,13 +51,14 @@ extension _FileManagerImpl {
         URL(filePath: String.temporaryDirectoryPath, directoryHint: .isDirectory)
     }
     
-#if FOUNDATION_FRAMEWORK
     func url(
         for directory: FileManager.SearchPathDirectory,
         in domain: FileManager.SearchPathDomainMask,
         appropriateFor url: URL?,
         create shouldCreate: Bool
     ) throws -> URL {
+        #if FOUNDATION_FRAMEWORK
+        // TODO: Support correct trash/replacement locations in swift-foundation
         #if os(macOS) || os(iOS)
         if let url, directory == .trashDirectory {
             return try fileManager._URLForTrashingItem(at: url, create: shouldCreate)
@@ -71,8 +72,12 @@ extension _FileManagerImpl {
         if domain == .systemDomainMask {
             domain = ._partitionedSystemDomainMask
         }
+        let lastElement = domain == ._partitionedSystemDomainMask
+        #else
+        let lastElement = false
+        #endif
         let paths = Array(_SearchPaths(for: directory, in: domain, expandTilde: true))
-        guard let path = domain == ._partitionedSystemDomainMask ? paths.last : paths.first else {
+        guard let path = lastElement ? paths.last : paths.first else {
             throw CocoaError(.fileReadUnknown)
         }
         
@@ -81,16 +86,20 @@ extension _FileManagerImpl {
             _LogSpecialFolderRecreation(fileManager, path)
             #endif
             var isUserDomain = domain == .userDomainMask
-            #if os(macOS)
+            #if os(macOS) && FOUNDATION_FRAMEWORK
             isUserDomain = isUserDomain || domain == ._sharedUserDomainMask
             #endif
             var attrDictionary: [FileAttributeKey : Any] = [:]
             if isUserDomain {
                 attrDictionary[.posixPermissions] = 0o700
-            } else if domain == ._partitionedSystemDomainMask {
-                attrDictionary[.posixPermissions] = 0o755
-                attrDictionary[.ownerAccountID] = 0 // root
-                attrDictionary[.groupOwnerAccountID] = 80 // admin
+            } else {
+                #if FOUNDATION_FRAMEWORK
+                if domain == ._partitionedSystemDomainMask {
+                    attrDictionary[.posixPermissions] = 0o755
+                    attrDictionary[.ownerAccountID] = 0 // root
+                    attrDictionary[.groupOwnerAccountID] = 80 // admin
+                }
+                #endif
             }
             try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: attrDictionary)
         }
@@ -106,6 +115,7 @@ extension _FileManagerImpl {
         }
     }
     
+    #if FOUNDATION_FRAMEWORK
     func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? {
         groupIdentifier.withCString {
             guard let path = container_create_or_lookup_app_group_path_by_app_group_identifier($0, nil)  else {

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -164,7 +164,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, removingItemAtPath: path)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, removingItemAtPath: path)
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, removingItemAt: URL(fileURLWithPath: path))
             #endif
         }
         
@@ -181,7 +181,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldRemoveItemAtPath: path)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldRemoveItemAtPath: path)
+            delegateResponse = delegate.fileManager(self, shouldRemoveItemAt: URL(fileURLWithPath: path))
             #endif
         }
         return delegateResponse ?? true
@@ -198,7 +198,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, copyingItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, copyingItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, copyingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         
@@ -215,7 +215,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldCopyItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldCopyItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldCopyItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         return delegateResponse ?? true
@@ -232,7 +232,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, linkingItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, linkingItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, linkingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         
@@ -249,7 +249,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldLinkItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldLinkItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldLinkItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         return delegateResponse ?? true
@@ -266,7 +266,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldProceedAfterError: error, movingItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, movingItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldProceedAfterError: error, movingItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         
@@ -283,7 +283,7 @@ extension FileManager {
                 delegateResponse = delegate.fileManager?(self, shouldMoveItemAtPath: path, toPath: dst)
             }
             #else
-            delegateResponse = delegate.fileManager(self, shouldMoveItemAtPath: path, toPath: dst)
+            delegateResponse = delegate.fileManager(self, shouldMoveItemAt: URL(fileURLWithPath: path), to: URL(fileURLWithPath: dst))
             #endif
         }
         return delegateResponse ?? true

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -185,7 +185,7 @@ open class FileManager {
     
     open weak var delegate: (any FileManagerDelegate)?
     
-    init() {
+    public init() {
         _impl = _FileManagerImpl()
         _impl._manager = self
     }
@@ -209,6 +209,14 @@ open class FileManager {
     open func subpathsOfDirectory(atPath path: String) throws -> [String] {
         try _impl.subpathsOfDirectory(atPath: path)
     }
+    
+    open func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        _impl.urls(for: directory, in: domainMask)
+    }
+    
+    open func url(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
+        try _impl.url(for: directory, in: domain, appropriateFor: url, create: shouldCreate)
+    }
 
     open func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
         try _impl.attributesOfItem(atPath: path)
@@ -220,6 +228,10 @@ open class FileManager {
 
     open func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
         try _impl.createSymbolicLink(atPath: path, withDestinationPath: destPath)
+    }
+    
+    open func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws {
+        try _impl.createSymbolicLink(at: url, withDestinationURL: destURL)
     }
 
     open func destinationOfSymbolicLink(atPath path: String) throws -> String {

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -210,6 +210,7 @@ open class FileManager {
         try _impl.subpathsOfDirectory(atPath: path)
     }
     
+    #if canImport(Darwin)
     open func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
         _impl.urls(for: directory, in: domainMask)
     }
@@ -217,6 +218,7 @@ open class FileManager {
     open func url(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
         try _impl.url(for: directory, in: domain, appropriateFor: url, create: shouldCreate)
     }
+    #endif
 
     open func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
         try _impl.attributesOfItem(atPath: path)

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
@@ -13,6 +13,7 @@
 #if !FOUNDATION_FRAMEWORK
 
 public protocol FileManagerDelegate : AnyObject {
+    // String-based requirements
     func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
     func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool
@@ -21,8 +22,19 @@ public protocol FileManagerDelegate : AnyObject {
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
     func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool
+    
+    // URL-based requirements
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAt srcURL: URL, to dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAt URL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAt URL: URL) -> Bool
 }
 
+// Default implementations for String-based requirements
 extension FileManagerDelegate {
     func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
@@ -32,6 +44,41 @@ extension FileManagerDelegate {
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
     func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool { return true }
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool { return false }
+}
+
+// Default implementations for URL-based requirements
+extension FileManagerDelegate {
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldCopyItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldProceedAfterError: error, copyingItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldMoveItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldProceedAfterError: error, movingItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldLinkItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAt srcURL: URL, to dstURL: URL) -> Bool {
+        self.fileManager(fileManager, shouldProceedAfterError: error, linkingItemAtPath: srcURL.relativePath, toPath: dstURL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAt URL: URL) -> Bool {
+        self.fileManager(fileManager, shouldRemoveItemAtPath: URL.relativePath)
+    }
+    
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAt URL: URL) -> Bool {
+        self.fileManager(fileManager, shouldProceedAfterError: error, removingItemAtPath: URL.relativePath)
+    }
 }
 
 #endif

--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -34,7 +34,7 @@ extension String {
                     }
                 }
             } else {
-                var earlyCheckAllASCII = self.utf8.withContiguousStorageIfAvailable {
+                let earlyCheckAllASCII = self.utf8.withContiguousStorageIfAvailable {
                     _allASCII($0)
                 }
                 if let earlyCheckAllASCII, !earlyCheckAllASCII {

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1221,7 +1221,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                 }
 
                 // Check prefs
-                if let firstWeekdayPref = prefs?.firstWeekday {
+                if prefs?.firstWeekday != nil {
                     // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
                     let calendarId = _lockedCalendarIdentifier(&state)
                     if let first = forceFirstWeekday(calendarId) {

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1221,7 +1221,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                 }
 
                 // Check prefs
-                if prefs?.firstWeekday != nil {
+                if let firstWeekdayPref = prefs?.firstWeekday {
                     // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
                     let calendarId = _lockedCalendarIdentifier(&state)
                     if let first = forceFirstWeekday(calendarId) {


### PR DESCRIPTION
Now that we have `URL` in `FileManager`, we can adopt it throughout the APIs. Many of the APIs already existed using the `URL` stub previously available, but now the delegate methods and other APIs have been updated to use the full `URL` implementation.

Some APIs are currently still not available/ported because they rely on the `URLResourceValues` implementation which hasn't been ported yet. Those will be added in a followup PR. I also made 2 minor warning fixes while I was here.