### PR TITLE
Avoid crashing due to malformed paths creating URLs

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -53,7 +53,8 @@ extension Dictionary<String, AnyHashable> {
     fileprivate func addingUserInfo(forPath path: String) -> Self {
         var dict = self
         dict[NSFilePathErrorKey] = path
-        dict[NSURLErrorKey] = URL(fileURLWithPath: path)
+        // Use the failable approach here bcause this could be an Error for a malformed path
+        dict[NSURLErrorKey] = URL(_fileManagerFailableFileURLWithPath: path)
         return dict
     }
     

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -896,6 +896,22 @@ public struct URL: Equatable, Sendable, Hashable {
         #endif
         self.init(filePath: path, directoryHint: .checkFileSystem)
     }
+    
+    // NSURL(fileURLWithPath:) can return nil incorrectly for some malformed paths
+    // This is only to be used by FileManager when dealing with potentially malformed paths, and only when truly necessary
+    internal init?(_fileManagerFailableFileURLWithPath path: __shared String) {
+        #if FOUNDATION_FRAMEWORK
+        guard foundation_swift_url_enabled() else {
+            let url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
+            guard unsafeBitCast(url, to: UnsafeRawPointer?.self) != nil else {
+                return nil
+            }
+            self.init(reference: url)
+            return
+        }
+        #endif
+        self.init(filePath: path, directoryHint: .checkFileSystem)
+    }
 
     /// Initializes a newly created URL using the contents of the given data, relative to a base URL.
     ///


### PR DESCRIPTION
In some cases, file manager APIs may be called with malformed string paths. We correctly `throw` an error in those cases, but when throwing an error we try to initialize a `URL` from the path. In certain `FOUNDATION_FRAMEWORK` scenarios this leads to calling into an `NSURL` initializer which crashes. This code works around that crash by creating an internal failable path we can take instead when we know we're in a scenario where we may have malformed paths.