### PR TITLE
FoundationEssentials: avoid precondition failure on Windows

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -742,10 +742,16 @@ final class FileManagerTests : XCTestCase {
         #else
         let isFramework = false
         #endif
+
+        #if os(Windows)
+        let isWindows = true
+        #else
+        let isWindows = false
+        #endif
         
         // .trashDirectory is unavailable on watchOS/tvOS and only produces paths on macOS (the framework build) + non-Darwin
         #if !os(watchOS) && !os(tvOS)
-        assertSearchPaths([.trashDirectory], exists: (isMacOS && isFramework) || !isDarwin)
+        assertSearchPaths([.trashDirectory], exists: (isMacOS && isFramework) || (!isDarwin && !isWindows))
         #endif
         
         // .applicationScriptsDirectory is only available on macOS and only produces paths in the framework build


### PR DESCRIPTION
Repair the error reporting on Windows in the case of a failure in `SHGetKnownFolder` - the returned value is a `HRESULT`, which is the extended error code unlike the Win32 APIs which return a `BOOL`.

The "Recyle Bin" is a virtual folder and does not have an associated path with the folder that we can query. Undo the implementation here for the time being to avoid the assertion failure in the runtime.