### PR TITLE
FoundationEssentials: limit autosave to user domain

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+XDGSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+XDGSearchPaths.swift
@@ -164,7 +164,7 @@ private enum _XDGUserDirectory: String {
 
 func _XDGSearchPathURL(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask) -> URL? {
     return switch (directory, domain) {
-    case (.autosavedInformationDirectory, _):
+    case (.autosavedInformationDirectory, .userDomainMask):
         _xdgDataHomeURL().appending(component: "Autosave Information", directoryHint: .isDirectory)
         
     case (.desktopDirectory, .userDomainMask):

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -797,12 +797,10 @@ final class FileManagerTests : XCTestCase {
                 let results = fileManager.urls(for: directory, in: domain)
                 XCTAssertTrue(results.contains(knownURL), "Results \(results.map(\.path)) did not contain known directory \(knownURL.path) for \(directory)/\(domain) while setting the \(key) environment variable", file: file, line: line)
             }
-            
+
             validate("XDG_DATA_HOME", suffix: "Autosave Information", directory: .autosavedInformationDirectory, domain: .userDomainMask)
-            validate("XDG_DATA_HOME", suffix: "Autosave Information", directory: .autosavedInformationDirectory, domain: .localDomainMask)
             validate("HOME", suffix: ".local/share/Autosave Information", directory: .autosavedInformationDirectory, domain: .userDomainMask)
-            validate("HOME", suffix: ".local/share/Autosave Information", directory: .autosavedInformationDirectory, domain: .localDomainMask)
-            
+
             validate("XDG_CACHE_HOME", directory: .cachesDirectory, domain: .userDomainMask)
             validate("HOME", suffix: ".cache", directory: .cachesDirectory, domain: .userDomainMask)
             


### PR DESCRIPTION
During the review for the changes to support Windows, we realized that the location that is being used for the autosave information is only available within the user domain mask. The Windows implementation was corrected as part of the implementation, but this corrects the XDG compliant path to reflect this reality.