### PR TITLE
Support Windows URL paths in FoundationEssentials

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -549,7 +549,7 @@ private func writeToFileNoAux(path inPath: PathOrURL, buffer: UnsafeRawBufferPoi
     assert(!options.contains(.atomic))
 
 #if os(Windows)
-    try inPath.path.withCString(encodedAs: UTF16.self) { pwszPath in
+    try inPath.path.withNTPathRepresentation { pwszPath in
         let hFile = CreateFileW(pwszPath, GENERIC_WRITE, FILE_SHARE_READ, nil, CREATE_ALWAYS | (options.contains(.withoutOverwriting) ? CREATE_NEW : 0), FILE_ATTRIBUTE_NORMAL, nil)
         if hFile == INVALID_HANDLE_VALUE {
             throw CocoaError.errorWithFilePath(inPath, win32: GetLastError(), reading: false)

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -546,7 +546,7 @@ extension String {
         }
         return result
     }
-    
+
     var standardizingPath: String {
         expandingTildeInPath._standardizingPath
     }
@@ -584,10 +584,6 @@ extension String {
         }
         let userDir = String.homeDirectoryPath(forUser: user)
         return userDir + self[firstSlash...]
-    }
-    
-    private var _isAbsolutePath: Bool {
-        first == "~" || first == "/"
     }
     
     private static func _resolvingSymlinksInPathUsingFullPathAttribute(_ fsRep: UnsafePointer<CChar>) -> String? {
@@ -636,7 +632,8 @@ extension String {
             // If not using the cache (which may not require hitting the disk at all if it's warm), try getting the full path from getattrlist.
             // If it succeeds, this approach always returns an absolute path starting from the root. Since this function returns relative paths when given a relative path to a relative symlink, dont use this approach unless the path is absolute.
             
-            if self._isAbsolutePath, let resolved = Self._resolvingSymlinksInPathUsingFullPathAttribute(fsPtr) {
+            var path = self
+            if URL.isAbsolute(standardizing: &path), let resolved = Self._resolvingSymlinksInPathUsingFullPathAttribute(fsPtr) {
                 return resolved
             }
             
@@ -725,4 +722,24 @@ extension String {
         return result._standardizingPath
     }
     #endif // !NO_FILESYSTEM
+}
+
+extension StringProtocol {
+    internal func replacing(_ a: UInt8, with b: UInt8) -> String {
+        var utf8Array = Array(self.utf8)
+        var didReplace = false
+        // ~300x faster than Array.replace([UInt8], with: [UInt8]) for one element
+        for i in 0..<utf8Array.count {
+            if utf8Array[i] == a {
+                utf8Array[i] = b
+                didReplace = true
+            }
+        }
+        guard didReplace else {
+            return String(self)
+        }
+        return String(unsafeUninitializedCapacity: utf8Array.count) { buffer in
+            buffer.initialize(fromContentsOf: utf8Array)
+        }
+    }
 }

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -588,6 +588,9 @@ internal struct RFC3986Parser: URLParserProtocol {
     /// Parses a URL string into `URLParseInfo`, with the option to add (or skip) encoding of invalid characters.
     /// If `encodingInvalidCharacters` is `true`, this function handles encoding of invalid components.
     static func parse(urlString: String, encodingInvalidCharacters: Bool) -> URLParseInfo? {
+        #if os(Windows)
+        let urlString = urlString.replacing(UInt8(ascii: "\\"), with: UInt8(ascii: "/"))
+        #endif
         guard let parseInfo = parse(urlString: urlString) else {
             return nil
         }


### PR DESCRIPTION
Supports initializing file URLs with Windows paths. Allow `"\"` as the path separator, allow UNC paths (`"\\"`) with host, and allow/standardize drive letter paths (`"C:"`). However, we always store the URL with forward slashes to stay consistent for path parsing operations. I think `String.withNTPathRepresentation(_:)` should then be used to convert any `"/"` back to `"\"` before consulting the file system on Windows. @compnerd thoughts on this approach?

The file URL initializers also now resolve against the base URL (or current directory) for checking if the file is a directory.