### PR TITLE
FoundationEssentials: use named constants for characters

### DIFF
--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -163,6 +163,7 @@ extension UInt8 {
     internal static var _question: UInt8 { UInt8(ascii: "?") }
     internal static var _exclamation: UInt8 { UInt8(ascii: "!") }
     internal static var _ampersand: UInt8 { UInt8(ascii: "&") }
+    internal static var _pipe: UInt8 { UInt8(ascii: "|") }
 
     internal var digitValue: Int? {
         guard _asciiNumbers.contains(self) else { return nil }

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -2007,7 +2007,7 @@ extension URL {
         #if os(Windows)
         var isAbsolute = false
         let utf8 = filePath.utf8
-        if utf8.first == UInt8(ascii: "\\") {
+        if utf8.first == ._backslash {
             // Either an absolute path or a UNC path
             isAbsolute = true
         } else if utf8.count >= 3 {
@@ -2019,16 +2019,16 @@ extension URL {
             let third = utf8[thirdIndex]
             isAbsolute = (
                 first.isAlpha
-                && (second == UInt8(ascii: ":") || second == UInt8(ascii: "|"))
-                && third == UInt8(ascii: "\\")
+                && (second == ._colon || second == ._pipe)
+                && third == ._backslash
             )
 
             if isAbsolute {
                 // Standardize to "\[drive-letter]:\..."
-                if second == UInt8(ascii: "|") {
+                if second == ._pipe {
                     var filePathArray = Array(utf8)
-                    filePathArray[1] = UInt8(ascii: ":")
-                    filePathArray.insert(UInt8(ascii: "\\"), at: 0)
+                    filePathArray[1] = ._colon
+                    filePathArray.insert(._backslash, at: 0)
                     filePath = String(decoding: filePathArray, as: UTF8.self)
                 } else {
                     filePath = "\\" + filePath


### PR DESCRIPTION
Use more named constants when checking for matching constants in the string.