### PR TITLE
FoundationEssentials: repair the Windows build

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+WindowsSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+WindowsSearchPaths.swift
@@ -12,6 +12,8 @@
 
 #if os(Windows)
 
+import WinSDK
+
 private func _url(for id: KNOWNFOLDERID) -> URL {
     var pszPath: PWSTR?
     let hrResult: HRESULT = withUnsafePointer(to: id) { id in

--- a/Sources/FoundationEssentials/WinSDK+Extensions.swift
+++ b/Sources/FoundationEssentials/WinSDK+Extensions.swift
@@ -174,7 +174,7 @@ package var GENERIC_WRITE: DWORD {
 }
 
 package var KF_FLAG_DEFAULT: DWORD {
-    DWORD(WinSDK.KF_FLAG_DEFAULT)
+    DWORD(WinSDK.KF_FLAG_DEFAULT.rawValue)
 }
 
 package var MOVEFILE_COPY_ALLOWED: DWORD {


### PR DESCRIPTION
Repair the Windows build after recent additions for FileManager.