### PR TITLE
testRangeRegexB can use System Foundation instead of FoundationEssentials

### DIFF
--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -308,9 +308,9 @@ final class StringTests : XCTestCase {
         test("🏳️‍🌈AB👩‍👩‍👧‍👦ab🕵️‍♀️")
     }
 
-    func testRangeRegexB() {
+    func testRangeRegexB() throws {
         let str = "self.name"
-        let range = str.range(of: "\\bname", options: .regularExpression)
+        let range = try str[...]._range(of: "\\bname"[...], options: .regularExpression)
         let start = str.index(str.startIndex, offsetBy: 5)
         let end = str.index(str.startIndex, offsetBy: 9)
         XCTAssertEqual(range, start ..< end)


### PR DESCRIPTION
This unit test started failing in some configurations on macOS. This is because the `range(of:)` function is not defined in FoundationEssentials (just in Foundation) so this test was inadvertently calling to the system Foundation which does not have the fixed behavior on all OS's. While the test now looks a bit more clunky, it explicitly calls the internal entry point in FoundationEssentials rather than the system Foundation to ensure we're testing the right version of this function