### PR TITLE
FoundationEssentials: recover from backslide on Windows

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1991,7 +1991,15 @@ extension URL {
 
 #if !NO_FILESYSTEM
     private static func isDirectory(_ path: String) -> Bool {
-        return FileManager.default._fileStat(path)?.isDirectory ?? false
+#if !FOUNDATION_FRAMEWORK
+        var isDirectory: Bool = false
+        _ = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        return isDirectory
+#else
+        var isDirectory: ObjCBool = false
+        _ = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        return isDirectory.boolValue
+#endif
     }
 #endif // !NO_FILESYSTEM
 


### PR DESCRIPTION
This new helper was added but did not support windows as `stat` is a Unix operation and the Windows equivalent is more nuanced when you are trying to minimise IO overheads. Add a Windows specific path to repair the build on Windows.