### PR TITLE
Use percentEncode(path, component: .path) instead of percentEncodePath(path)

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -659,7 +659,7 @@ internal struct RFC3986Parser: URLParserProtocol {
 
         let path = parseInfo.path
         if invalidComponents.contains(.path) {
-            finalURLString += percentEncodePath(path)
+            finalURLString += percentEncode(path, component: .path)!
         } else {
             finalURLString += path
         }


### PR DESCRIPTION
In RFC3986Parser, while constructing the percent-encoded urlString, .user, .password, .host, .query, and .fragment all call `percentEncode(_:component:)`, but only .path calls `percentEncodePath(_:)`. 
This PR replaces `percentEncodePath(_:)` with `percentEncode(_:component:)` for consistency.
