### PR TITLE
Minor fixes to support using URL in swift-corelibs-foundation

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError.swift
@@ -171,7 +171,7 @@ extension CocoaError {
     public static func error(_ code: CocoaError.Code, userInfo: [String : AnyHashable]? = nil, url: URL? = nil) -> Error {
         var info: [String : AnyHashable] = userInfo ?? [:]
         if let url = url {
-            info["NSURLErrorKey"] = url
+            info[NSURLErrorKey] = url
         }
         return CocoaError(code, userInfo: info)
     }

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1739,7 +1739,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
         #endif
         guard isFileURL && !fileSystemPath.isEmpty else { return self }
-        return URL(filePath: fileSystemPath.standardizingPath, directoryHint: .checkFileSystem)
+        return URL(filePath: fileSystemPath.standardizingPath, directoryHint: hasDirectoryPath ? .isDirectory : .notDirectory)
     }
 
     /// Resolves any symlinks in the path of a file URL.
@@ -1754,7 +1754,7 @@ public struct URL: Equatable, Sendable, Hashable {
         }
         #endif
         guard isFileURL && !fileSystemPath.isEmpty else { return self }
-        return URL(filePath: fileSystemPath.resolvingSymlinksInPath)
+        return URL(filePath: fileSystemPath.resolvingSymlinksInPath, directoryHint: hasDirectoryPath ? .isDirectory : .notDirectory)
     }
 
     /// Resolves any symlinks in the path of a file URL.


### PR DESCRIPTION
This PR includes two minor bug fixes identified while adopting `URL` in the re-cored package branch of SCF. This ensures that we use the proper error user info key declaration and also ensures that standardizing a URL or resolving symlinks in a URL will respect the directory designation when that `URL` was initialized even if it doesn't match what's on the filesystem.