### PR TITLE
Improve String+Path performance by removing Regex

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1189,6 +1189,7 @@ internal extension UInt8 {
     static var _singleQuote: UInt8 { UInt8(ascii: "'") }
     static var _dollar: UInt8 { UInt8(ascii: "$") }
     static var _underscore: UInt8 { UInt8(ascii: "_") }
+    static var _dot: UInt8 { UInt8(ascii: ".") }
 }
 
 var _json5Infinity: StaticString { "Infinity" }


### PR DESCRIPTION
Reimplement `String._transmutingCompressingSlashes` and `pathHasDotDot` without using Regex. Reimplementing this method without Regex allows us to:
- Reduce the additional frames at launch since the Swift rewrite (Regex parsing brings in tons of frames)
- Not having to load additional dylib (`libswift_StringProcessing)