### PR TITLE
Prevent throwing when applying file attributes retrieved via `attributesOfItem(atPath:)`

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -112,15 +112,19 @@ extension _FileManagerImpl {
         #endif
     }
     
-    // Exclude .creationDate from this check because it is unconditionally returned from attributesOfItem(atPath:)
-    private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden]
+    private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
+    private static let _swiftFoundationUnsupportedKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden]
     static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
         let hasRelevantKeys = attributes.keys.contains(where: { _catInfoKeys.contains($0) })
         guard hasRelevantKeys else { return }
         
         #if !FOUNDATION_FRAMEWORK
-        // TODO: Implement CAT info attributes for swift-foundation
-        throw CocoaError.errorWithFilePath(.featureUnsupported, path)
+        // Exclude some attributes (like .creationDate) from this check since they are unconditionally, implicitly included in `attributesForItem(atPath:)` results
+        if attributes.keys.contains(where: { _swiftFoundationUnsupportedKeys.contains($0) }) {
+            throw CocoaError.errorWithFilePath(.featureUnsupported, path)
+        } else {
+            return // TODO: support relevant cat info keys in swift-foundation
+        }
         #else
         // -setAttributes:ofItemAtPath:error: follows symlinks (<rdar://5815920>), but the NSURL resource value API doesn't, so we have to manually resolve the symlink.
         // We lie to fileURLWithPath:isDirectory: to avoid the extra stat. Since this URL isn't used as a base URL for another URL, it shouldn't make any difference.

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -112,7 +112,8 @@ extension _FileManagerImpl {
         #endif
     }
     
-    private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden, .creationDate]
+    // Exclude .creationDate from this check because it is unconditionally returned from attributesOfItem(atPath:)
+    private static let _catInfoKeys: [FileAttributeKey] = [.hfsCreatorCode, .hfsTypeCode, .busy, .extensionHidden]
     static func _setCatInfoAttributes(_ attributes: [FileAttributeKey : Any], path: String) throws {
         let hasRelevantKeys = attributes.keys.contains(where: { _catInfoKeys.contains($0) })
         guard hasRelevantKeys else { return }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -811,4 +811,13 @@ final class FileManagerTests : XCTestCase {
         }
         #endif
     }
+    
+    func testGetSetAttributes() throws {
+        try FileManagerPlayground {
+            File("foo", contents: randomData())
+        }.test {
+            let attrs = try $0.attributesOfItem(atPath: "foo")
+            try $0.setAttributes(attrs, ofItemAtPath: "foo")
+        }
+    }
 }


### PR DESCRIPTION
There are some scenarios in which you want to copy attributes from one file to another (for example, from within `copyItem(atPath:toPath:)`. However currently, calling `setAttributes(_:forItemAtPath:)` with attributes retrieved from `attributesForItem(atPath:)` will `throw` because we can fetch `.creationDate` but we cannot set it (yet). Until this functionality is implemented in swift-foundation, we exclude `.creationDate` from the `featureUnsupported` check to ensure that applying attributes that Foundation provides will succeed.

This prevents throwing an error from `copyItem` calls made by SwiftPM when using the new re-cored Foundation