### PR TITLE
FoundationEssentials: protect against a failed query on Windows

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -263,6 +263,7 @@ extension Platform {
 #elseif os(Windows)
         let hFile = GetModuleHandleW(nil)
         let dwLength: DWORD = GetFinalPathNameByHandleW(hFile, nil, 0, FILE_NAME_NORMALIZED)
+        guard dwLength > 0 else { return nil }
         return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) { lpBuffer in
             guard GetFinalPathNameByHandleW(hFile, lpBuffer.baseAddress, dwLength, FILE_NAME_NORMALIZED) == dwLength - 1 else {
                 return nil


### PR DESCRIPTION
In the case that the query fails due to a reason other than an insufficient buffer, the returned value is 0. However, a 0 sized allocation can trigger an issue, so ensure that we always have a non-zero buffer size before we attempt an allocation.