### PR TITLE
FoundationEssentials: correct error handling for item removal

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -358,11 +358,12 @@ enum _FileOperations {
             try directory.withNTPathRepresentation {
                 if RemoveDirectoryW($0) { return }
                 let dwError: DWORD = GetLastError()
-                if dwError == ERROR_DIR_NOT_EMPTY {
+                guard dwError == ERROR_DIR_NOT_EMPTY else {
                     let error = CocoaError.removeFileError(dwError, directory)
                     guard (filemanager?._shouldProceedAfter(error: error, removingItemAtPath: directory) ?? false) else {
                         throw error
                     }
+                    return
                 }
                 stack.append(directory)
 


### PR DESCRIPTION
The condition of the error check was inverted as it was meant to be a `guard` statement. This was resulting in an infinite loop. With this we now pass a few additional tests and the test suite no longer hangs.