### PR TITLE
FoundationEssentials: drop invalid modification dates

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -718,7 +718,10 @@ extension _FileManagerImpl {
                 let seconds = modification.timeIntervalSince1601
 
                 var uiTime: ULARGE_INTEGER = .init()
-                uiTime.QuadPart = UInt64(seconds * 10000000)
+                guard let converted = UInt64(exactly: seconds * 10000000.0) else {
+                    return
+                }
+                uiTime.QuadPart = converted
 
                 var ftTime: FILETIME = .init()
                 ftTime.dwLowDateTime = uiTime.LowPart


### PR DESCRIPTION
Follow the expected behaviour to drop invalid modification dates, e.g. `+NaN`. This matches the semantics that are expected on Unix and avoids a crash due to the initialiser.