### PR TITLE
Update FileManager for use by SCL-F

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -78,7 +78,9 @@ func _readFileAttributePrimitive<T: BinaryInteger>(_ value: Any?, as type: T.Typ
     }
     #endif
     
-    if let binInt = value as? (any BinaryInteger), let result = T(exactly: binInt) {
+    if let exact = value as? T {
+        return exact
+    } else if let binInt = value as? (any BinaryInteger), let result = T(exactly: binInt) {
         return result
     }
     return nil

--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+XDGSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+XDGSearchPaths.swift
@@ -135,7 +135,7 @@ private enum _XDGUserDirectory: String {
                 
                 let path = String(line[line.unicodeScalars.index(after: equalsIdx)...])._trimmingWhitespace()
                 if !path.isEmpty {
-                    entries[directory] = home.appending(path: path)
+                    entries[directory] = URL(filePath: path, directoryHint: .isDirectory, relativeTo: home)
                 }
             } else {
                 return nil // Incorrect syntax.


### PR DESCRIPTION
There are two pieces of `FileManager` that need to be updated so that swift-corelibs-foundation can use this `FileManager` implementation:

1. When providing file attributes, many call-sites provide numeric attributes as SCL-F's `NSNumber` type. However, since swift-foundation does not know about `NSNumber`, it currently doesn't work. `NSNumber` is implicitly bridged to concrete numeric types, but not to an existential type like `any BinaryInteger`. So to fix this, when reading numeric attributes we now try a direct dynamic cast to the target type (`as? T`) which will succeed if `value` is an `NSNumber`, then we try a dynamic cast to `any BinaryInteger` to catch any other numeric types
2. User directories provided by XDG configuration files can be absolute or relative, but the current implementation assumes they are always relative. This change supports absolute paths.