### PR TITLE
Adjust errors thrown from FileManager's copyItem function

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -154,7 +154,7 @@ struct _FTSSequence: Sequence {
         init(_ path: UnsafePointer<CChar>, _ opts: Int32) {
             self.path = path
             var statBuf = stat()
-            if lstat(path, &statBuf) > 0 {
+            guard lstat(path, &statBuf) == 0 else {
                 state = .error(errno, String(cString: path))
                 return
             }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -399,8 +399,9 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
             XCTAssertEqual($0.delegateCaptures.shouldCopy, [.init("dir", "dir2"), .init("dir/foo", "dir2/foo"), .init("dir/bar", "dir2/bar")])
             
-            try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")
-            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError.last, .init("does_not_exist", "dir3", code: .fileNoSuchFile))
+            XCTAssertThrowsError(try $0.copyItem(atPath: "does_not_exist", toPath: "dir3")) {
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+            }
             
             #if canImport(Darwin)
             // Not supported on linux because it ends up trying to set attributes that are currently unimplemented


### PR DESCRIPTION
Due to an incorrect check of the `lstat` return value, the copy item functions can return incorrect errors when the source file/directory does not exist. This corrects that logic to ensure the appropriate error codes are thrown (and match the error codes in the old ObjC implementation)