### PR TITLE
URL.init(filePath:) should resolve against the base URL before checking if the file is a directory

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -199,6 +199,16 @@ extension String {
         return result
     }
 
+    internal func merging(relativePath: String) -> String {
+        guard relativePath.utf8.first != UInt8(ascii: "/") else {
+            return relativePath
+        }
+        guard let basePathEnd = self.utf8.lastIndex(of: UInt8(ascii: "/")) else {
+            return relativePath
+        }
+        return self[...basePathEnd] + relativePath
+    }
+
     internal var removingDotSegments: String {
         let input = self.utf8
         guard !input.isEmpty else {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -330,6 +330,28 @@ final class URLTests : XCTestCase {
         try FileManager.default.removeItem(at: URL(filePath: "\(tempDirectory.path)/tmp-dir"))
     }
 
+    func testURLFilePathRelativeToBase() throws {
+        try FileManagerPlayground {
+            Directory("dir") {
+                "Foo"
+                "Bar"
+            }
+        }.test {
+            let currentDirectoryPath = $0.currentDirectoryPath
+            let baseURL = URL(filePath: currentDirectoryPath, directoryHint: .isDirectory)
+            let relativePath = "dir"
+
+            let url1 = URL(filePath: relativePath, directoryHint: .isDirectory, relativeTo: baseURL)
+
+            let url2 = URL(filePath: relativePath, directoryHint: .checkFileSystem, relativeTo: baseURL)
+            XCTAssertEqual(url1, url2, "\(url1) was not equal to \(url2)")
+
+            // directoryHint is `.inferFromPath` by default
+            let url3 = URL(filePath: relativePath + "/", relativeTo: baseURL)
+            XCTAssertEqual(url1, url3, "\(url1) was not equal to \(url3)")
+        }
+    }
+
     func testAppendFamily() throws {
         let base = URL(string: "https://www.example.com")!
 


### PR DESCRIPTION
The fix I added in #602 to address this wasn't correct since `.mergedPath(for:)` should be called on an URL that has already been initialized with a base URL. I separated this logic out into a String extension that handles the merging generally and use this method when determining the absolute file path to directory check in `.init(filePath:)`.