### PR TITLE
Gracefully handle cases where the isDirectory url resource might not be set

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -382,7 +382,7 @@ extension _FileManagerImpl {
         // Get url's resource identifier, volume identifier, and make sure it is a directory
         let dirValues = try directoryURL.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey, .isDirectoryKey])
         
-        guard dirValues.isDirectory! else {
+        guard let isDirectory = dirValues.isDirectory, isDirectory else {
             outRelationship.pointee = .other
             return
         }


### PR DESCRIPTION
In some cases, the `isDirectory` resource value may not be set even though it was requested. We should gracefully handle this to avoid a crash in this situation