### PR TITLE
build: adjust package manifest to allow building on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -134,16 +134,23 @@ let package = Package(
                 .enableExperimentalFeature("AccessLevelOnImport")
             ] + availabilityMacros
         ),
-        .testTarget(
-            name: "FoundationMacrosTests",
-            dependencies: [
-                "FoundationMacros",
-                "TestSupport"
-            ],
-            swiftSettings: availabilityMacros
-        )
     ]
 )
+
+// https://github.com/apple/swift-package-manager/issues/7174
+// Test macro targets result in multiple definitions of `main` on Windows.
+#if !os(Windows)
+package.targets.append(contentsOf: [
+    .testTarget(
+        name: "FoundationMacrosTests",
+        dependencies: [
+            "FoundationMacros",
+            "TestSupport"
+        ],
+        swiftSettings: availabilityMacros
+    )
+])
+#endif
 
 #if canImport(RegexBuilder)
 package.targets.append(contentsOf: [


### PR DESCRIPTION
SPM does not permit building macro tests on Windows due to mishandling of build types, resulting in multiply defined `main` which is a strong error on Windows. As a workaround, remove the macro tests for the time being.