### PR TITLE
FoundationEssentials: simplify path normalization

### DIFF
--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -168,6 +168,10 @@ extension UInt8 {
         guard _asciiNumbers.contains(self) else { return nil }
         return Int(self &- UInt8(ascii: "0"))
     }
+
+    internal var isLetter: Bool? {
+        return (0x41 ... 0x5a) ~= self || (0x61 ... 0x7a) ~= self
+    }
 }
 
 


### PR DESCRIPTION
We would previously conditionally call `GetFullPathNameW` and do string manipulations for normalising the path. Instead, always call `GetFullPathNameW` to normalise the path as per Windows' rules. This more importantly will collapse runs of the arc separator, which is crucial when using extended paths as the NT path form must always use the normalised paths or the access will fail.