### PR TITLE
FoundationEssentials: ensure that the path exists when stat'ing

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -626,6 +626,11 @@ extension _FileManagerImpl {
     func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
 #if os(Windows)
         return try path.withNTPathRepresentation { pwszPath in
+            var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = .init()
+            guard GetFileAttributesExW(pwszPath, GetFileExInfoStandard, &faAttributes) else {
+                throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
+            }
+
             let dwLength: DWORD = GetFullPathNameW(pwszPath, 0, nil, nil)
             guard dwLength > 0 else {
                 throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)


### PR DESCRIPTION
On non-Windows targets we ensure that the path exists when we attempt to query the attributes of the path. This adds the same check on Windows so that we can have similar behaviour on all platforms.