### PR TITLE
FoundationEssentials: do not strip non-absolute paths

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -2023,10 +2023,7 @@ extension URL {
                 && third == UInt8(ascii: "\\")
             )
 
-            if !isAbsolute {
-                // Strip the drive letter so it's not mistaken as a scheme
-                filePath = String(filePath[thirdIndex...])
-            } else {
+            if isAbsolute {
                 // Standardize to "\[drive-letter]:\..."
                 if second == UInt8(ascii: "|") {
                     var filePathArray = Array(utf8)


### PR DESCRIPTION
We would strip the first characters of a path if it were non-absolute. For special files like `CON` we would end up stripping the name to `N`.