### PR TITLE
Use ICU-equivalent \b behavior with Regex for String.range(of:)

### DIFF
--- a/Sources/FoundationEssentials/String/RegexPatternCache.swift
+++ b/Sources/FoundationEssentials/String/RegexPatternCache.swift
@@ -34,7 +34,7 @@ struct RegexPatternCache: @unchecked Sendable {
                 return cached
             }
 
-            var r = try Regex(pattern)
+            var r = try Regex(pattern).wordBoundaryKind(.simple)
             if caseInsensitive {
                 r = r.ignoresCase()
             }

--- a/Sources/FoundationEssentials/String/String+Comparison.swift
+++ b/Sources/FoundationEssentials/String/String+Comparison.swift
@@ -600,7 +600,7 @@ extension Substring {
     }
 
     func _range(of strToFind: Substring, options: String.CompareOptions) throws -> Range<Index>? {
-        #if canImport(FoundationICU)
+        #if !NO_REGEX
         if options.contains(.regularExpression) {
             guard let regex = try RegexPatternCache.cache.regex(for: String(strToFind), caseInsensitive: options.contains(.caseInsensitive)) else {
                 return nil

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -307,6 +307,14 @@ final class StringTests : XCTestCase {
         test("\u{1F425}")
         test("🏳️‍🌈AB👩‍👩‍👧‍👦ab🕵️‍♀️")
     }
+
+    func testRangeRegexB() {
+        let str = "self.name"
+        let range = str.range(of: "\\bname", options: .regularExpression)
+        let start = str.index(str.startIndex, offsetBy: 5)
+        let end = str.index(str.startIndex, offsetBy: 9)
+        XCTAssertEqual(range, start ..< end)
+    }
     
     func testParagraphLineRangeOfSeparator() {
         for separator in ["\n", "\r", "\r\n", "\u{2029}", "\u{2028}", "\u{85}"] {


### PR DESCRIPTION
Previously the `String.range(of:)` function's regex matching used ICU word boundaries rather than the more advanced Unicode boundaries. However, when we adopted `Regex` for the implementation we changed the behavior because `Regex` defaults to more advanced unicode word boundaries. This changes `String.range(of:)` back to ICU word boundaries for this API