### PR TITLE
FoundationEssentials: correct path canonicalisation handling on Windows

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -665,7 +665,9 @@ extension String {
                 guard GetFinalPathNameByHandleW(hFile, $0.baseAddress, dwLength, VOLUME_NAME_DOS) == dwLength - 1 else {
                     return nil
                 }
-                return String(decodingCString: $0.baseAddress!, as: UTF16.self)
+
+                // When using `VOLUME_NAME_DOS`, the returned path uses `\\?\`.
+                return String(String(decodingCString: $0.baseAddress!.advanced(by: 4), as: UTF16.self))
             }
         }
 #else

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -667,7 +667,7 @@ extension String {
                 }
 
                 // When using `VOLUME_NAME_DOS`, the returned path uses `\\?\`.
-                return String(String(decodingCString: $0.baseAddress!.advanced(by: 4), as: UTF16.self))
+                return String(decodingCString: $0.baseAddress!.advanced(by: 4), as: UTF16.self)
             }
         }
 #else


### PR DESCRIPTION
Strip the extended path prefix for bypassing the Win32 API layer. This is guaranteed to be prefixed on strings as per the documentation.