### PR TITLE
Prepare for _FoundationCollections module name

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeContainer.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#else
-internal import _RopeModule
-#endif
-
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public struct AttributeContainer : Sendable {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+CharacterView.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Guts.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#else
-internal import _RopeModule
-#endif
-
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString.Runs {
     @preconcurrency

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+Run.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+UnicodeScalarView.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRun.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRun.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRuns.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRuns.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRunsSlice.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+_InternalRunsSlice.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 extension AttributedString {

--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#else
-internal import _RopeModule
-#endif
-
 // MARK: AttributedStringKey API
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeConstrainingBehavior.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttributeStorage.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) internal import CollectionsInternal
-#else
-internal import _RopeModule
-#endif
-
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
     internal struct _AttributeValue : Hashable, CustomStringConvertible, Sendable {

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringCodable.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 // MARK: AttributedStringKey

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringProtocol.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedSubstring.swift
@@ -12,8 +12,10 @@
 
 #if FOUNDATION_FRAMEWORK
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 @dynamicMemberLookup

--- a/Sources/FoundationEssentials/AttributedString/Conversion.swift
+++ b/Sources/FoundationEssentials/AttributedString/Conversion.swift
@@ -15,8 +15,10 @@
 import Darwin
 internal import os
 @_spi(Unstable) internal import CollectionsInternal
-#else
+#elseif canImport(_RopeModule)
 internal import _RopeModule
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 extension String {

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -12,6 +12,10 @@
 
 // MARK: Attribute Scope
 
+#if FOUNDATION_FRAMEWORK
+internal import Foundation_Private.NSAttributedString
+#endif
+
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes {
     public var foundation: FoundationAttributes.Type { FoundationAttributes.self }

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -12,13 +12,6 @@
 
 // MARK: Attribute Scope
 
-#if FOUNDATION_FRAMEWORK
-internal import Foundation_Private.NSAttributedString
-@_spi(Unstable) internal import CollectionsInternal
-#else
-internal import _RopeModule
-#endif
-
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes {
     public var foundation: FoundationAttributes.Type { FoundationAttributes.self }

--- a/Sources/FoundationEssentials/PropertyList/BPlistEncodingFormat.swift
+++ b/Sources/FoundationEssentials/PropertyList/BPlistEncodingFormat.swift
@@ -21,6 +21,8 @@ internal import _CShims
 internal import CollectionsInternal
 #elseif canImport(OrderedCollections)
 internal import OrderedCollections
+#elseif canImport(_FoundationCollections)
+internal import _FoundationCollections
 #endif
 
 // MARK: - __PlistEncoder
@@ -655,7 +657,7 @@ struct _BPlistEncodingFormat : PlistEncodingFormat {
 
             case array(ContiguousArray<Reference>)
             // Ordered, because some clients are expecting some level of stability from binary plist encoding
-#if canImport(CollectionsInternal) || canImport(OrderedCollections)
+#if canImport(CollectionsInternal) || canImport(OrderedCollections) || canImport(_FoundationCollections)
             case dictionary(OrderedDictionary<Reference,Reference>)
 #else
             case dictionary(Dictionary<Reference,Reference>)
@@ -1059,7 +1061,7 @@ struct _BPlistEncodingFormat : PlistEncodingFormat {
             write(sizedInteger: dateAsTimeInterval.bitPattern)
         }
 
-#if canImport(CollectionsInternal) || canImport(OrderedCollections)
+#if canImport(CollectionsInternal) || canImport(OrderedCollections) || canImport(_FoundationCollections)
         mutating func append(_ dictionary: OrderedDictionary<Reference,Reference>) {
             // First write the indexes of the dictionary contents, then write the actual contents to the output in a pre-order traversal.
             append(.dict, count: dictionary.count)

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -23,12 +23,6 @@ import TestSupport
 @testable import Foundation
 #endif
 
-#if FOUNDATION_FRAMEWORK
-@_spi(Unstable) import CollectionsInternal
-#else
-import _RopeModule
-#endif
-
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 final class DateFormatStyleTests : XCTestCase {
     let referenceDate = Date(timeIntervalSinceReferenceDate: 0)

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -21,9 +21,6 @@ import TestSupport
 
 #if FOUNDATION_FRAMEWORK
 @testable import Foundation
-@_spi(Unstable) import CollectionsInternal
-#else
-import _RopeModule
 #endif
 
 final class NumberFormatStyleTests: XCTestCase {


### PR DESCRIPTION
When swift-foundation builds within the toolchain, the collections module name will be `_FoundationCollections` instead of separate `OrderedCollections`/`_RopeModule` modules. This change prepares for the toolchain build by conditionalizing between `CollectionsInternal` for `FOUNDATION_FRAMEWORK` builds, `_RopeModule`/`OrderedCollections` for SPM builds, and `_FoundationCollections` for toolchain builds.