### PR TITLE
FoundationEssentials: correct the template path for Windows

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -225,7 +225,7 @@ private func createProtectedTemporaryFile(at destinationPath: String, inPath: Pa
     }
 #endif
     
-    let temporaryDirectoryPath = destinationPath.deletingLastPathComponent()
+    let temporaryDirectoryPath = destinationPath.deletingLastPathComponent().withFileSystemRepresentation { String(cString: $0!) }
     let (fd, auxFile) = try createTemporaryFile(at: temporaryDirectoryPath, inPath: inPath, prefix: ".dat.nosync", options: options)
     return (fd, auxFile, nil)
 }


### PR DESCRIPTION
We need to use the FSR for the template path to ensure that we are giving the underlying system a valid path. This was causing a spurious failure with the MSVC runtime due to the errant leading `/`.