### PR TITLE
Enable complete concurrency checking in Foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,11 @@ let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
     }
 }
 
+let concurrencyChecking: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency"),
+    .enableUpcomingFeature("InferSendableFromCaptures")
+]
+
 let package = Package(
     name: "FoundationPreview",
     platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")],
@@ -75,7 +80,7 @@ let package = Package(
         .target(name: "TestSupport", dependencies: [
             "FoundationEssentials",
             "FoundationInternationalization",
-        ], swiftSettings: availabilityMacros),
+        ], swiftSettings: availabilityMacros + concurrencyChecking),
 
         // FoundationEssentials
         .target(
@@ -92,7 +97,7 @@ let package = Package(
           swiftSettings: [
             .enableExperimentalFeature("VariadicGenerics"),
             .enableExperimentalFeature("AccessLevelOnImport")
-          ] + availabilityMacros
+          ] + availabilityMacros + concurrencyChecking
         ),
         .testTarget(
             name: "FoundationEssentialsTests",
@@ -103,7 +108,7 @@ let package = Package(
             resources: [
                 .copy("Resources")
             ],
-            swiftSettings: availabilityMacros
+            swiftSettings: availabilityMacros + concurrencyChecking
         ),
 
         // FoundationInternationalization
@@ -116,7 +121,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
-            ] + availabilityMacros
+            ] + availabilityMacros + concurrencyChecking
         ),
         
         // FoundationMacros
@@ -132,7 +137,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("AccessLevelOnImport")
-            ] + availabilityMacros
+            ] + availabilityMacros + concurrencyChecking
         ),
     ]
 )
@@ -147,7 +152,7 @@ package.targets.append(contentsOf: [
             "FoundationMacros",
             "TestSupport"
         ],
-        swiftSettings: availabilityMacros
+        swiftSettings: availabilityMacros + concurrencyChecking
     )
 ])
 #endif
@@ -157,6 +162,6 @@ package.targets.append(contentsOf: [
     .testTarget(name: "FoundationInternationalizationTests", dependencies: [
         "TestSupport",
         "FoundationInternationalization",
-    ], swiftSettings: availabilityMacros),
+    ], swiftSettings: availabilityMacros + concurrencyChecking),
 ])
 #endif

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -52,7 +52,9 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) {
+    ) 
+    where
+        K.Value : Sendable {
         if orig.range != changed.range || orig.attrName != changed.attrName {
             attrStr._guts.removeAttributeValue(forKey: K.self, in: orig.range._bstringRange) // If the range changed, we need to remove from the old range first.
         }
@@ -63,7 +65,7 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) {
+    ) where K.Value : Sendable {
         if orig.range != changed.range || orig.attrName != changed.attrName || orig.attr != changed.attr {
             if let newVal = changed.attr { // Then if there's a new value, we add it in.
                 // Unfortunately, we can't use the attrStr[range].set() provided by the AttributedStringProtocol, because we *don't know* the new type statically!
@@ -78,10 +80,13 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    @preconcurrency
     public func transformingAttributes<K>(
         _ k:  K.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where 
+        K.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -95,12 +100,16 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  K1.Type,
         _ k2: K2.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where 
+        K1.Value : Sendable,
+        K2.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -118,6 +127,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -125,7 +135,11 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -147,6 +161,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -156,7 +171,12 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -182,6 +202,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -193,7 +214,13 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable,
+        K5.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -226,22 +253,30 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    @preconcurrency
     public func transformingAttributes<K>(
         _ k: KeyPath<AttributeDynamicLookup, K>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K.Value : Sendable {
         self.transformingAttributes(K.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -249,10 +284,15 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -262,10 +302,16 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -277,7 +323,13 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable,
+        K5.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, K5.self, c)
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -100,11 +100,13 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> {
+    @preconcurrency
+    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> where T.Value : Sendable {
         return AttributesSlice1<T>(runs: self)
     }
 
-    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> {
+    @preconcurrency
+    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> where T.Value : Sendable {
         return AttributesSlice1<T>(runs: self)
     }
 }
@@ -205,23 +207,31 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>
-    ) -> AttributesSlice2<T, U> {
+    ) -> AttributesSlice2<T, U>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable {
         return AttributesSlice2<T, U>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: T.Type,
         _ u: U.Type
-    ) -> AttributesSlice2<T, U> {
+    ) -> AttributesSlice2<T, U>
+    where 
+        T.Value : Sendable,
+        U.Value : Sendable {
         return AttributesSlice2<T, U>(runs: self)
     }
 }
@@ -328,6 +338,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -336,10 +347,15 @@ extension AttributedString.Runs {
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>,
         _ v: KeyPath<AttributeDynamicLookup, V>
-    ) -> AttributesSlice3<T, U, V> {
+    ) -> AttributesSlice3<T, U, V>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -348,7 +364,11 @@ extension AttributedString.Runs {
         _ t: T.Type,
         _ u: U.Type,
         _ v: V.Type
-    ) -> AttributesSlice3<T, U, V> {
+    ) -> AttributesSlice3<T, U, V>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 }
@@ -464,6 +484,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -478,6 +499,7 @@ extension AttributedString.Runs {
         return AttributesSlice4<T, U, V, W>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -610,6 +632,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -622,10 +645,17 @@ extension AttributedString.Runs {
         _ v: KeyPath<AttributeDynamicLookup, V>,
         _ w: KeyPath<AttributeDynamicLookup, W>,
         _ x: KeyPath<AttributeDynamicLookup, X>
-    ) -> AttributesSlice5<T, U, V, W, X> {
+    ) -> AttributesSlice5<T, U, V, W, X> 
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable,
+        X.Value : Sendable {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -638,7 +668,13 @@ extension AttributedString.Runs {
         _ v: V.Type,
         _ w: W.Type,
         _ x: X.Type
-    ) -> AttributesSlice5<T, U, V, W, X> {
+    ) -> AttributesSlice5<T, U, V, W, X> 
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable,
+        X.Value : Sendable {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -96,7 +96,12 @@ extension AttributeScopes.FoundationAttributes {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum LinkAttribute : CodableAttributedStringKey {
         public typealias Value = URL
-        public static var name = "NSLink"
+        
+        public static var name: String {
+            // Used to be: public static var name = "NSLink", but changed for Sendability and ABI compatibility
+            get { "NSLink" }
+            set { }
+        }
     }
     
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Enumerate.swift
@@ -38,8 +38,8 @@ extension DateInterval {
 extension Calendar {
     // MARK: - Logging
 #if FOUNDATION_FRAMEWORK
-    static fileprivate let log: OSLog = {
-        OSLog(subsystem: "com.apple.foundation", category: "calendar_enumeration")
+    static fileprivate let log: SendableOSLog = {
+        .init(OSLog(subsystem: "com.apple.foundation", category: "calendar_enumeration"))
     }()
 #endif // FOUNDATION_FRAMEWORK
 
@@ -253,19 +253,19 @@ private func _handleCalendarError(_ error: CalendarEnumerationError, date: Date,
 #if FOUNDATION_FRAMEWORK
     switch error {
     case .dateOutOfRange(let component, let test):
-        Logger(Calendar.log).error("Out of range Calendar enumeration result: start: \(date.timeIntervalSinceReferenceDate, privacy: .public) test: \(test.timeIntervalSinceReferenceDate, privacy: .public) \(component.debugDescription, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
+        Logger(Calendar.log.log).error("Out of range Calendar enumeration result: start: \(date.timeIntervalSinceReferenceDate, privacy: .public) test: \(test.timeIntervalSinceReferenceDate, privacy: .public) \(component.debugDescription, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
         
     case .notAdvancing(let next, let previous):
-        Logger(Calendar.log).error("Not advancing Calendar enumeration result: \(date.timeIntervalSinceReferenceDate, privacy: .public) next: \(next.timeIntervalSinceReferenceDate, privacy: .public) previous: \(previous.timeIntervalSinceReferenceDate, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
+        Logger(Calendar.log.log).error("Not advancing Calendar enumeration result: \(date.timeIntervalSinceReferenceDate, privacy: .public) next: \(next.timeIntervalSinceReferenceDate, privacy: .public) previous: \(previous.timeIntervalSinceReferenceDate, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
     case .unexpectedResult(let component, let test):
-        Logger(Calendar.log).error("Unexpected Calendar enumeration result: start: \(date.timeIntervalSinceReferenceDate, privacy: .public) test: \(test.timeIntervalSinceReferenceDate, privacy: .public) \(component.debugDescription, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
+        Logger(Calendar.log.log).error("Unexpected Calendar enumeration result: start: \(date.timeIntervalSinceReferenceDate, privacy: .public) test: \(test.timeIntervalSinceReferenceDate, privacy: .public) \(component.debugDescription, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
     }
 #endif
 }
 
 private func _handleCalendarResultNotFound(date: Date, calendar: Calendar, comps: DateComponents, direction: Calendar.SearchDirection, matchingPolicy: Calendar.MatchingPolicy, repeatedTimePolicy: Calendar.RepeatedTimePolicy) {
 #if FOUNDATION_FRAMEWORK
-    Logger(Calendar.log).debug("Unable to find Calendar enumeration result: \(date.timeIntervalSinceReferenceDate, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
+    Logger(Calendar.log.log).debug("Unable to find Calendar enumeration result: \(date.timeIntervalSinceReferenceDate, privacy: .public) \(calendar, privacy: .public) \(comps, privacy: .public) \(direction.debugDescription, privacy: .public) \(matchingPolicy.debugDescription, privacy: .public) \(repeatedTimePolicy.debugDescription)")
 #endif
 }
 

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -21,7 +21,7 @@ import Glibc
 //===----------------------------------------------------------------------===//
 
 // This construction allows overall fewer and smaller allocations as the coding path is modified.
-internal enum _CodingPathNode {
+internal enum _CodingPathNode : Sendable {
     case root
     indirect case node(CodingKey, _CodingPathNode, depth: Int)
     indirect case indexNode(Int, _CodingPathNode, depth: Int)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -41,12 +41,14 @@
 @usableFromInline let memcmp = WASILibc.memcmp
 #endif
 
+internal import _CShims
+
 #if canImport(Darwin)
 import Darwin
 
 internal func __DataInvokeDeallocatorVirtualMemory(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     guard vm_deallocate(
-        mach_task_self_,
+        _platform_mach_task_self(),
         vm_address_t(UInt(bitPattern: mem)),
         vm_size_t(length)) == ERR_SUCCESS else {
         fatalError("*** __DataInvokeDeallocatorVirtualMemory(\(mem), \(length)) failed")
@@ -2032,7 +2034,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     public typealias ReadingOptions = NSData.ReadingOptions
     public typealias WritingOptions = NSData.WritingOptions
 #else
-    public struct ReadingOptions : OptionSet {
+    public struct ReadingOptions : OptionSet, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
@@ -2042,7 +2044,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     }
     
     // This is imported from the ObjC 'option set', which is actually a combination of an option and an enumeration (file protection).
-    public struct WritingOptions : OptionSet {
+    public struct WritingOptions : OptionSet, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
 

--- a/Sources/FoundationEssentials/Error/CocoaError.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError.swift
@@ -57,7 +57,9 @@ extension CocoaError.Code : _ErrorCodeProtocol {
 public struct CocoaError : Error {
     // On not-Darwin, CocoaError is backed by a simple code.
     public let code: Code
-    public let userInfo: [String: Any]
+    
+    // On Darwin, this is backed by an NSDictionary which allows for non-Sendable types to be inserted into the userInfo.
+    public nonisolated(unsafe) let userInfo: [String: Any]
     
     public init(_ code: Code, userInfo: [String: Any] = [:]) {
         self.code = code

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -11,9 +11,9 @@
 
 // Import for POSIXErrorCode
 #if canImport(Glibc)
-import Glibc 
+@preconcurrency import Glibc 
 #elseif canImport(Darwin)
-import Darwin
+@preconcurrency import Darwin
 #elseif os(Windows)
 import CRT
 import WinSDK
@@ -46,7 +46,7 @@ extension POSIXErrorCode : _ErrorCodeProtocol {
 #else
 
 /// Describes an error in the POSIX error domain.
-public struct POSIXError : Error, Hashable {
+public struct POSIXError : Error, Hashable, Sendable {
     public let code: Code
 
     public static var errorDomain: String { return "NSPOSIXErrorDomain" }

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -28,11 +28,8 @@ import WinSDK
 internal import _CShims
 
 #if FOUNDATION_FRAMEWORK
-var _shouldLog: Bool = {
-    UserDefaults.standard.bool(forKey: "NSLogSpecialFolderRecreation")
-}()
 func _LogSpecialFolderRecreation(_ fileManager: FileManager, _ path: String) {
-    if _shouldLog && !fileManager.fileExists(atPath: path) {
+    if UserDefaults.standard.bool(forKey: "NSLogSpecialFolderRecreation") && !fileManager.fileExists(atPath: path) {
         Logger().info("*** Application: \(Bundle.main.bundleIdentifier ?? "(null)") just recreated special folder: \(path)")
     }
 }

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManagerDelegate.swift
@@ -12,7 +12,7 @@
 
 #if !FOUNDATION_FRAMEWORK
 
-public protocol FileManagerDelegate : AnyObject {
+public protocol FileManagerDelegate : AnyObject, Sendable {
     // String-based requirements
     func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool
     func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool

--- a/Sources/FoundationEssentials/Formatting/FormatterCache.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatterCache.swift
@@ -15,7 +15,7 @@ package struct FormatterCache<Format : Hashable & Sendable, FormattingType: Send
     let countLimit = 100
 
     private let _lock: LockedState<[Format: FormattingType]>
-    package func formatter(for config: Format, creator: () -> FormattingType) -> FormattingType {
+    package func formatter(for config: Format, creator: () throws -> FormattingType) rethrows -> FormattingType {
         let existed = _lock.withLock { cache in
             return cache [config]
         }
@@ -25,7 +25,7 @@ package struct FormatterCache<Format : Hashable & Sendable, FormattingType: Send
         }
 
         // Call `creator()` outside of the cache's lock to avoid blocking
-        let df = creator()
+        let df = try creator()
 
         _lock.withLockExtendingLifetimeOfState { cache in
             if cache.count > countLimit {

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -513,7 +513,7 @@ class JSONReference {
         case directArray([String])
     }
     
-    var backing: Backing
+    private(set) var backing: Backing
 
     @inline(__always)
     func insert(_ ref: JSONReference, for key: String) {
@@ -595,15 +595,21 @@ class JSONReference {
         return true
     }
 
-    static let null : JSONReference = .init(.null)
+    // Sendable note: this is an immutable singleton
+    static nonisolated(unsafe) let null : JSONReference = .init(.null)
     static func string(_ str: String) -> JSONReference { .init(.string(str)) }
     static func number(_ str: String) -> JSONReference { .init(.number(str)) }
-    static let `true` : JSONReference = .init(.bool(true))
-    static let `false` : JSONReference = .init(.bool(false))
+    
+    // Sendable note: this is an immutable singleton
+    static nonisolated(unsafe) let `true` : JSONReference = .init(.bool(true))
+    
+    // Sendable note: this is an immutable singleton
+    static nonisolated(unsafe) let `false` : JSONReference = .init(.bool(false))
     static func bool(_ b: Bool) -> JSONReference { b ? .true : .false }
     static var emptyArray : JSONReference { .init(.array([])) }
     static var emptyObject : JSONReference { .init(.object([:])) }
 }
+
 
 private struct _JSONEncodingStorage {
     // MARK: Properties

--- a/Sources/FoundationEssentials/JSON/JSONScanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSONScanner.swift
@@ -127,7 +127,7 @@ internal class JSONMap {
 
     @inline(__always)
     func withBuffer<T>(
-      for region: Region, perform closure: (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
+      for region: Region, perform closure: @Sendable (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
     ) rethrows -> T {
         try dataLock.withLock {
             return try closure($0.buffer[region], $0.buffer)

--- a/Sources/FoundationEssentials/Locale/Locale_Cache.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Cache.swift
@@ -24,7 +24,7 @@ struct LocaleCache : Sendable {
     // MARK: - Concrete Classes
     
     // _LocaleICU, if present. Otherwise we use _LocaleUnlocalized. The `Locale` initializers are not failable, so we just fall back to the unlocalized type when needed without failure.
-    static var localeICUClass: _LocaleProtocol.Type = {
+    static let localeICUClass: _LocaleProtocol.Type = {
 #if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
         return _LocaleICU.self
 #else

--- a/Sources/FoundationEssentials/Logging.swift
+++ b/Sources/FoundationEssentials/Logging.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if FOUNDATION_FRAMEWORK
+
+internal import os
+
+/// Wrapper for OSLog until it is marked as Sendable.
+package struct SendableOSLog : @unchecked Sendable {
+    init(_ log: OSLog) { self.log = log }
+    let log: OSLog
+}
+
+#endif

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -172,7 +172,8 @@ extension PredicateExpressions {
         arg
     }
     
-    public static func build_KeyPath<Root, Value>(root: Root, keyPath: Swift.KeyPath<Root.Output, Value>) -> PredicateExpressions.KeyPath<Root, Value> {
+    @preconcurrency
+    public static func build_KeyPath<Root, Value>(root: Root, keyPath: Swift.KeyPath<Root.Output, Value> & Sendable) -> PredicateExpressions.KeyPath<Root, Value> {
         KeyPath(root: root, keyPath: keyPath)
     }
 

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+ObjC.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo+ObjC.swift
@@ -16,12 +16,12 @@ internal import MachO_Private.dyld
 internal import CoreFoundation_Private
 
 @objc(_NSSwiftProcessInfo)
-internal final class _NSSwiftProcessInfo: ProcessInfo {
+internal final class _NSSwiftProcessInfo: ProcessInfo, @unchecked Sendable {
 
     private static let _shared: _NSSwiftProcessInfo = _NSSwiftProcessInfo()
 
     internal static let _globalState: LockedState<GlobalState> = .init(initialState: .init())
-    internal var _state: LockedState<State>
+    internal let _state: LockedState<State>
     private let _processInfo: _ProcessInfo
 
     override static var processInfo: ProcessInfo {

--- a/Sources/FoundationEssentials/PropertyList/BPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/BPlistScanner.swift
@@ -128,7 +128,7 @@ class BPlistMap : PlistDecodingMap {
 
     @inline(__always)
     func withBuffer<T>(
-      for region: Region, perform closure: (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
+      for region: Region, perform closure: @Sendable (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
     ) rethrows -> T {
         try dataLock.withLock {
             return try closure($0.buffer[region], $0.buffer)
@@ -157,7 +157,8 @@ class BPlistMap : PlistDecodingMap {
     }
 
     func loadValue(at idx: BPlistObjectIndex) throws -> Value {
-        return try dataLock.withLock { state in
+        // Sendable note: We do not mutate self from within this lock
+        return try dataLock.withLockUnchecked { state in
             guard Int(idx) < objectOffsets.count else {
                 throw BPlistError.corruptedValue("object index")
             }

--- a/Sources/FoundationEssentials/PropertyList/PlistDictionaryEncoder.swift
+++ b/Sources/FoundationEssentials/PropertyList/PlistDictionaryEncoder.swift
@@ -598,6 +598,7 @@ internal class __PlistDictionaryReferencingEncoder : __PlistDictionaryEncoder {
     }
 }
 
-internal let _plistNullNSString = NSString(string: _plistNullString)
+// Sendable note: This is an immutable instance of NSString.
+internal nonisolated(unsafe) let _plistNullNSString = NSString(string: _plistNullString)
 
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
+++ b/Sources/FoundationEssentials/PropertyList/XMLPlistScanner.swift
@@ -196,7 +196,7 @@ class XMLPlistMap : PlistDecodingMap {
 
     @inline(__always)
     func withBuffer<T>(
-      for region: Region, perform closure: (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
+      for region: Region, perform closure: @Sendable (_ jsonBytes: BufferView<UInt8>, _ fullSource: BufferView<UInt8>) throws -> T
     ) rethrows -> T {
         try dataLock.withLock {
             return try closure($0.buffer[region], $0.buffer)

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -35,7 +35,7 @@ struct TimeZoneCache : Sendable {
     // MARK: - Concrete Classes
     
     // _TimeZoneICU, if present
-    static var timeZoneICUClass: _TimeZoneProtocol.Type? = {
+    static let timeZoneICUClass: _TimeZoneProtocol.Type? = {
 #if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
         _TimeZoneICU.self
 #else
@@ -48,7 +48,7 @@ struct TimeZoneCache : Sendable {
     }()
     
     // _TimeZoneGMTICU or _TimeZoneGMT
-    static var timeZoneGMTClass: _TimeZoneProtocol.Type = {
+    static let timeZoneGMTClass: _TimeZoneProtocol.Type = {
 #if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)
         _TimeZoneGMTICU.self
 #else

--- a/Sources/FoundationEssentials/URL/URLComponents_ObjC.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents_ObjC.swift
@@ -400,8 +400,8 @@ extension NSURLQueryItem {
 }
 
 @objc(_NSSwiftURLQueryItem)
-internal class _NSSwiftURLQueryItem: _NSURLQueryItemBridge {
-    var queryItem: URLQueryItem
+internal final class _NSSwiftURLQueryItem: _NSURLQueryItemBridge, @unchecked Sendable {
+    let queryItem: URLQueryItem
 
     init(queryItem: URLQueryItem) {
         self.queryItem = queryItem

--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -160,7 +160,7 @@ package protocol UIDNAHook {
 
 internal struct RFC3986Parser: URLParserProtocol {
     static let kind: URLParserKind = .RFC3986
-    static var uidnaHook: UIDNAHook.Type? = {
+    static let uidnaHook: UIDNAHook.Type? = {
         #if FOUNDATION_FRAMEWORK && !canImport(_FoundationICU)
         nil
         #elseif FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/UUID_Wrappers.swift
+++ b/Sources/FoundationEssentials/UUID_Wrappers.swift
@@ -65,7 +65,7 @@ extension NSUUID : _HasCustomAnyHashableRepresentation {
 }
 
 @objc(__NSConcreteUUID)
-internal class __NSConcreteUUID : _NSUUIDBridge {
+internal class __NSConcreteUUID : _NSUUIDBridge, @unchecked Sendable {
     final var _storage: UUID
 
     fileprivate init(value: Foundation.UUID) {

--- a/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
+++ b/Sources/FoundationInternationalization/Formatting/ByteCountFormatStyle.swift
@@ -162,7 +162,9 @@ public struct ByteCountFormatStyle: FormatStyle, Sendable {
                 }
 
                 let configuration = DescriptiveNumberFormatConfiguration.Collection(presentation: .cardinal, capitalizationContext: .beginningOfSentence)
-                let spellOutFormatter = ICULegacyNumberFormatter.formatter(for: .descriptive(configuration), locale: locale)
+                guard let spellOutFormatter = ICULegacyNumberFormatter.formatter(for: .descriptive(configuration), locale: locale) else {
+                    return attributedFormat
+                }
 
                 guard let zeroFormatted = spellOutFormatter.format(Int64.zero) else {
                     return attributedFormat

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -24,8 +24,9 @@ import Glibc
 
 typealias UChar = UInt16
 
-final class ICUDateFormatter {
+final class ICUDateFormatter : @unchecked Sendable {
 
+    /// `Sendable` notes: `UDateFormat` is safe to use from multiple threads after initialization. The `UCal` using API clones the calendar before using it.
     var udateFormat: UnsafeMutablePointer<UDateFormat?>
     var lenientParsing: Bool
 
@@ -257,7 +258,7 @@ final class ICUDateFormatter {
     }
 
     static let formatterCache = FormatterCache<DateFormatInfo, ICUDateFormatter?>()
-    static var patternCache = LockedState<[PatternCacheKey : String]>(initialState: [:])
+    static let patternCache = LockedState<[PatternCacheKey : String]>(initialState: [:])
 
     static func cachedFormatter(for dateFormatInfo: DateFormatInfo) -> ICUDateFormatter? {
         return Self.formatterCache.formatter(for: dateFormatInfo) {

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateIntervalFormatter.swift
@@ -16,7 +16,7 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
-final class ICUDateIntervalFormatter {
+final class ICUDateIntervalFormatter : @unchecked Sendable {
     struct Signature : Hashable {
         let localeComponents: Locale.Components
         let calendarIdentifier: Calendar.Identifier
@@ -26,6 +26,7 @@ final class ICUDateIntervalFormatter {
     
     internal static let cache = FormatterCache<Signature, ICUDateIntervalFormatter?>()
 
+    /// `Sendable` notes: After initialization, we only use the ICU `udtitvfmt_format` function, which does not mutate the underlying formatter and is thread-safe.
     let uformatter: OpaquePointer // UDateIntervalFormat
 
     private init?(signature: Signature) {

--- a/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICURelativeDateFormatter.swift
@@ -17,7 +17,7 @@ import FoundationEssentials
 internal import _FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-internal final class ICURelativeDateFormatter {
+internal final class ICURelativeDateFormatter : @unchecked Sendable {
     struct Signature : Hashable {
         let localeIdentifier: String
         let numberFormatStyle: UNumberFormatStyle.RawValue?
@@ -37,6 +37,7 @@ internal final class ICURelativeDateFormatter {
         .second: .second
     ]
 
+    /// `Sendable` notes: `ureldatefmt_format` is thread safe after initialization.
     let uformatter: OpaquePointer
 
     internal static let cache = FormatterCache<Signature, ICURelativeDateFormatter?>()

--- a/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/ICUListFormatter.swift
@@ -17,7 +17,9 @@ import FoundationEssentials
 internal import _FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-internal final class ICUListFormatter {
+internal final class ICUListFormatter : @unchecked Sendable {
+    
+    /// `Sendable` notes: `UListFormatter` is thread safe for formatting, and we only use `ulistfmt_format` after init.
     let uformatter: OpaquePointer
 
     struct Signature : Hashable {

--- a/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/Decimal+ParseStrategy.swift
@@ -62,7 +62,9 @@ extension Decimal.ParseStrategy {
             locale = .autoupdatingCurrent
         }
 
-        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
+        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
+            return nil
+        }
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         guard let value = parser.parseAsDecimal(substr, upperBound: &upperBound) else {

--- a/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/FloatingPointParseStrategy.swift
@@ -29,7 +29,10 @@ extension FloatingPointParseStrategy : Sendable where Format : Sendable {}
 extension FloatingPointParseStrategy: ParseStrategy {
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func parse(_ value: String) throws -> Format.FormatInput {
-        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
+        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
+            throw CocoaError(CocoaError.formatting, userInfo: [
+                NSDebugDescriptionErrorKey: "Cannot parse \(value), unable to create formatter" ])
+        }
         if let v = parser.parseAsDouble(value._trimmingWhitespace()) {
             return Format.FormatInput(v)
         } else {
@@ -45,7 +48,9 @@ extension FloatingPointParseStrategy: ParseStrategy {
             return nil
         }
 
-        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
+        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
+            return nil
+        }
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         if let value = parser.parseAsDouble(substr, upperBound: &upperBound) {

--- a/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICULegacyNumberFormatter.swift
@@ -17,44 +17,17 @@ import FoundationEssentials
 internal import _FoundationICU
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-internal final class ICULegacyNumberFormatter {
+internal final class ICULegacyNumberFormatter : @unchecked Sendable {
 
+    /// `Sendable` notes: `UNumberFormat` is safe to use from multple threads after initialization and configuration.
     let uformatter: UnsafeMutablePointer<UNumberFormat?>
 
-    private init(type: UNumberFormatStyle, localeIdentifier: String) throws {
-        var status = U_ZERO_ERROR
-        let result = unum_open(type, nil, 0, localeIdentifier, nil, &status)
-        guard let result else { throw ICUError(code: U_UNSUPPORTED_ERROR) }
-        try status.checkSuccess()
-        uformatter = result
+    private init(openedFormatter: UnsafeMutablePointer<UNumberFormat?>) {
+        uformatter = openedFormatter
     }
 
     deinit {
         unum_close(uformatter)
-    }
-
-    func setAttribute(_ attr: UNumberFormatAttribute, value: Double) {
-        if attr == .roundingIncrement {
-            // RoundingIncrement is the only attribute that takes a double value.
-            unum_setDoubleAttribute(uformatter, attr, value)
-        } else {
-            unum_setAttribute(uformatter, attr, Int32(value))
-        }
-    }
-
-    func setAttribute(_ attr: UNumberFormatAttribute, value: Int) {
-        unum_setAttribute(uformatter, attr, Int32(value))
-    }
-
-    func setAttribute(_ attr: UNumberFormatAttribute, value: Bool) {
-        unum_setAttribute(uformatter, attr, value ? 1 : 0)
-    }
-
-    func setTextAttribute(_ attr: UNumberFormatTextAttribute, value: String) throws {
-        let uvalue = Array(value.utf16)
-        var status = U_ZERO_ERROR
-        unum_setTextAttribute(uformatter, attr, uvalue, Int32(uvalue.count), &status)
-        try status.checkSuccess()
     }
 
     func parseAsInt(_ string: some StringProtocol) -> Int64? {
@@ -145,80 +118,6 @@ internal final class ICULegacyNumberFormatter {
         }
     }
 
-    // Attribute setters
-
-    func setPrecision(_ precision: NumberFormatStyleConfiguration.Precision?) {
-        guard let precision = precision else { return }
-
-        switch precision.option {
-        case .significantDigits(let min, let max):
-            setAttribute(.significantDigitsUsed, value: true)
-            setAttribute(.minSignificantDigits, value: min)
-            if let max = max {
-                setAttribute(.maxSignificantDigits, value: max)
-            }
-        case .integerAndFractionalLength(let minInt, let maxInt, let minFraction, let maxFraction):
-            setAttribute(.significantDigitsUsed, value: false)
-            if let minInt = minInt {
-                setAttribute(.minIntegerDigits, value: minInt)
-            }
-            if let maxInt = maxInt {
-                setAttribute(.maxIntegerDigits, value: maxInt)
-            }
-            if let minFraction = minFraction {
-                setAttribute(.minFractionDigits, value: minFraction)
-            }
-            if let maxFraction = maxFraction {
-                setAttribute(.maxFractionDigits, value: maxFraction)
-            }
-        }
-    }
-
-    func setMultiplier(_ multiplier: Double?) {
-        if let multiplier {
-            setAttribute(.multiplier, value: multiplier)
-        }
-    }
-
-    func setGrouping(_ group: NumberFormatStyleConfiguration.Grouping?) {
-        guard let group = group else { return }
-
-        switch group.option {
-        case .automatic:
-            break
-        case .hidden:
-            setAttribute(.groupingUsed, value: false)
-        }
-    }
-
-    func setDecimalSeparator(_ decimalSeparator: NumberFormatStyleConfiguration.DecimalSeparatorDisplayStrategy?) {
-        guard let decimalSeparator = decimalSeparator else { return }
-
-        switch decimalSeparator.option {
-        case .automatic:
-            break
-        case .always:
-            setAttribute(.decimalAlwaysShown, value: true)
-        }
-    }
-
-    func setRoundingIncrement(_ increment: NumberFormatStyleConfiguration.RoundingIncrement?) {
-        guard let increment = increment else { return }
-
-        switch increment {
-        case .integer(let value):
-            setAttribute(.roundingIncrement, value: value)
-        case .floatingPoint(let value):
-            setAttribute(.roundingIncrement, value: value)
-        }
-    }
-
-    func setCapitalizationContext(_ context: FormatStyleCapitalizationContext) {
-        var status = U_ZERO_ERROR
-        unum_setContext(uformatter, context.icuContext, &status)
-        // status ignored, nothing to do on failure
-    }
-
     // MARK: - Cache utilities
 
     enum NumberFormatType : Hashable, Codable {
@@ -233,7 +132,7 @@ internal final class ICULegacyNumberFormatter {
         let localeIdentifier: String
         let lenient: Bool
 
-        func createNumberFormatter() -> ICULegacyNumberFormatter {
+        func createNumberFormatter() throws -> ICULegacyNumberFormatter {
             var icuType: UNumberFormatStyle
             switch type {
             case .number(let config):
@@ -250,41 +149,47 @@ internal final class ICULegacyNumberFormatter {
                 icuType = config.icuNumberFormatStyle
             }
 
-            let formatter = try! ICULegacyNumberFormatter(type: icuType, localeIdentifier: localeIdentifier)
-            formatter.setAttribute(.lenientParse, value: lenient)
+            var status = U_ZERO_ERROR
+            let formatter = unum_open(icuType, nil, 0, localeIdentifier, nil, &status)
+            guard let formatter else {
+                throw ICUError(code: U_UNSUPPORTED_ERROR)
+            }
+            try status.checkSuccess()
+
+            setAttribute(.lenientParse, formatter: formatter, value: lenient)
 
             switch type {
             case .number(let config):
                 fallthrough
             case .percent(let config):
-                formatter.setMultiplier(config.scale)
-                formatter.setPrecision(config.precision)
-                formatter.setGrouping(config.group)
-                formatter.setDecimalSeparator(config.decimalSeparatorStrategy)
-                formatter.setRoundingIncrement(config.roundingIncrement)
+                setMultiplier(config.scale, formatter: formatter)
+                setPrecision(config.precision, formatter: formatter)
+                setGrouping(config.group, formatter: formatter)
+                setDecimalSeparator(config.decimalSeparatorStrategy, formatter: formatter)
+                setRoundingIncrement(config.roundingIncrement, formatter: formatter)
 
                 // Decimal and percent style specific attributes
                 if let sign = config.signDisplayStrategy {
                     switch sign.positive {
                     case .always:
-                        formatter.setAttribute(.signAlwaysShown, value: true)
+                        setAttribute(.signAlwaysShown, formatter: formatter, value: true)
                     case .hidden:
                         break
                     }
                 }
 
             case .currency(let config):
-                formatter.setMultiplier(config.scale)
-                formatter.setPrecision(config.precision)
-                formatter.setGrouping(config.group)
-                formatter.setDecimalSeparator(config.decimalSeparatorStrategy)
-                formatter.setRoundingIncrement(config.roundingIncrement)
+                setMultiplier(config.scale, formatter: formatter)
+                setPrecision(config.precision, formatter: formatter)
+                setGrouping(config.group, formatter: formatter)
+                setDecimalSeparator(config.decimalSeparatorStrategy, formatter: formatter)
+                setRoundingIncrement(config.roundingIncrement, formatter: formatter)
 
                 // Currency specific attributes
                 if let sign = config.signDisplayStrategy {
                     switch sign.positive {
                     case .always:
-                        formatter.setAttribute(.signAlwaysShown, value: true)
+                        setAttribute(.signAlwaysShown, formatter: formatter, value: true)
                     case .hidden:
                         break
                     }
@@ -292,7 +197,7 @@ internal final class ICULegacyNumberFormatter {
                 
             case .descriptive(let config):
                 if let capitalizationContext = config.capitalizationContext {
-                    formatter.setCapitalizationContext(capitalizationContext)
+                    setCapitalizationContext(capitalizationContext, formatter: formatter)
                 }
                 
                 switch config.presentation.option {
@@ -302,23 +207,122 @@ internal final class ICULegacyNumberFormatter {
                     break
                 case .cardinal:
                     do {
-                        try formatter.setTextAttribute(.defaultRuleSet, value: "%spellout-cardinal")
+                        try setTextAttribute(.defaultRuleSet, formatter: formatter, value: "%spellout-cardinal")
                     } catch {
                         // the general cardinal rule isn't supported, so try a gendered cardinal. Note that a proper fix requires using the gender of the subsequent noun
-                        try? formatter.setTextAttribute(.defaultRuleSet, value: "%spellout-cardinal-masculine")
+                        try? setTextAttribute(.defaultRuleSet, formatter: formatter, value: "%spellout-cardinal-masculine")
                     }
                 }
             }
-            return formatter
+            
+            return ICULegacyNumberFormatter(openedFormatter: formatter)
         }
     }
 
     private static let cache = FormatterCache<Signature, ICULegacyNumberFormatter>()
     // lenient is only used for parsing
-    static func formatter(for type: NumberFormatType, locale: Locale, lenient: Bool = false) -> ICULegacyNumberFormatter {
+    static func formatter(for type: NumberFormatType, locale: Locale, lenient: Bool = false) -> ICULegacyNumberFormatter? {
         let sig = Signature(type: type, localeIdentifier: locale.identifier, lenient: lenient)
-        let formatter = ICULegacyNumberFormatter.cache.formatter(for: sig, creator: sig.createNumberFormatter)
+        let formatter = try? ICULegacyNumberFormatter.cache.formatter(for: sig, creator: sig.createNumberFormatter)
 
         return formatter
     }
+}
+
+// MARK: - Helper Setters
+
+private func setAttribute(_ attr: UNumberFormatAttribute, formatter: UnsafeMutablePointer<UNumberFormat?>, value: Double) {
+    if attr == .roundingIncrement {
+        // RoundingIncrement is the only attribute that takes a double value.
+        unum_setDoubleAttribute(formatter, attr, value)
+    } else {
+        unum_setAttribute(formatter, attr, Int32(value))
+    }
+}
+
+private func setAttribute(_ attr: UNumberFormatAttribute, formatter: UnsafeMutablePointer<UNumberFormat?>, value: Int) {
+    unum_setAttribute(formatter, attr, Int32(value))
+}
+
+private func setAttribute(_ attr: UNumberFormatAttribute, formatter: UnsafeMutablePointer<UNumberFormat?>, value: Bool) {
+    unum_setAttribute(formatter, attr, value ? 1 : 0)
+}
+
+private func setTextAttribute(_ attr: UNumberFormatTextAttribute, formatter: UnsafeMutablePointer<UNumberFormat?>, value: String) throws {
+    let uvalue = Array(value.utf16)
+    var status = U_ZERO_ERROR
+    unum_setTextAttribute(formatter, attr, uvalue, Int32(uvalue.count), &status)
+    try status.checkSuccess()
+}
+
+private func setPrecision(_ precision: NumberFormatStyleConfiguration.Precision?, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    guard let precision = precision else { return }
+
+    switch precision.option {
+    case .significantDigits(let min, let max):
+        setAttribute(.significantDigitsUsed, formatter: formatter, value: true)
+        setAttribute(.minSignificantDigits, formatter: formatter, value: min)
+        if let max = max {
+            setAttribute(.maxSignificantDigits, formatter: formatter, value: max)
+        }
+    case .integerAndFractionalLength(let minInt, let maxInt, let minFraction, let maxFraction):
+        setAttribute(.significantDigitsUsed, formatter: formatter, value: false)
+        if let minInt = minInt {
+            setAttribute(.minIntegerDigits, formatter: formatter, value: minInt)
+        }
+        if let maxInt = maxInt {
+            setAttribute(.maxIntegerDigits, formatter: formatter, value: maxInt)
+        }
+        if let minFraction = minFraction {
+            setAttribute(.minFractionDigits, formatter: formatter, value: minFraction)
+        }
+        if let maxFraction = maxFraction {
+            setAttribute(.maxFractionDigits, formatter: formatter, value: maxFraction)
+        }
+    }
+}
+
+private func setMultiplier(_ multiplier: Double?, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    if let multiplier {
+        setAttribute(.multiplier, formatter: formatter, value: multiplier)
+    }
+}
+
+private func setGrouping(_ group: NumberFormatStyleConfiguration.Grouping?, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    guard let group = group else { return }
+
+    switch group.option {
+    case .automatic:
+        break
+    case .hidden:
+        setAttribute(.groupingUsed, formatter: formatter, value: false)
+    }
+}
+
+private func setDecimalSeparator(_ decimalSeparator: NumberFormatStyleConfiguration.DecimalSeparatorDisplayStrategy?, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    guard let decimalSeparator = decimalSeparator else { return }
+
+    switch decimalSeparator.option {
+    case .automatic:
+        break
+    case .always:
+        setAttribute(.decimalAlwaysShown, formatter: formatter, value: true)
+    }
+}
+
+private func setRoundingIncrement(_ increment: NumberFormatStyleConfiguration.RoundingIncrement?, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    guard let increment = increment else { return }
+
+    switch increment {
+    case .integer(let value):
+        setAttribute(.roundingIncrement, formatter: formatter, value: value)
+    case .floatingPoint(let value):
+        setAttribute(.roundingIncrement, formatter: formatter, value: value)
+    }
+}
+
+private func setCapitalizationContext(_ context: FormatStyleCapitalizationContext, formatter: UnsafeMutablePointer<UNumberFormat?>) {
+    var status = U_ZERO_ERROR
+    unum_setContext(formatter, context.icuContext, &status)
+    // status ignored, nothing to do on failure
 }

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -27,7 +27,8 @@ internal func resetAllNumberFormatterCaches() {
 }
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-internal class ICUNumberFormatterBase {
+internal class ICUNumberFormatterBase : @unchecked Sendable {
+    /// `Sendable` notes: ICU's `UNumberFormatter` itself is thread safe. The result type is not, but we create that each time we format.
     internal let uformatter: OpaquePointer
     /// Stored for testing purposes only
     internal let skeleton: String
@@ -219,7 +220,7 @@ internal class ICUNumberFormatterBase {
 
 // MARK: - Integer
 
-final class ICUNumberFormatter : ICUNumberFormatterBase {
+final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let collection: NumberFormatStyleConfiguration.Collection
         let localeIdentifier: String
@@ -256,7 +257,7 @@ final class ICUNumberFormatter : ICUNumberFormatterBase {
 
 // MARK: - Currency
 
-final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase {
+final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let collection: CurrencyFormatStyleConfiguration.Collection
         let currencyCode: String
@@ -305,7 +306,7 @@ final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase {
 
 // MARK: - Integer Percent
 
-final class ICUPercentNumberFormatter : ICUNumberFormatterBase {
+final class ICUPercentNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let collection: NumberFormatStyleConfiguration.Collection
         let localeIdentifier: String
@@ -351,7 +352,7 @@ final class ICUPercentNumberFormatter : ICUNumberFormatterBase {
 
 // MARK: - Byte Count
 
-final class ICUByteCountNumberFormatter : ICUNumberFormatterBase {
+final class ICUByteCountNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let localeIdentifier: String
@@ -410,7 +411,7 @@ final class ICUByteCountNumberFormatter : ICUNumberFormatterBase {
 
 // MARK: - Measurement
 
-final class ICUMeasurementNumberFormatter : ICUNumberFormatterBase {
+final class ICUMeasurementNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let localeIdentifier: String

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -28,7 +28,10 @@ extension IntegerParseStrategy : Sendable where Format : Sendable {}
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 extension IntegerParseStrategy: ParseStrategy {
     public func parse(_ value: String) throws -> Format.FormatInput {
-        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
+        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
+            throw CocoaError(CocoaError.formatting, userInfo: [
+                NSDebugDescriptionErrorKey: "Cannot parse \(value). Could not create parser." ])
+        }
         let trimmedString = value._trimmingWhitespace()
         if let v = parser.parseAsInt(trimmedString) {
             return Format.FormatInput(v)
@@ -46,7 +49,9 @@ extension IntegerParseStrategy: ParseStrategy {
             return nil
         }
 
-        let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient)
+        guard let parser = ICULegacyNumberFormatter.formatter(for: numberFormatType, locale: locale, lenient: lenient) else {
+            return nil
+        }
         let substr = value[index..<range.upperBound]
         var upperBound = 0
         if let value = parser.parseAsInt(substr, upperBound: &upperBound) {

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -141,8 +141,8 @@ public enum NumberFormatStyleConfiguration {
 
         // The maximum total length that ICU allows is 999.
         // We take one off to reserve one character for the non-zero digit skeleton (the "0" skeleton in the number format)
-        static var validPartLength = 0..<999
-        static var validSignificantDigits = 1..<999
+        static let validPartLength = 0..<999
+        static let validSignificantDigits = 1..<999
 
         // min 3, max 3: 12345 -> 12300
         // min 3, max 3: 0.12345 -> 0.123

--- a/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
+++ b/Sources/FoundationInternationalization/ICU/ICUPatternGenerator.swift
@@ -16,8 +16,9 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
-final class ICUPatternGenerator {
+final class ICUPatternGenerator : @unchecked Sendable {
 
+    /// `Sendable` notes: We create this in init, and the non-thread safe API of `udatpg_getBestPatternWithOptions` is performed on a clone of it. `udatpg_getDefaultHourCycle` is thread safe as the underlying data is initialized at init time of the pattern generator itself.
     let upatternGenerator: UnsafeMutablePointer<UDateTimePatternGenerator?>
 
     private init?(localeIdentifier: String, calendarIdentifier: Calendar.Identifier) {

--- a/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale+Components_ICU.swift
@@ -180,7 +180,7 @@ extension Locale.LanguageCode {
     }
     
     // This is sorted
-    internal static var _isoLanguageCodeStrings: [String] = {
+    internal static let _isoLanguageCodeStrings: [String] = {
         var result: [String] = []
         let langs = uloc_getISOLanguages()
         guard var langs else { return [] }
@@ -276,7 +276,7 @@ extension Locale.Region {
     }
 
     /// Used for deprecated ISO Country Code
-    internal static var isoCountries: [String] = {
+    internal static let isoCountries: [String] = {
         var result: [String] = []
         let langs = uloc_getISOCountries()
         guard var langs else { return [] }
@@ -288,7 +288,7 @@ extension Locale.Region {
         return result
     }()
 
-    internal static var _isoRegionCodes: [String] {
+    internal static let _isoRegionCodes: [String] = {
         var status = U_ZERO_ERROR
         let types = [URGN_WORLD, URGN_CONTINENT, URGN_SUBCONTINENT, URGN_TERRITORY]
         var codes: [String] = []
@@ -301,7 +301,7 @@ extension Locale.Region {
             }
         }
         return codes
-    }
+    }()
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -135,8 +135,8 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
     // MARK: - Logging
 #if FOUNDATION_FRAMEWORK
-    static private let log: OSLog = {
-        OSLog(subsystem: "com.apple.foundation", category: "locale")
+    static private let log: SendableOSLog = {
+        .init(OSLog(subsystem: "com.apple.foundation", category: "locale"))
     }()
 #endif // FOUNDATION_FRAMEWORK
     
@@ -184,11 +184,11 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
         if let name {
             ident = Locale._canonicalLocaleIdentifier(from: name)
 #if FOUNDATION_FRAMEWORK
-            if Self.log.isEnabled(type: .debug) {
+            if Self.log.log.isEnabled(type: .debug) {
                 if let ident {
                     let components = Locale.Components(identifier: ident)
                     if components.languageComponents.region == nil {
-                        Logger(Self.log).debug("Current locale fetched with overriding locale identifier '\(ident, privacy: .public)' which does not have a country code")
+                        Logger(Self.log.log).debug("Current locale fetched with overriding locale identifier '\(ident, privacy: .public)' which does not have a country code")
                     }
                 }
             }
@@ -213,7 +213,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
             #if FOUNDATION_FRAMEWORK
             if preferredLanguages == nil && (preferredLocale == nil || performBundleMatching) {
-                Logger(Self.log).debug("Lookup of 'AppleLanguages' from current preferences failed lookup (app preferences do not contain the key); likely falling back to default locale identifier as current")
+                Logger(Self.log.log).debug("Lookup of 'AppleLanguages' from current preferences failed lookup (app preferences do not contain the key); likely falling back to default locale identifier as current")
             }
             #endif
 
@@ -246,18 +246,18 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                         // Country???
                         if let countryCode = prefs.country {
                             #if FOUNDATION_FRAMEWORK
-                            Logger(Self.log).debug("Locale.current constructing a locale identifier from preferred languages by combining with set country code '\(countryCode, privacy: .public)'")
+                            Logger(Self.log.log).debug("Locale.current constructing a locale identifier from preferred languages by combining with set country code '\(countryCode, privacy: .public)'")
                             #endif // FOUNDATION_FRAMEWORK
                             ident = Locale._canonicalLocaleIdentifier(from: "\(languageIdentifier)_\(countryCode)")
                         } else {
                             #if FOUNDATION_FRAMEWORK
-                            Logger(Self.log).debug("Locale.current constructing a locale identifier from preferred languages without a set country code")
+                            Logger(Self.log.log).debug("Locale.current constructing a locale identifier from preferred languages without a set country code")
                             #endif // FOUNDATION_FRAMEWORK
                             ident = Locale._canonicalLocaleIdentifier(from: languageIdentifier)
                         }
                     } else {
                         #if FOUNDATION_FRAMEWORK
-                        Logger(Self.log).debug("Value for 'AppleLanguages' found in preferences contains no valid entries; falling back to default locale identifier as current")
+                        Logger(Self.log.log).debug("Value for 'AppleLanguages' found in preferences contains no valid entries; falling back to default locale identifier as current")
                         #endif // FOUNDATION_FRAMEWORK
                     }
                 } else {
@@ -326,19 +326,19 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
             }
             return result
         case "AppleICUDateTimeSymbols":
-            return prefs.icuDateTimeSymbols
+            return prefs.icuSymbolsAndStrings.icuDateTimeSymbols
         case "AppleICUForce24HourTime":
             return prefs.force24Hour
         case "AppleICUForce12HourTime":
             return prefs.force12Hour
         case "AppleICUDateFormatStrings":
-            return prefs.icuDateFormatStrings
+            return prefs.icuSymbolsAndStrings.icuDateFormatStrings
         case "AppleICUTimeFormatStrings":
-            return prefs.icuTimeFormatStrings
+            return prefs.icuSymbolsAndStrings.icuTimeFormatStrings
         case "AppleICUNumberFormatStrings":
-            return prefs.icuNumberFormatStrings
+            return prefs.icuSymbolsAndStrings.icuNumberFormatStrings
         case "AppleICUNumberSymbols":
-            return prefs.icuNumberSymbols
+            return prefs.icuSymbolsAndStrings.icuNumberSymbols
         default:
             return nil
         }

--- a/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
@@ -226,7 +226,7 @@ extension NSLocale {
 /// Wraps a Swift `struct Locale` with an `NSLocale`, so that it can be used from Objective-C.
 /// The goal is to forward as much of the implementation as possible into Swift.
 @objc(_NSSwiftLocale)
-internal class _NSSwiftLocale: _NSLocaleBridge {
+internal class _NSSwiftLocale: _NSLocaleBridge, @unchecked Sendable {
     var locale: Locale
 
     internal init(_ locale: Locale) {
@@ -658,8 +658,8 @@ extension Locale {
 
 extension NSLocale.Key {
     // Extra keys used by CoreFoundation
-    static var cfLocaleCollatorID = NSLocale.Key(rawValue: "locale:collator id")
-    static var languageIdentifier = NSLocale.Key(rawValue: "locale:languageIdentifier")
+    static let cfLocaleCollatorID = NSLocale.Key(rawValue: "locale:collator id")
+    static let languageIdentifier = NSLocale.Key(rawValue: "locale:languageIdentifier")
 }
 
 #endif // FOUNDATION_FRAMEWORK

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -20,7 +20,8 @@ import FoundationEssentials
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct KeyPathComparator<Compared>: SortComparator {
     /// The key path to the property to be used for comparisons.
-    public let keyPath: PartialKeyPath<Compared>
+    @preconcurrency
+    public let keyPath: PartialKeyPath<Compared> & Sendable
 
     public var order: SortOrder {
         get {
@@ -33,7 +34,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
 
     var comparator: AnySortComparator
 
-    private let extractField: (Compared) -> Any
+    private let extractField: @Sendable (Compared) -> Any
 
     /// Get the field at `cachedOffset` if there is one, otherwise
     /// access the field directly through the keypath.
@@ -60,7 +61,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) {
+    @preconcurrency
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) {
         self.keyPath = keyPath
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
@@ -97,7 +99,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) {
+    @preconcurrency
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) {
         self.keyPath = keyPath
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
@@ -130,7 +133,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator) where Comparator.Compared == Value {
+    @preconcurrency
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -155,7 +159,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator) where Comparator.Compared == Value {
+    @preconcurrency
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -175,7 +180,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
     ///   - order: The initial order to use for comparison.
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+    @preconcurrency
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -199,7 +205,8 @@ public struct KeyPathComparator<Compared>: SortComparator {
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
     ///   - order: The initial order to use for comparison.
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+    @preconcurrency
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ICU.swift
@@ -479,7 +479,7 @@ internal final class _TimeZoneICU: _TimeZoneProtocol, Sendable {
 
 // MARK: -
 
-var icuTZIdentifiers: [String] = {
+let icuTZIdentifiers: [String] = {
     _TimeZoneICU.timeZoneNamesFromICU()
 }()
 

--- a/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
+++ b/Sources/FoundationInternationalization/TimeZone/TimeZone_ObjC.swift
@@ -130,7 +130,7 @@ extension NSTimeZone {
 
 /// Wraps a Swift `struct TimeZone` with an `NSTimeZone` so it can be used from Objective-C. The goal here is to forward as much of the meaningful implementation as possible to Swift.
 @objc(_NSSwiftTimeZone)
-final class _NSSwiftTimeZone: _NSTimeZoneBridge {
+final class _NSSwiftTimeZone: _NSTimeZoneBridge, @unchecked Sendable {
     var timeZone: TimeZone
     struct State {
         var data: Data?

--- a/Sources/TestSupport/TestSupport.swift
+++ b/Sources/TestSupport/TestSupport.swift
@@ -234,7 +234,7 @@ public typealias URLQueryItem = FoundationEssentials.URLQueryItem
 
 /// ICU uses `\u{202f}` and `\u{020f}` interchangeably.
 /// This function compares two strings ignoring the separator.
-public func XCTAssertEqualIgnoreSeparator(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertEqualIgnoreSeparator(_ lhs: String, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
     return XCTAssertEqual(
         lhs.normalizingICUSeparator(),
         rhs.normalizingICUSeparator(),
@@ -245,7 +245,7 @@ public func XCTAssertEqualIgnoreSeparator(_ lhs: String, _ rhs: String, file: St
 
 /// ICU uses `\u{202f}` and `\u{020f}` interchangeably.
 /// This function compares two attributed strings ignoring the separator.
-public func XCTAssertEqualIgnoreSeparator(_ lhs: AttributedString, _ rhs: AttributedString, file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertEqualIgnoreSeparator(_ lhs: AttributedString, _ rhs: AttributedString, file: StaticString = #filePath, line: UInt = #line) {
     return XCTAssertEqual(lhs.normalizingICUSeparator(), rhs.normalizingICUSeparator(), file: file, line: line)
 }
 

--- a/Sources/TestSupport/Utilities.swift
+++ b/Sources/TestSupport/Utilities.swift
@@ -20,12 +20,12 @@ import FoundationEssentials
 
 extension Optional {
     @available(*, unavailable, message: "Use XCTUnwrap() instead")
-    func unwrapped(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) throws -> Wrapped {
+    func unwrapped(_ fn: String = #function, file: StaticString = #filePath, line: UInt = #line) throws -> Wrapped {
         return try XCTUnwrap(self, file: file, line: line)
     }
 }
 
-func expectThrows<Error: Swift.Error & Equatable>(_ expectedError: Error, _ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+func expectThrows<Error: Swift.Error & Equatable>(_ expectedError: Error, _ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     var caught = false
     do {
         try test()
@@ -39,31 +39,31 @@ func expectThrows<Error: Swift.Error & Equatable>(_ expectedError: Error, _ test
     XCTAssert(caught, "No error thrown -- \(message())", file: file, line: line)
 }
 
-func expectDoesNotThrow(_ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+func expectDoesNotThrow(_ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertNoThrow(try test(), message(), file: file, line: line)
 }
 
-func expectTrue(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+func expectTrue(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertTrue(actual, message(), file: file, line: line)
 }
 
-func expectFalse(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+func expectFalse(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertFalse(actual, message(), file: file, line: line)
 }
 
-public func expectEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func expectEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(expected, actual, message(), file: file, line: line)
 }
 
-public func expectNotEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func expectNotEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertNotEqual(expected, actual, message(), file: file, line: line)
 }
 
-public func expectEqual<T: FloatingPoint>(_ expected: T, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func expectEqual<T: FloatingPoint>(_ expected: T, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(expected, actual, accuracy: within, message(), file: file, line: line)
 }
 
-public func expectEqual<T: FloatingPoint>(_ expected: T?, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func expectEqual<T: FloatingPoint>(_ expected: T?, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertNotNil(expected, message(), file: file, line: line)
     if let expected = expected {
         XCTAssertEqual(expected, actual, accuracy: within, message(), file: file, line: line)
@@ -74,7 +74,7 @@ public func expectEqual(
     _ expected: Any.Type,
     _ actual: Any.Type,
     _ message: @autoclosure () -> String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     XCTAssertTrue(expected == actual, message(), file: file, line: line)
@@ -102,13 +102,13 @@ public func expectEqualSequence< Expected: Sequence, Actual: Sequence>(
     }
 }
 
-func expectEqual(_ actual: Date, _ expected: Date , within: Double = 0.001, file: StaticString = #file, line: UInt = #line) {
+func expectEqual(_ actual: Date, _ expected: Date , within: Double = 0.001, file: StaticString = #filePath, line: UInt = #line) {
     let debugDescription = "\nactual: \(actual.formatted(.iso8601));\nexpected: \(expected.formatted(.iso8601))"
     XCTAssertEqual(actual.timeIntervalSinceReferenceDate, expected.timeIntervalSinceReferenceDate, accuracy: within, debugDescription, file: file, line: line)
 }
 
 // Compare two date components like the original equality, but compares nanosecond within a reasonable epsilon, and optionally ignores quarter and calendar equality since they were often not supported in the original implementation
-public func expectEqual(_ first: DateComponents, _ second: DateComponents, within nanosecondAccuracy: Int = 5000, expectQuarter: Bool = true, expectCalendar: Bool = true, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func expectEqual(_ first: DateComponents, _ second: DateComponents, within nanosecondAccuracy: Int = 5000, expectQuarter: Bool = true, expectCalendar: Bool = true, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(first.era, second.era, message(), file: file, line: line)
     XCTAssertEqual(first.year, second.year, message(), file: file, line: line)
     XCTAssertEqual(first.month, second.month, message(), file: file, line: line)
@@ -142,7 +142,7 @@ public func expectEqual(_ first: DateComponents, _ second: DateComponents, withi
 
 }
 
-func expectChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) rethrows {
+func expectChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, _ expression: () throws -> ()) rethrows {
     let valueBefore = check()
     try expression()
     let valueAfter = check()
@@ -153,7 +153,7 @@ func expectChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by differenc
     }
 }
 
-func expectNoChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) rethrows {
+func expectNoChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, _ expression: () throws -> ()) rethrows {
     let valueBefore = check()
     try expression()
     let valueAfter = check()
@@ -175,7 +175,7 @@ public func checkEquatable<Instances: Collection>(
     oracle: (Instances.Index, Instances.Index) -> Bool,
     allowBrokenTransitivity: Bool = false,
     _ message: @autoclosure () -> String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) where Instances.Element: Equatable {
     let indices = Array(instances.indices)
@@ -201,7 +201,7 @@ internal func _checkEquatableImpl<Instance : Equatable>(
     oracle: (Int, Int) -> Bool,
     allowBrokenTransitivity: Bool = false,
     _ message: @autoclosure () -> String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     // For each index (which corresponds to an instance being tested) track the
@@ -285,7 +285,7 @@ public func checkHashable<Instances: Collection>(
     equalityOracle: (Instances.Index, Instances.Index) -> Bool,
     allowIncompleteHashing: Bool = false,
     _ message: @autoclosure () -> String = "",
-    file: StaticString = #file, line: UInt = #line
+    file: StaticString = #filePath, line: UInt = #line
 ) where Instances.Element: Hashable {
     checkHashable(
         instances,
@@ -304,7 +304,7 @@ public func checkHashable<Instances: Collection>(
     hashEqualityOracle: (Instances.Index, Instances.Index) -> Bool,
     allowIncompleteHashing: Bool = false,
     _ message: @autoclosure () -> String = "",
-    file: StaticString = #file, line: UInt = #line
+    file: StaticString = #filePath, line: UInt = #line
 ) where Instances.Element: Hashable {
 
     checkEquatable(
@@ -394,7 +394,7 @@ public func checkHashableGroups<Groups: Collection>(
     _ groups: Groups,
     _ message: @autoclosure () -> String = "",
     allowIncompleteHashing: Bool = false,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) where Groups.Element: Collection, Groups.Element.Element: Hashable {
     let instances = groups.flatMap { $0 }

--- a/Sources/_CShims/include/platform_shims.h
+++ b/Sources/_CShims/include/platform_shims.h
@@ -36,6 +36,16 @@ INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ();
 INTERNAL void _platform_shims_lock_environ();
 INTERNAL void _platform_shims_unlock_environ();
 
+#if __has_include(<mach/vm_page_size.h>)
+#include <mach/vm_page_size.h>
+INTERNAL vm_size_t _platform_shims_vm_size();
+#endif
+
+#if __has_include(<mach/mach.h>)
+#include <mach/mach.h>
+INTERNAL mach_port_t _platform_mach_task_self();
+#endif
+
 #if __has_include(<libkern/OSThermalNotification.h>)
 typedef enum {
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST

--- a/Sources/_CShims/platform_shims.c
+++ b/Sources/_CShims/platform_shims.c
@@ -35,9 +35,7 @@ void _platform_shims_lock_environ() { /* noop */ }
 void _platform_shims_unlock_environ() { /* noop */ }
 #endif
 
-char **
-_platform_shims_get_environ()
-{
+char ** _platform_shims_get_environ() {
 #if __has_include(<crt_externs.h>)
     return *_NSGetEnviron();
 #elif defined(_WIN32)
@@ -50,10 +48,22 @@ _platform_shims_get_environ()
 }
 
 #if __has_include(<libkern/OSThermalNotification.h>)
-const char *
-_platform_shims_kOSThermalNotificationPressureLevelName()
-{
+const char * _platform_shims_kOSThermalNotificationPressureLevelName() {
     return kOSThermalNotificationPressureLevelName;
+}
+#endif
+
+#if __has_include(<mach/vm_page_size.h>)
+vm_size_t _platform_shims_vm_size() {
+    // This shim exists because vm_page_size is not marked const, and therefore looks like global mutable state to Swift.
+    return vm_page_size;
+}
+#endif
+
+#if __has_include(<mach/mach.h>)
+mach_port_t _platform_mach_task_self() {
+    // This shim exists because mach_task_self_ is not marked const, and therefore looks like global mutable state to Swift.
+    return mach_task_self();
 }
 #endif
 

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringCOWTests.swift
@@ -38,14 +38,14 @@ final class TestAttributedStringCOW: XCTestCase {
         return str
     }
     
-    func assertCOWCopy(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+    func assertCOWCopy(file: StaticString = #filePath, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
         let str = createAttributedString()
         var copy = str
         operation(&copy)
         XCTAssertNotEqual(str, copy, "Mutation operation did not copy when multiple references exist", file: file, line: line)
     }
     
-    func assertCOWNoCopy(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+    func assertCOWNoCopy(file: StaticString = #filePath, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
         var str = createAttributedString()
         let gutsPtr = Unmanaged.passUnretained(str._guts)
         operation(&str)
@@ -53,7 +53,7 @@ final class TestAttributedStringCOW: XCTestCase {
         XCTAssertEqual(gutsPtr.toOpaque(), newGutsPtr.toOpaque(), "Mutation operation copied when only one reference exists", file: file, line: line)
     }
     
-    func assertCOWBehavior(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+    func assertCOWBehavior(file: StaticString = #filePath, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
         assertCOWCopy(file: file, line: line, operation)
         assertCOWNoCopy(file: file, line: line, operation)
     }

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringConstrainingBehaviorTests.swift
@@ -20,8 +20,10 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         string: AttributedString,
         matches expected: [(String, K.Value?)],
         for key: KeyPath<AttributeDynamicLookup, K>,
-        file: StaticString = #file, line: UInt = #line
-    ) {
+        file: StaticString = #filePath, line: UInt = #line
+    ) 
+    where K.Value : Sendable
+    {
         let runs = string.runs[key]
         XCTAssertEqual(runs.count, expected.count, "Unexpected number of runs", file: file, line: line)
         for ((val, range), expectation) in zip(runs, expected) {
@@ -36,7 +38,9 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         }
     }
     
-    func verify<K: AttributedStringKey, K2: AttributedStringKey>(string: AttributedString, matches expected: [(String, K.Value?, K2.Value?)], for key: KeyPath<AttributeDynamicLookup, K>, _ key2: KeyPath<AttributeDynamicLookup, K2>, file: StaticString = #file, line: UInt = #line) {
+    func verify<K: AttributedStringKey, K2: AttributedStringKey>(string: AttributedString, matches expected: [(String, K.Value?, K2.Value?)], for key: KeyPath<AttributeDynamicLookup, K>, _ key2: KeyPath<AttributeDynamicLookup, K2>, file: StaticString = #filePath, line: UInt = #line) 
+    where K.Value : Sendable, K2.Value : Sendable
+    {
         let runs = string.runs[key, key2]
         XCTAssertEqual(runs.count, expected.count, "Unexpected number of runs", file: file, line: line)
         for ((val1, val2, range), expectation) in zip(runs, expected) {
@@ -51,7 +55,9 @@ class TestAttributedStringConstrainingBehavior: XCTestCase {
         }
     }
     
-    func verify<K: AttributedStringKey, K2: AttributedStringKey, K3: AttributedStringKey>(string: AttributedString, matches expected: [(String, K.Value?, K2.Value?, K3.Value?)], for key: KeyPath<AttributeDynamicLookup, K>, _ key2: KeyPath<AttributeDynamicLookup, K2>, _ key3: KeyPath<AttributeDynamicLookup, K3>, file: StaticString = #file, line: UInt = #line) {
+    func verify<K: AttributedStringKey, K2: AttributedStringKey, K3: AttributedStringKey>(string: AttributedString, matches expected: [(String, K.Value?, K2.Value?, K3.Value?)], for key: KeyPath<AttributeDynamicLookup, K>, _ key2: KeyPath<AttributeDynamicLookup, K2>, _ key3: KeyPath<AttributeDynamicLookup, K3>, file: StaticString = #filePath, line: UInt = #line) 
+    where K.Value : Sendable, K2.Value : Sendable, K3.Value : Sendable
+    {
         let runs = string.runs[key, key2, key3]
         XCTAssertEqual(runs.count, expected.count, "Unexpected number of runs", file: file, line: line)
         for ((val1, val2, val3, range), expectation) in zip(runs, expected) {

--- a/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
+++ b/Tests/FoundationEssentialsTests/AttributedString/AttributedStringTests.swift
@@ -45,7 +45,7 @@ final class TestAttributedString: XCTestCase {
         }
     }
 
-    func verifyAttributes<T>(_ runs: AttributedString.Runs.AttributesSlice1<T>, string: AttributedString, expectation: [(String, T.Value?)]) {
+    func verifyAttributes<T>(_ runs: AttributedString.Runs.AttributesSlice1<T>, string: AttributedString, expectation: [(String, T.Value?)]) where T.Value : Sendable {
         // Test that the attribute is correct when iterating through attribute runs
         var expectIterator = expectation.makeIterator()
         for (attribute, range) in runs {
@@ -65,7 +65,7 @@ final class TestAttributedString: XCTestCase {
         XCTAssertNil(expectIterator.next(), "Additional runs expected but not found")
     }
 
-    func verifyAttributes<T, U>(_ runs: AttributedString.Runs.AttributesSlice2<T, U>, string: AttributedString, expectation: [(String, T.Value?, U.Value?)]) {
+    func verifyAttributes<T, U>(_ runs: AttributedString.Runs.AttributesSlice2<T, U>, string: AttributedString, expectation: [(String, T.Value?, U.Value?)]) where T.Value : Sendable, U.Value : Sendable {
         // Test that the attributes are correct when iterating through attribute runs
         var expectIterator = expectation.makeIterator()
         for (attribute, attribute2, range) in runs {
@@ -88,7 +88,7 @@ final class TestAttributedString: XCTestCase {
     }
     
 #if FOUNDATION_FRAMEWORK
-    func verifyAttributes(_ runs: AttributedString.Runs.NSAttributesSlice, string: AttributedString, expectation: [(String, AttributeContainer)], file: StaticString = #file, line: UInt = #line) {
+    func verifyAttributes(_ runs: AttributedString.Runs.NSAttributesSlice, string: AttributedString, expectation: [(String, AttributeContainer)], file: StaticString = #filePath, line: UInt = #line) {
         // Test that the attribute is correct when iterating through attribute runs
         var expectIterator = expectation.makeIterator()
         for (attribute, range) in runs {
@@ -1213,7 +1213,7 @@ E {
     func testCodingErrorsPropagateUpToCallSite() {
         enum CustomAttribute : CodableAttributedStringKey {
             typealias Value = String
-            static var name = "CustomAttribute"
+            static let name = "CustomAttribute"
             
             static func encode(_ value: Value, to encoder: Encoder) throws {
                 throw TestError.encodingError
@@ -1243,7 +1243,7 @@ E {
     func testEncodeWithPartiallyCodableScope() throws {
         enum NonCodableAttribute : AttributedStringKey {
             typealias Value = Int
-            static var name = "NonCodableAttributes"
+            static let name = "NonCodableAttributes"
         }
         struct PartialCodableScope : AttributeScope {
             var codableAttr : AttributeScopes.TestAttributes.TestIntAttribute
@@ -1637,7 +1637,7 @@ E {
                 var subValue: String
             }
             typealias ObjectiveCValue = NSString
-            static var name = "Convertible"
+            static let name = "Convertible"
             
             static func objectiveCValue(for value: Value) throws -> NSString {
                 return value.subValue as NSString
@@ -1689,7 +1689,7 @@ E {
         
         // Ensure attributes that throw are dropped
         enum Attribute : ObjectiveCConvertibleAttributedStringKey {
-            static var name = "TestAttribute"
+            static let name = "TestAttribute"
             typealias Value = Int
             typealias ObjectiveCValue = NSString
             

--- a/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTest.swift
+++ b/Tests/FoundationEssentialsTests/BuiltInUnicodeScalarSetTest.swift
@@ -23,7 +23,7 @@ import TestSupport
 final class BuiltInUnicodeScalarSetTest: XCTestCase {
 
     func testMembership() {
-        func setContainsScalar(_ set: BuiltInUnicodeScalarSet, _ scalar: Unicode.Scalar, _ expect: Bool, file: StaticString = #file, line: UInt = #line) {
+        func setContainsScalar(_ set: BuiltInUnicodeScalarSet, _ scalar: Unicode.Scalar, _ expect: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let actual = set.contains(scalar)
             XCTAssertEqual(actual, expect, file: file, line: line)
         }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -603,7 +603,7 @@ class DataTests : XCTestCase {
             func assertFirstRange(_ data: Data, _ fragment: Data, range: ClosedRange<Int>? = nil,
                                   expectedStartIndex: Int?,
                                   _ message: @autoclosure () -> String = "",
-                                  file: StaticString = #file, line: UInt = #line) {
+                                  file: StaticString = #filePath, line: UInt = #line) {
                 if let index = expectedStartIndex {
                     let expectedRange: Range<Int> = index..<(index + fragment.count)
                     if let someRange = range {
@@ -645,7 +645,7 @@ class DataTests : XCTestCase {
             func assertLastRange(_ data: Data, _ fragment: Data, range: ClosedRange<Int>? = nil,
                                  expectedStartIndex: Int?,
                                  _ message: @autoclosure () -> String = "",
-                                 file: StaticString = #file, line: UInt = #line) {
+                                 file: StaticString = #filePath, line: UInt = #line) {
                 if let index = expectedStartIndex {
                     let expectedRange: Range<Int> = index..<(index + fragment.count)
                     if let someRange = range {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerPlayground.swift
@@ -100,7 +100,7 @@ struct FileManagerPlayground {
         self.directory = Directory("FileManagerPlayground_\(UUID().uuidString)", contentsClosure)
     }
     
-    func test(captureDelegateCalls: Bool = false, file: StaticString = #file, line: UInt = #line, _ tester: (FileManager) throws -> Void) throws {
+    func test(captureDelegateCalls: Bool = false, file: StaticString = #filePath, line: UInt = #line, _ tester: (FileManager) throws -> Void) throws {
         let capturingDelegate = CapturingFileManagerDelegate()
         try withExtendedLifetime(capturingDelegate) {
             let fileManager = FileManager()

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -226,22 +226,22 @@ final class BinaryIntegerFormatStyleTestsUsingBinaryIntegerWords: XCTestCase {
     
     // MARK: Assertions
     
-    func check(_ integer: some BinaryInteger, expectation: String, file: StaticString = #file, line: UInt = #line) {
+    func check(_ integer: some BinaryInteger, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(integer.description, expectation, "integer description does not match expectation", file: file, line: line)
         check(ascii: integer.numericStringRepresentation.utf8, expectation: expectation, file: file, line: line)
         check(words: Array(integer.words), isSigned: type(of: integer).isSigned, expectation: expectation, file: file, line: line)
     }
     
-    func check(x64: [UInt64], isSigned: Bool, expectation: String, file: StaticString = #file, line: UInt = #line) {
+    func check(x64: [UInt64], isSigned: Bool, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
         check(words: x64.flatMap(\.words), isSigned: isSigned, expectation: expectation, file: file, line: line)
     }
     
-    func check(words: [UInt], isSigned: Bool, expectation: String, file: StaticString = #file, line: UInt = #line) {
+    func check(words: [UInt], isSigned: Bool, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
         let ascii =  numericStringRepresentationForBinaryInteger(words: words, isSigned: isSigned).utf8
         check(ascii: ascii, expectation: expectation, file: file, line: line)
     }
     
-    func check(ascii: some Collection<UInt8>, expectation: String, file: StaticString = #file, line: UInt = #line) {
+    func check(ascii: some Collection<UInt8>, expectation: String, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(String(decoding: ascii, as: Unicode.ASCII.self), expectation, file: file, line: line)
     }
 }

--- a/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/ISO8601FormatStyleParsingTests.swift
@@ -188,11 +188,11 @@ result  : \(parsed != nil ? parsed!.debugDescription : "nil") \(parsed != nil ? 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
 
-    func _matchFullRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #file, line: UInt = #line) {
+    func _matchFullRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
         _matchRange(str, formatStyle: formatStyle, range: nil, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, file: file, line: line)
     }
 
-    func _matchRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #file, line: UInt = #line) {
+    func _matchRange(_ str: String, formatStyle: Date.ISO8601FormatStyle, range: Range<String.Index>?, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
         // FIXME: Need tests that starts from somewhere else
         let m = try? formatStyle.consuming(str, startingAt: str.startIndex, in: range ?? str.startIndex..<str.endIndex)
         let upperBound = m?.upperBound
@@ -215,7 +215,7 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
     func testMatchDefaultISO8601Style() throws {
 
         let iso8601FormatStyle = Date.ISO8601FormatStyle()
-        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ str: String, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
             _matchFullRange(str, formatStyle: iso8601FormatStyle, expectedUpperBound: expectedUpperBound, expectedDate: expectedDate, file: file, line: line)
         }
 
@@ -233,7 +233,7 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
     func testPartialMatchISO8601() throws {
         var expectedDate: Date?
         var expectedLength: Int?
-        func verify(_ str: String, _ style: Date.ISO8601FormatStyle,  file: StaticString = #file, line: UInt = #line) {
+        func verify(_ str: String, _ style: Date.ISO8601FormatStyle,  file: StaticString = #filePath, line: UInt = #line) {
             let expectedUpperBoundStrIndx = (expectedLength != nil) ? str.index(str.startIndex, offsetBy: expectedLength!) : nil
             _matchFullRange(str, formatStyle: style, expectedUpperBound: expectedUpperBoundStrIndx, expectedDate: expectedDate, file: file, line: line)
         }
@@ -305,7 +305,7 @@ final class DateISO8601FormatStylePatternMatchingTests : XCTestCase {
     func testFullMatch() {
 
         var expectedDate: Date
-        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ str: String, _ style: Date.ISO8601FormatStyle, file: StaticString = #filePath, line: UInt = #line) {
             _matchFullRange(str, formatStyle: style, expectedUpperBound: str.endIndex, expectedDate: expectedDate, file: file, line: line)
         }
 

--- a/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
+++ b/Tests/FoundationEssentialsTests/GregorianCalendarTests.swift
@@ -75,7 +75,7 @@ final class GregorianCalendarTests : XCTestCase {
 
         let tz = TimeZone(identifier: "America/Los_Angeles")!
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: tz, locale: nil, firstWeekday: nil, minimumDaysInFirstWeek: nil, gregorianStartDate: nil)
-        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #file, line: UInt = #line) {
+        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #filePath, line: UInt = #line) {
             let date = gregorianCalendar.date(from: dateComponents)!
             XCTAssertEqual(date, expected, "DateComponents: \(dateComponents)", file: file, line: line)
         }
@@ -98,7 +98,7 @@ final class GregorianCalendarTests : XCTestCase {
         // The expected dates were generated using ICU Calendar
         let tz = TimeZone.gmt
         let cal = _CalendarGregorian(identifier: .gregorian, timeZone: tz, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
-        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #file, line: UInt = #line) {
+        func test(_ dateComponents: DateComponents, expected: Date, file: StaticString = #filePath, line: UInt = #line) {
             let date = cal.date(from: dateComponents)
             XCTAssertEqual(date, expected, "date components: \(dateComponents)", file: file, line: line)
         }
@@ -223,7 +223,7 @@ final class GregorianCalendarTests : XCTestCase {
     // MARK: - DateComponents from date
     func testDateComponentsFromDate() {
         let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: 0)!, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
-        func test(_ date: Date, _ timeZone: TimeZone, expectedEra era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int, weekday: Int, weekdayOrdinal: Int, quarter: Int, weekOfMonth: Int, weekOfYear: Int, yearForWeekOfYear: Int, isLeapMonth: Bool, file: StaticString = #file, line: UInt = #line) {
+        func test(_ date: Date, _ timeZone: TimeZone, expectedEra era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int, weekday: Int, weekdayOrdinal: Int, quarter: Int, weekOfMonth: Int, weekOfYear: Int, yearForWeekOfYear: Int, isLeapMonth: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let dc = calendar.dateComponents([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .calendar, .timeZone], from: date)
             XCTAssertEqual(dc.era, era, file: file, line: line)
             XCTAssertEqual(dc.year, year, file: file, line: line)
@@ -251,7 +251,7 @@ final class GregorianCalendarTests : XCTestCase {
 
     func testDateComponentsFromDate_DST() {
 
-        func test(_ date: Date, expectedEra era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int, weekday: Int, weekdayOrdinal: Int, quarter: Int, weekOfMonth: Int, weekOfYear: Int, yearForWeekOfYear: Int, isLeapMonth: Bool, file: StaticString = #file, line: UInt = #line) {
+        func test(_ date: Date, expectedEra era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int, weekday: Int, weekdayOrdinal: Int, quarter: Int, weekOfMonth: Int, weekOfYear: Int, yearForWeekOfYear: Int, isLeapMonth: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let dc = calendar.dateComponents([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .calendar, .timeZone], from: date)
             XCTAssertEqual(dc.era, era, "era should be equal", file: file, line: line)
             XCTAssertEqual(dc.year, year, "era should be equal", file: file, line: line)
@@ -289,7 +289,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testAdd() {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: 3600)!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
         var date: Date
-        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, wrap: Bool, expectedDate: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, wrap: Bool, expectedDate: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let components = DateComponents(component: field, value: value)!
             let result = gregorianCalendar.date(byAdding: components, to: addingToDate, wrappingComponents: wrap)!
             XCTAssertEqual(result, expectedDate, file: file, line: line)
@@ -411,7 +411,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testAdd_boundaries() {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: 3600)!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
         var date: Date
-        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, wrap: Bool, expectedDate: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, wrap: Bool, expectedDate: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let components = DateComponents(component: field, value: value)!
             let result = gregorianCalendar.date(byAdding: components, to: addingToDate, wrappingComponents: wrap)!
             XCTAssertEqual(result, expectedDate, file: file, line: line)
@@ -531,7 +531,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testAddDateComponents() {
 
         let s = Date.ISO8601FormatStyle(timeZone: TimeZone(secondsFromGMT: 3600)!)
-        func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: wrap)!
             XCTAssertEqual(result, expected, "actual = \(result.timeIntervalSince1970), \(s.format(result))", file: file, line: line)
         }
@@ -626,7 +626,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testAddDateComponents_DST() {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 2, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
 
-        func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func testAdding(_ comp: DateComponents, to date: Date, wrap: Bool, expected: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: wrap)!
             XCTAssertEqual(result, expected, "result = \(result.timeIntervalSince1970)" , file: file, line: line)
         }
@@ -660,7 +660,7 @@ final class GregorianCalendarTests : XCTestCase {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
 
         let fmt = Date.ISO8601FormatStyle(timeZone: gregorianCalendar.timeZone)
-        func testAdding(_ comp: DateComponents, to date: Date, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func testAdding(_ comp: DateComponents, to date: Date, expected: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: false)!
             XCTAssertEqual(result, expected, "result: \(fmt.format(result)); expected: \(fmt.format(expected))", file: file, line: line)
         }
@@ -1351,7 +1351,7 @@ final class GregorianCalendarTests : XCTestCase {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
 
         let fmt = Date.ISO8601FormatStyle(timeZone: gregorianCalendar.timeZone)
-        func testAdding(_ comp: DateComponents, to date: Date, expected: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func testAdding(_ comp: DateComponents, to date: Date, expected: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let result = gregorianCalendar.date(byAdding: comp, to: date, wrappingComponents: true)!
             XCTAssertEqual(result, expected, "result: \(fmt.format(result)); expected: \(fmt.format(expected))", file: file, line: line)
         }
@@ -1915,7 +1915,7 @@ final class GregorianCalendarTests : XCTestCase {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
 
         let fmt = Date.ISO8601FormatStyle(timeZone: gregorianCalendar.timeZone)
-        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, expectedDate: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, expectedDate: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let components = DateComponents(component: field, value: value)!
             let result = gregorianCalendar.date(byAdding: components, to: addingToDate, wrappingComponents: false)!
             let actualDiff = result.timeIntervalSince(addingToDate)
@@ -2247,7 +2247,7 @@ final class GregorianCalendarTests : XCTestCase {
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
 
         let fmt = Date.ISO8601FormatStyle(timeZone: gregorianCalendar.timeZone)
-        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, expectedDate: Date, _ file: StaticString = #file, _ line: UInt = #line) {
+        func test(addField field: Calendar.Component, value: Int, to addingToDate: Date, expectedDate: Date, _ file: StaticString = #filePath, _ line: UInt = #line) {
             let components = DateComponents(component: field, value: value)!
             let result = gregorianCalendar.date(byAdding: components, to: addingToDate, wrappingComponents: true)!
             let msg = "actual = \(fmt.format(result)), expected = \(fmt.format(expectedDate))"
@@ -2431,7 +2431,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testOrdinality() {
         let cal = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: 3600)!, locale: nil, firstWeekday: 5, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
 
-        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Int?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
             let result = cal.ordinality(of: small, in: large, for: date)
             XCTAssertEqual(result, expected,  "small: \(small), large: \(large)", file: file, line: line)
         }
@@ -2547,7 +2547,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testOrdinality_DST() {
         let cal = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 5, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
 
-        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Int?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
             let result = cal.ordinality(of: small, in: large, for: date)
             XCTAssertEqual(result, expected,  "small: \(small), large: \(large)", file: file, line: line)
         }
@@ -2831,7 +2831,7 @@ final class GregorianCalendarTests : XCTestCase {
         let minimumDaysInFirstWeek = 4
         let timeZone = TimeZone(secondsFromGMT: -3600 * 8)!
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: timeZone, locale: nil, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: nil)
-        func test(_ unit: Calendar.Component, at date: Date, expected: Date, file: StaticString = #file, line: UInt = #line) {
+        func test(_ unit: Calendar.Component, at date: Date, expected: Date, file: StaticString = #filePath, line: UInt = #line) {
             let new = gregorianCalendar.start(of: unit, at: date)!
             XCTAssertEqual(new, expected, file: file, line: line)
         }
@@ -2864,7 +2864,7 @@ final class GregorianCalendarTests : XCTestCase {
         let minimumDaysInFirstWeek = 4
         let timeZone = TimeZone(identifier: "America/Los_Angeles")!
         let gregorianCalendar = _CalendarGregorian(identifier: .gregorian, timeZone: timeZone, locale: nil, firstWeekday: firstWeekday, minimumDaysInFirstWeek: minimumDaysInFirstWeek, gregorianStartDate: nil)
-        func test(_ unit: Calendar.Component, at date: Date, expected: Date, file: StaticString = #file, line: UInt = #line) {
+        func test(_ unit: Calendar.Component, at date: Date, expected: Date, file: StaticString = #filePath, line: UInt = #line) {
             let new = gregorianCalendar.start(of: unit, at: date)!
             XCTAssertEqual(new, expected, file: file, line: line)
         }
@@ -3040,7 +3040,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testDateInterval() {
         let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -28800)!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
 
-        func test(_ c: Calendar.Component, _ date: Date, expectedStart start: Date?, end: Date?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ c: Calendar.Component, _ date: Date, expectedStart start: Date?, end: Date?, file: StaticString = #filePath, line: UInt = #line) {
             let new = calendar.dateInterval(of: c, for: date)
             let new_start = new?.start
             let new_end = new?.end
@@ -3100,7 +3100,7 @@ final class GregorianCalendarTests : XCTestCase {
 
     func testDateInterval_DST() {
         let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(identifier: "America/Los_Angeles")!, locale: nil, firstWeekday: 3, minimumDaysInFirstWeek: 5, gregorianStartDate: nil)
-        func test(_ c: Calendar.Component, _ date: Date, expectedStart start: Date, end: Date, file: StaticString = #file, line: UInt = #line) {
+        func test(_ c: Calendar.Component, _ date: Date, expectedStart start: Date, end: Date, file: StaticString = #filePath, line: UInt = #line) {
             let new = calendar.dateInterval(of: c, for: date)!
             let new_start = new.start
             let new_end = new.end
@@ -3286,7 +3286,7 @@ final class GregorianCalendarTests : XCTestCase {
     func testRangeOf() {
         let calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -28800)!, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
 
-        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ small: Calendar.Component, in large: Calendar.Component, for date: Date, expected: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
             let new = calendar.range(of: small, in: large, for: date)
             XCTAssertEqual(new, expected, file: file, line: line)
         }
@@ -3455,7 +3455,7 @@ final class GregorianCalendarTests : XCTestCase {
         var calendar = _CalendarGregorian(identifier: .gregorian, timeZone: .gmt, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
         var start: Date!
         var end: Date!
-        func test(_ components: Calendar.ComponentSet, expected: DateComponents, file: StaticString = #file, line: UInt = #line) {
+        func test(_ components: Calendar.ComponentSet, expected: DateComponents, file: StaticString = #filePath, line: UInt = #line) {
             let actual = calendar.dateComponents(components, from: start, to: end)
             XCTAssertEqual(actual, expected, file: file, line: line)
         }
@@ -3576,7 +3576,7 @@ final class GregorianCalendarTests : XCTestCase {
         var calendar = _CalendarGregorian(identifier: .gregorian, timeZone: TimeZone(secondsFromGMT: -28800)!, locale: nil, firstWeekday: 1, minimumDaysInFirstWeek: 4, gregorianStartDate: nil)
         var start: Date!
         var end: Date!
-        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #file, line: UInt = #line) {
+        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #filePath, line: UInt = #line) {
             let (actualDiff, _) = try! calendar.difference(inComponent: component, from: start, to: end)
             XCTAssertEqual(actualDiff, expected, file: file, line: line)
         }
@@ -3821,7 +3821,7 @@ final class GregorianCalendarTests : XCTestCase {
 
         var start: Date!
         var end: Date!
-        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #file, line: UInt = #line) {
+        func test(_ component: Calendar.Component, expected: Int, file: StaticString = #filePath, line: UInt = #line) {
             let (actualDiff, _) = try! calendar.difference(inComponent: component, from: start, to: end)
             XCTAssertEqual(actualDiff, expected, file: file, line: line)
         }

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -70,7 +70,7 @@ final class PredicateCodableTests: XCTestCase {
         var g: [Int]
         var h: Object2
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object>] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object> & Sendable] {
             [
                 "Object.f" : \.f,
                 "Object.g" : \.g,
@@ -85,7 +85,7 @@ final class PredicateCodableTests: XCTestCase {
         var a: Int
         var b: String
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2>] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2> & Sendable] {
             ["Object2.a" : \.a]
         }
     }
@@ -345,7 +345,7 @@ final class PredicateCodableTests: XCTestCase {
     }
     
     func testMalformedData() {
-        func _malformedDecode<T: PredicateCodingConfigurationProviding>(_ json: String, config: T.Type = StandardConfig.self, reason: String, file: StaticString = #file, line: UInt = #line) {
+        func _malformedDecode<T: PredicateCodingConfigurationProviding>(_ json: String, config: T.Type = StandardConfig.self, reason: String, file: StaticString = #filePath, line: UInt = #line) {
             let data = Data(json.utf8)
             let decoder = JSONDecoder()
             XCTAssertThrowsError(try decoder.decode(CodableConfiguration<Predicate<Object>, T>.self, from: data), file: file, line: line) {

--- a/Tests/FoundationEssentialsTests/PredicateTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateTests.swift
@@ -25,6 +25,9 @@ import RegexBuilder
 macro Predicate<each Input>(_ body: (repeat each Input) -> Bool) -> Predicate<repeat each Input> = #externalMacro(module: "FoundationMacros", type: "PredicateMacro")
 #endif
 
+// Work around an issue issue on older Swift compilers
+#if compiler(>=6.0)
+
 final class PredicateTests: XCTestCase {
     
     override func setUp() async throws {
@@ -251,11 +254,8 @@ final class PredicateTests: XCTestCase {
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
     func testLazyDefaultValueSubscript() throws {
         struct Foo : Codable, Sendable {
-            static var num = 1
-            
             var property: Int {
-                defer { Foo.num += 1 }
-                return Foo.num
+                fatalError("This property should not have been accessed")
             }
         }
         
@@ -264,7 +264,6 @@ final class PredicateTests: XCTestCase {
             $0["key", default: foo.property] == 1
         }
         XCTAssertFalse(try predicate.evaluate(["key" : 2]))
-        XCTAssertEqual(Foo.num, 1)
     }
     
     @available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
@@ -466,3 +465,5 @@ final class PredicateTests: XCTestCase {
         }
     }
 }
+
+#endif // compiler(>=6.0)

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -24,7 +24,7 @@ final class StringTests : XCTestCase {
     // MARK: - Case mapping
 
     func testCapitalize() {
-        func test(_ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ string: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(string._capitalized(), expected, file: file, line: line)
         }
 
@@ -64,7 +64,7 @@ final class StringTests : XCTestCase {
     }
 
     func testTrimmingWhitespace() {
-        func test(_ str: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ str: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(str._trimmingWhitespace(), expected, file: file, line: line)
         }
         test(" \tABCDEFGAbc \t \t  ", "ABCDEFGAbc")
@@ -80,7 +80,7 @@ final class StringTests : XCTestCase {
     }
 
     func testTrimmingCharactersWithPredicate() {
-        func test(_ str: String, while predicate: (Character) -> Bool, _ expected: Substring, file: StaticString = #file, line: UInt = #line) {
+        func test(_ str: String, while predicate: (Character) -> Bool, _ expected: Substring, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(str._trimmingCharacters(while: predicate), expected, file: file, line: line)
         }
 
@@ -136,7 +136,7 @@ final class StringTests : XCTestCase {
         test("11 B\u{0662}\u{0661}", while: alwaysTrim, "")
     }
 
-    func _testRangeOfString(_ tested: String, string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+    func _testRangeOfString(_ tested: String, string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
         let result = tested._range(of: string, anchored: anchored, backwards: backwards)
         var exp: Range<String.Index>?
         if let expectation {
@@ -157,7 +157,7 @@ final class StringTests : XCTestCase {
 
     func testRangeOfString() {
         var tested: String
-        func testASCII(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+        func testASCII(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
             return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
         }
 
@@ -207,7 +207,7 @@ final class StringTests : XCTestCase {
 
     func testRangeOfString_graphemeCluster() {
         var tested: String
-        func test(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
             return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
         }
 
@@ -241,7 +241,7 @@ final class StringTests : XCTestCase {
     }
 
     func testRangeOfString_lineSeparator() {
-        func test(_ tested: String, _ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ tested: String, _ string: String, anchored: Bool, backwards: Bool, _ expectation: Range<Int>?, file: StaticString = #filePath, line: UInt = #line) {
             return _testRangeOfString(tested, string: string, anchored: anchored, backwards: backwards, expectation, file: file, line: line)
         }
         test("\r\n \r", "\r", anchored: false, backwards: false, 2..<3)
@@ -256,7 +256,7 @@ final class StringTests : XCTestCase {
     }
 
     func testTryFromUTF16() {
-        func test(_ utf16Buffer: [UInt16], expected: String?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ utf16Buffer: [UInt16], expected: String?, file: StaticString = #filePath, line: UInt = #line) {
             let result = utf16Buffer.withUnsafeBufferPointer {
                 String(_utf16: $0)
             }
@@ -285,7 +285,7 @@ final class StringTests : XCTestCase {
 
     func testTryFromUTF16_roundtrip() {
 
-        func test(_ string: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ string: String, file: StaticString = #filePath, line: UInt = #line) {
             let utf16Array = Array(string.utf16)
             let res = utf16Array.withUnsafeBufferPointer {
                 String(_utf16: $0)
@@ -335,7 +335,7 @@ final class StringTests : XCTestCase {
     }
     
     func testFileSystemRepresentation() {
-        func assertCString(_ ptr: UnsafePointer<CChar>, equals other: String, file: StaticString = #file, line: UInt = #line) {
+        func assertCString(_ ptr: UnsafePointer<CChar>, equals other: String, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(String(cString: ptr), other, file: file, line: line)
         }
         

--- a/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
+++ b/Tests/FoundationInternationalizationTests/DurationExtensionTests.swift
@@ -27,7 +27,7 @@ final class DurationExtensionTests : XCTestCase {
 
     func testRoundingMode() {
 
-        func verify(_ tests: [Int64], increment: Int64, expected: [FloatingPointRoundingRule: [Int64]], file: StaticString = #file, line: UInt = #line) {
+        func verify(_ tests: [Int64], increment: Int64, expected: [FloatingPointRoundingRule: [Int64]], file: StaticString = #filePath, line: UInt = #line) {
             let modes: [FloatingPointRoundingRule] = [.down, .up, .towardZero, .awayFromZero, .toNearestOrEven, .toNearestOrAwayFromZero]
             for mode in modes {
                 var actual: [Duration] = []

--- a/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateFormatStyleTests.swift
@@ -329,7 +329,7 @@ final class DateFormatStyleTests : XCTestCase {
         let date = Date(timeIntervalSince1970: 0)
         let enUS = "en_US"
 
-        func test(dateStyle: Date.FormatStyle.DateStyle, timeStyle: Date.FormatStyle.TimeStyle, dateFormatOverride: [Date.FormatStyle.DateStyle: String], expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(dateStyle: Date.FormatStyle.DateStyle, timeStyle: Date.FormatStyle.TimeStyle, dateFormatOverride: [Date.FormatStyle.DateStyle: String], expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let locale = Locale.localeAsIfCurrent(name: enUS, overrides: .init(dateFormats: dateFormatOverride))
             let style = Date.FormatStyle(date: dateStyle, time: timeStyle, locale: locale, calendar: Calendar(identifier: .gregorian), timeZone: TimeZone(identifier: "PST")!, capitalizationContext: .standalone)
             let formatted = style.format(date)
@@ -418,7 +418,7 @@ final class DateFormatStyleTests : XCTestCase {
 
         var locale: Locale
         var format: Date.FormatStyle
-        func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let fmt = format.locale(locale)
             let formatted = fmt.format(date)
             XCTAssertEqualIgnoreSeparator(formatted, expected, file: file, line: line)
@@ -586,7 +586,7 @@ final class DateFormatStyleTests : XCTestCase {
     @available(FoundationPreview 0.4, *)
     func testRemovingFields() {
         var format: Date.FormatStyle = .init(calendar: .init(identifier: .gregorian), timeZone: .gmt).locale(Locale(identifier: "en_US"))
-        func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func verifyWithFormat(_ date: Date, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let formatted = format.format(date)
             XCTAssertEqualIgnoreSeparator(formatted, expected, file: file, line: line)
         }
@@ -692,7 +692,7 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         let date = Date(timeIntervalSinceReferenceDate: 639932672.0)
         let zhTW = Locale(identifier: "zh_TW")
 
-        func test(_ attributedResult: AttributedString, _ expected: [Segment], file: StaticString = #file, line: UInt = #line) {
+        func test(_ attributedResult: AttributedString, _ expected: [Segment], file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(attributedResult, expected.attributedString, file: file, line: line)
         }
 
@@ -711,7 +711,7 @@ final class DateAttributedFormatStyleTests : XCTestCase {
         let date = Date(timeIntervalSince1970: 0)
         let enUS = "en_US"
 
-        func test(dateStyle: Date.FormatStyle.DateStyle, timeStyle: Date.FormatStyle.TimeStyle, dateFormatOverride: [Date.FormatStyle.DateStyle: String], expected: [Segment], file: StaticString = #file, line: UInt = #line) {
+        func test(dateStyle: Date.FormatStyle.DateStyle, timeStyle: Date.FormatStyle.TimeStyle, dateFormatOverride: [Date.FormatStyle.DateStyle: String], expected: [Segment], file: StaticString = #filePath, line: UInt = #line) {
             let locale = Locale.localeAsIfCurrent(name: enUS, overrides: .init(dateFormats: dateFormatOverride))
             let style = Date.FormatStyle(date: dateStyle, time: timeStyle, locale: locale, calendar: Calendar(identifier: .gregorian), timeZone: TimeZone(identifier: "PST")!, capitalizationContext: .standalone).attributed
             XCTAssertEqualIgnoreSeparator(style.format(date), expected.attributedString, file: file, line: line)
@@ -872,7 +872,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
         // dateFormatter.date(from: "2021-01-23 14:51:20")!
         let date = Date(timeIntervalSinceReferenceDate: 633106280.0)
 
-        func verify(_ f: Date.FormatString, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ f: Date.FormatString, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let s = date.formatted(Date.VerbatimFormatStyle.verbatim(f, timeZone: utcTimeZone, calendar: Calendar(identifier: .gregorian)))
             XCTAssertEqual(s, expected, file: file, line: line)
         }
@@ -893,7 +893,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
     func testParseable() throws {
         // dateFormatter.date(from: "2021-01-23 14:51:20")!
         let date = Date(timeIntervalSinceReferenceDate: 633106280.0)
-        func verify(_ f: Date.FormatString, expectedString: String, expectedDate: Date, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ f: Date.FormatString, expectedString: String, expectedDate: Date, file: StaticString = #filePath, line: UInt = #line) {
             let style = Date.VerbatimFormatStyle.verbatim(f, timeZone: utcTimeZone, calendar: Calendar(identifier: .gregorian))
             let s = date.formatted(style)
             XCTAssertEqual(s, expectedString)
@@ -915,7 +915,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
 
         // dateFormatter.date(from: "1970-01-01 00:00:00")!
         let date = Date(timeIntervalSinceReferenceDate: -978307200.0)
-        func verify(_ f: Date.FormatString, localeID: String, calendarID: Calendar.Identifier, expectedString: String, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ f: Date.FormatString, localeID: String, calendarID: Calendar.Identifier, expectedString: String, file: StaticString = #filePath, line: UInt = #line) {
             let style = Date.VerbatimFormatStyle.verbatim(f, locale: Locale(identifier: localeID), timeZone: .gmt, calendar: Calendar(identifier: calendarID))
 
             let s = date.formatted(style)
@@ -977,7 +977,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
     func testAttributedString() throws {
         // dateFormatter.date(from: "2021-01-23 14:51:20")!
         let date = Date(timeIntervalSinceReferenceDate: 633106280.0)
-        func verify(_ f: Date.FormatString, expected: [Segment], file: StaticString = #file, line: UInt = #line) {
+        func verify(_ f: Date.FormatString, expected: [Segment], file: StaticString = #filePath, line: UInt = #line) {
             let s = date.formatted(Date.VerbatimFormatStyle.verbatim(f, locale:Locale(identifier: "en_US"), timeZone: utcTimeZone, calendar: Calendar(identifier: .gregorian)).attributed)
             XCTAssertEqual(s, expected.attributedString, file: file, line: line)
         }
@@ -1009,7 +1009,7 @@ final class DateVerbatimFormatStyleTests : XCTestCase {
         let gregorian = Calendar(identifier: .gregorian)
         let enUS = Locale(identifier: "en_US")
 
-        func _verify(_ f: Date.FormatString, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func _verify(_ f: Date.FormatString, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let s = date.formatted(Date.VerbatimFormatStyle.verbatim(f, locale: enUS, timeZone: utcTimeZone, calendar: gregorian))
             XCTAssertEqual(s, expected, file: file, line: line)
         }
@@ -1073,14 +1073,14 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
     let utcTimeZone = TimeZone(identifier: "UTC")!
     let gregorian = Calendar(identifier: .gregorian)
 
-    func _verifyUTF16String(_ string: String, matches format: Date.FormatString, in range: Range<Int>, expectedUpperBound: Int?, expectedDate: Date?, file: StaticString = #file, line: UInt = #line) {
+    func _verifyUTF16String(_ string: String, matches format: Date.FormatString, in range: Range<Int>, expectedUpperBound: Int?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
         let lower = string.index(string.startIndex, offsetBy: range.lowerBound)
         let upper = string.index(string.startIndex, offsetBy: range.upperBound)
 
         _verifyString(string, matches: format, start: lower, in: lower..<upper, expectedUpperBound: (expectedUpperBound != nil) ? string.index(string.startIndex, offsetBy: expectedUpperBound!) : nil, expectedDate: expectedDate, file: file, line: line)
     }
 
-    func _verifyString(_ string: String, matches format: Date.FormatString, start: String.Index, in range: Range<String.Index>, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #file, line: UInt = #line) {
+    func _verifyString(_ string: String, matches format: Date.FormatString, start: String.Index, in range: Range<String.Index>, expectedUpperBound: String.Index?, expectedDate: Date?, file: StaticString = #filePath, line: UInt = #line) {
         let style = Date.VerbatimFormatStyle(format: format, locale: enUS, timeZone: utcTimeZone, calendar: gregorian)
 
         let m = try? style.consuming(string, startingAt: start, in: range)
@@ -1094,7 +1094,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
     }
 
     func testMatchFullRanges() {
-        func verify(_ string: String, matches format: Date.FormatString, expectedDate: TimeInterval?, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ string: String, matches format: Date.FormatString, expectedDate: TimeInterval?, file: StaticString = #filePath, line: UInt = #line) {
             let targetDate: Date? = (expectedDate != nil) ? Date(timeIntervalSinceReferenceDate: expectedDate!) : nil
             _verifyString(string, matches: format, start: string.startIndex, in: string.startIndex..<string.endIndex, expectedUpperBound: (expectedDate != nil) ? string.endIndex: nil, expectedDate: targetDate, file: file, line: line)
         }
@@ -1140,7 +1140,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
 #if FOUNDATION_FRAMEWORK
     // Disabled in package because _range is imported twice, once from Essentials, once from Internationalization
     func testMatchPartialRangesFromBeginning() {
-        func verify(_ string: String, matches format: Date.FormatString, expectedMatch: String, expectedDate: TimeInterval, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ string: String, matches format: Date.FormatString, expectedMatch: String, expectedDate: TimeInterval, file: StaticString = #filePath, line: UInt = #line) {
             let occurrenceRange = string._range(of: expectedMatch, anchored: false, backwards: false)!
             _verifyString(string, matches: format, start: string.startIndex, in: string.startIndex..<string.endIndex, expectedUpperBound: occurrenceRange.upperBound, expectedDate: Date(timeIntervalSinceReferenceDate: expectedDate), file: file, line: line)
         }
@@ -1156,7 +1156,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
 #endif
 
     func testMatchPartialRangesWithinLegitimateString() {
-        func verify(_ string: String, in range: Range<Int>,  matches format: Date.FormatString, expectedDate: TimeInterval, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ string: String, in range: Range<Int>,  matches format: Date.FormatString, expectedDate: TimeInterval, file: StaticString = #filePath, line: UInt = #line) {
             _verifyUTF16String(string, matches: format, in: range, expectedUpperBound: range.upperBound, expectedDate: Date(timeIntervalSinceReferenceDate: expectedDate), file: file, line: line)
         }
 
@@ -1169,7 +1169,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
     func testDateFormatStyleMatchRoundtrip() {
         // dateFormatter.date(from: "2021-01-23 14:51:20")!
         let date = Date(timeIntervalSinceReferenceDate: 633106280.0)
-        func verify(_ formatStyle: Date.FormatStyle, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ formatStyle: Date.FormatStyle, file: StaticString = #filePath, line: UInt = #line) {
             var format = formatStyle
             format.calendar = gregorian
             format.timeZone = utcTimeZone
@@ -1216,7 +1216,7 @@ final class MatchConsumerAndSearcherTests : XCTestCase {
     }
 
     func testMatchPartialRangesFromMiddle() {
-        func verify(_ string: String, matches format: Date.FormatString, expectedMatch: String, expectedDate: TimeInterval, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ string: String, matches format: Date.FormatString, expectedMatch: String, expectedDate: TimeInterval, file: StaticString = #filePath, line: UInt = #line) {
             let occurrenceRange = string.range(of: expectedMatch)!
             _verifyString(string, matches: format, start: occurrenceRange.lowerBound, in: string.startIndex..<string.endIndex, expectedUpperBound: occurrenceRange.upperBound, expectedDate: Date(timeIntervalSinceReferenceDate: expectedDate), file: file, line: line)
         }
@@ -1324,7 +1324,7 @@ extension DateFormatStyleTests {
 
     }
 
-    func _verify(_ style: Date.FormatStyle, expectedFormat: String, locale: Locale, file: StaticString = #file, line: UInt = #line) {
+    func _verify(_ style: Date.FormatStyle, expectedFormat: String, locale: Locale, file: StaticString = #filePath, line: UInt = #line) {
         var style = style
         let timeZone = TimeZone(secondsFromGMT: -3600)!
         style.timeZone = timeZone

--- a/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateIntervalFormatStyleTests.swift
@@ -124,7 +124,7 @@ final class DateIntervalFormatStyleTests: XCTestCase {
 
         let range = (date..<date + hour)
         let afternoon = (Date(timeIntervalSince1970: 13 * 3600)..<Date(timeIntervalSince1970: 15 * 3600))
-        func verify(date: Date.IntervalFormatStyle.DateStyle? = nil, time: Date.IntervalFormatStyle.TimeStyle, locale: Locale, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func verify(date: Date.IntervalFormatStyle.DateStyle? = nil, time: Date.IntervalFormatStyle.TimeStyle, locale: Locale, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let style = Date.IntervalFormatStyle(date: date, time: time, locale: locale, calendar: calendar, timeZone: timeZone)
 
             XCTAssertEqualIgnoreSeparator(style.format(range), expected, file: file, line: line)
@@ -150,7 +150,7 @@ final class DateIntervalFormatStyleTests: XCTestCase {
         verify(date: .numeric, time: .standard, locale: default24force24, expected: "01/01/2001, 00:00:00 – 01:00:00")
         verify(date: .numeric, time: .standard, locale: default24force12, expected: "01/01/2001, 12:00:00 AM – 1:00:00 AM")
 
-        func verify(_ tests: (locale: Locale, expected: String, expectedAfternoon: String)..., file: StaticString = #file, line: UInt = #line, customStyle: (Date.IntervalFormatStyle) -> (Date.IntervalFormatStyle)) {
+        func verify(_ tests: (locale: Locale, expected: String, expectedAfternoon: String)..., file: StaticString = #filePath, line: UInt = #line, customStyle: (Date.IntervalFormatStyle) -> (Date.IntervalFormatStyle)) {
 
             let style = customStyle(Date.IntervalFormatStyle(locale: enUSLocale, calendar: calendar, timeZone: timeZone))
             for (i, (locale, expected, expectedAfternoon)) in tests.enumerated() {

--- a/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DateRelativeFormatStyleTests.swift
@@ -67,7 +67,7 @@ final class DateRelativeFormatStyleTests: XCTestCase {
     func testNamedStyleRounding() throws {
         let named = Date.RelativeFormatStyle(presentation: .named, locale: enUSLocale, calendar: calendar)
 
-        func _verifyStyle(_ dateValue: TimeInterval, relativeTo: TimeInterval, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func _verifyStyle(_ dateValue: TimeInterval, relativeTo: TimeInterval, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let date = Date(timeIntervalSinceReferenceDate: dateValue)
             let refDate = Date(timeIntervalSinceReferenceDate: relativeTo)
             let formatted = named._format(date, refDate: refDate)
@@ -189,7 +189,7 @@ final class DateRelativeFormatStyleTests: XCTestCase {
     func testNumericStyleRounding() throws {
         let numeric = Date.RelativeFormatStyle(presentation: .numeric, locale: enUSLocale, calendar: calendar)
 
-        func _verifyStyle(_ dateValue: TimeInterval, relativeTo: TimeInterval, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func _verifyStyle(_ dateValue: TimeInterval, relativeTo: TimeInterval, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let date = Date(timeIntervalSinceReferenceDate: dateValue)
             let refDate = Date(timeIntervalSinceReferenceDate: relativeTo)
             let formatted = numeric._format(date, refDate: refDate)
@@ -332,7 +332,7 @@ final class DateRelativeFormatStyleTests: XCTestCase {
     func testAllowedFieldsNamed() throws {
         var named = Date.RelativeFormatStyle(presentation: .named, locale: enUSLocale, calendar: calendar)
 
-        func _verifyStyle(_ dateStr: String, relativeTo: String, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func _verifyStyle(_ dateStr: String, relativeTo: String, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let date = try! Date.ISO8601FormatStyle().parse(dateStr)
             let refDate = try! Date.ISO8601FormatStyle().parse(relativeTo)
             let formatted = named._format(date, refDate: refDate)
@@ -366,7 +366,7 @@ final class DateRelativeFormatStyleTests: XCTestCase {
     func testAllowedFieldsNumeric() throws {
         var named = Date.RelativeFormatStyle(presentation: .numeric, locale: enUSLocale, calendar: calendar)
 
-        func _verifyStyle(_ dateStr: String, relativeTo: String, expected: String, file: StaticString = #file, line: UInt = #line) {
+        func _verifyStyle(_ dateStr: String, relativeTo: String, expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let date = try! Date.ISO8601FormatStyle().parse(dateStr)
             let refDate = try! Date.ISO8601FormatStyle().parse(relativeTo)
             let formatted = named._format(date, refDate: refDate)

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
@@ -34,7 +34,7 @@ extension Duration {
 
 final class DurationToMeasurementAdditionTests : XCTestCase {
     typealias Unit = Duration._UnitsFormatStyle.Unit
-    func assertEqualDurationUnitValues(_ duration: Duration, units: [Unit], rounding: FloatingPointRoundingRule = .toNearestOrEven, trailingFractionalLength: Int = .max, roundingIncrement: Double? = nil, expectation values: [Double], file: StaticString = #file, line: UInt = #line) {
+    func assertEqualDurationUnitValues(_ duration: Duration, units: [Unit], rounding: FloatingPointRoundingRule = .toNearestOrEven, trailingFractionalLength: Int = .max, roundingIncrement: Double? = nil, expectation values: [Double], file: StaticString = #filePath, line: UInt = #line) {
         let result = duration.valuesForUnits(units, trailingFractionalLength: trailingFractionalLength, smallestUnitRounding: rounding, roundingIncrement: roundingIncrement)
         XCTAssertEqual(result, values, file: file, line: line)
     }
@@ -67,7 +67,7 @@ final class DurationToMeasurementAdditionTests : XCTestCase {
     }
 
     func testDurationRounding() {
-        func test(_ duration: Duration, units: [Unit], trailingFractionalLength: Int = 0, _ tests: (rounding: FloatingPointRoundingRule, expected: [Double])..., file: StaticString = #file, line: UInt = #line) {
+        func test(_ duration: Duration, units: [Unit], trailingFractionalLength: Int = 0, _ tests: (rounding: FloatingPointRoundingRule, expected: [Double])..., file: StaticString = #filePath, line: UInt = #line) {
             for (i, (rounding, expected)) in tests.enumerated() {
                 assertEqualDurationUnitValues(duration, units: units, rounding: rounding, trailingFractionalLength: trailingFractionalLength, expectation: expected, file: file, line: line + UInt(i) + 1)
 
@@ -298,7 +298,7 @@ final class DurationToMeasurementAdditionTests : XCTestCase {
 final class TestDurationTimeFormatStyle : XCTestCase {
     let enUS = Locale(identifier: "en_US")
 
-    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, grouping: NumberFormatStyleConfiguration.Grouping? = nil, expected: String, file: StaticString = #file, line: UInt = #line) {
+    func assertFormattedWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, grouping: NumberFormatStyleConfiguration.Grouping? = nil, expected: String, file: StaticString = #filePath, line: UInt = #line) {
         var style = Duration.TimeFormatStyle(pattern: pattern).locale(enUS)
         if let grouping {
             style.grouping = grouping
@@ -489,7 +489,7 @@ final class DurationTimeAttributedStyleTests : XCTestCase {
     typealias Segment = (String, AttributeScopes.FoundationAttributes.DurationFieldAttribute.Field?)
     let enUS = Locale(identifier: "en_US")
 
-    func assertWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, expected: [Segment], locale: Locale = Locale(identifier: "en_US"), file: StaticString = #file, line: UInt = #line) {
+    func assertWithPattern(seconds: Int, milliseconds: Int = 0, pattern: Duration._TimeFormatStyle.Pattern, expected: [Segment], locale: Locale = Locale(identifier: "en_US"), file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(Duration(seconds: Int64(seconds), milliseconds: Int64(milliseconds)).formatted(.time(pattern: pattern).locale(locale).attributed), expected.attributedString, file: file, line: line)
     }
 

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
@@ -75,7 +75,7 @@ final class DurationUnitsFormatStyleTests : XCTestCase {
         XCTAssertEqual(Duration(minutes: 43, seconds: 24, milliseconds: 490).formatted(.units(allowed: [.hours, .minutes, .seconds], width: .wide, valueLength: 2, fractionalPart: .show(length: 2)).locale(enUS)), "43 minutes, 24.49 seconds")
     }
 
-    func verify(seconds: Int, milliseconds: Int, allowedUnits: Set<Duration._UnitsFormatStyle.Unit>, fractionalSecondsLength: Int = 0, rounding: FloatingPointRoundingRule = .toNearestOrEven, increment: Double? = nil, expected: String, file: StaticString = #file, line: UInt = #line) {
+    func verify(seconds: Int, milliseconds: Int, allowedUnits: Set<Duration._UnitsFormatStyle.Unit>, fractionalSecondsLength: Int = 0, rounding: FloatingPointRoundingRule = .toNearestOrEven, increment: Double? = nil, expected: String, file: StaticString = #filePath, line: UInt = #line) {
         let d = Duration(seconds: Int64(seconds), milliseconds: Int64(milliseconds))
         XCTAssertEqual(d.formatted(.units(allowed: allowedUnits, zeroValueUnits: .show(length: 1), fractionalPart: .show(length: fractionalSecondsLength, rounded: rounding, increment: increment)).locale(enUS)), expected, file: file, line: line)
     }
@@ -291,12 +291,12 @@ final class DurationUnitsFormatStyleTests : XCTestCase {
         var duration: Duration!
         let allowedUnits: Set<Duration._UnitsFormatStyle.Unit> = [.weeks, .days, .hours]
         func assertZeroValueUnit(_ zeroFormat: Duration._UnitsFormatStyle.ZeroValueUnitsDisplayStrategy, _ expected: String,
-                                  file: StaticString = #file, line: UInt = #line) {
+                                  file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(duration.formatted(.units(allowed: allowedUnits, width: .wide, zeroValueUnits: zeroFormat).locale(enUS)), expected, file: file, line: line)
         }
 
         func assertMaxUnitCount(_ maxUnitCount: Int, fractionalPart: Duration._UnitsFormatStyle.FractionalPartDisplayStrategy, _ expected: String,
-                                  file: StaticString = #file, line: UInt = #line) {
+                                  file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(duration.formatted(.units(allowed: allowedUnits, width: .wide, maximumUnitCount: maxUnitCount, fractionalPart: fractionalPart).locale(enUS)), expected, file: file, line: line)
         }
 
@@ -335,7 +335,7 @@ final class DurationUnitsFormatStyleTests : XCTestCase {
         var duration: Duration
         var allowedUnits: Set<Duration._UnitsFormatStyle.Unit>
         func test(_ zeroFormat: Duration._UnitsFormatStyle.ZeroValueUnitsDisplayStrategy, _ expected: String,
-                                  file: StaticString = #file, line: UInt = #line) {
+                                  file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(duration.formatted(.units(allowed: allowedUnits, width: .wide, zeroValueUnits: zeroFormat).locale(enUS)), expected, file: file, line: line)
         }
 
@@ -435,7 +435,7 @@ final class DurationUnitsFormatStyleTests : XCTestCase {
     func assertEqual(_ duration: Duration,
                      allowedUnits: Set<Duration._UnitsFormatStyle.Unit>, maximumUnitCount: Int? = nil, roundSmallerParts: FloatingPointRoundingRule = .toNearestOrEven, trailingFractionalPartLength: Int = Int.max, roundingIncrement: Double? = nil, dropZeroUnits: Bool = false,
                      expected: (units: [Duration._UnitsFormatStyle.Unit], values: [Double]),
-                     file: StaticString = #file, line: UInt = #line) {
+                     file: StaticString = #filePath, line: UInt = #line) {
 
         let (units, values) = Duration._UnitsFormatStyle.unitsToUse(duration: duration, allowedUnits: allowedUnits, maximumUnitCount: maximumUnitCount, roundSmallerParts: roundSmallerParts, trailingFractionalPartLength: trailingFractionalPartLength, roundingIncrement: roundingIncrement, dropZeroUnits: dropZeroUnits)
         guard values.count == expected.values.count else {
@@ -495,7 +495,7 @@ final class DurationUnitsFormatStyleTests : XCTestCase {
         var duration: Duration
         var allowedUnits: Set<Duration._UnitsFormatStyle.Unit>
 
-        func verify<R: RangeExpression, R2: RangeExpression>(intLimits: R, fracLimits: R2, _ expected: String, file: StaticString = #file, line: UInt = #line) where R.Bound == Int, R2.Bound == Int {
+        func verify<R: RangeExpression, R2: RangeExpression>(intLimits: R, fracLimits: R2, _ expected: String, file: StaticString = #filePath, line: UInt = #line) where R.Bound == Int, R2.Bound == Int {
             let style = Duration._UnitsFormatStyle(allowedUnits: allowedUnits, width: .abbreviated, valueLengthLimits: intLimits, fractionalPart: .init(lengthLimits: fracLimits)).locale(enUS)
             let formatted = style.format(duration)
             XCTAssertEqual(formatted, expected, file: file, line: line)

--- a/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/FormatterCacheTests.swift
@@ -25,14 +25,14 @@ import TestSupport
 
 final class FormatterCacheTests: XCTestCase {
 
-    class TestCacheItem: Equatable {
+    final class TestCacheItem: Equatable, Sendable {
         static func == (lhs: FormatterCacheTests.TestCacheItem, rhs: FormatterCacheTests.TestCacheItem) -> Bool {
             return lhs.value == rhs.value
         }
 
         let value: Int
-        let deinitBlock: () -> Void
-        init(value: Int, deinitBlock: @escaping () -> Void) {
+        let deinitBlock: @Sendable () -> Void
+        init(value: Int, deinitBlock: @Sendable @escaping () -> Void) {
             self.value = value
             self.deinitBlock = deinitBlock
         }

--- a/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ICUPatternGeneratorTests.swift
@@ -26,7 +26,7 @@ final class ICUPatternGeneratorTests: XCTestCase {
 
         var locale: Locale
         var calendar: Calendar
-        func test(symbols: Date.FormatStyle.DateFieldCollection, expectedPattern: String, file: StaticString = #file, line: UInt = #line) {
+        func test(symbols: Date.FormatStyle.DateFieldCollection, expectedPattern: String, file: StaticString = #filePath, line: UInt = #line) {
             let pattern = ICUPatternGenerator.localizedPattern(symbols: symbols, locale: locale, calendar: calendar)
             XCTAssertEqualIgnoreSeparator(pattern, expectedPattern, file: file, line: line)
 

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberFormatStyleTests.swift
@@ -36,18 +36,18 @@ final class NumberFormatStyleTests: XCTestCase {
     let testNegativePositiveDoubleData: [Double] = [ 87650, 8765, 876.5, 87.65, 8.765, 0.8765, 0.08765, 0.008765, 0, -0.008765, -876.5, -87650 ]
     let testNegativePositiveDecimalData: [Decimal] = [  Decimal(string:"87650")!, Decimal(string:"8765")!, Decimal(string:"876.5")!, Decimal(string:"87.65")!, Decimal(string:"8.765")!, Decimal(string:"0.8765")!, Decimal(string:"0.08765")!, Decimal(string:"0.008765")!, Decimal(string:"0")!, Decimal(string:"-0.008765")!, Decimal(string:"-876.5")!, Decimal(string:"-87650")! ]
 
-    func _testNegativePositiveInt<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #file, line: UInt = #line) where F.FormatInput == Int, F.FormatOutput == String {
+    func _testNegativePositiveInt<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) where F.FormatInput == Int, F.FormatOutput == String {
         for i in 0..<testNegativePositiveIntegerData.count {
             XCTAssertEqual(style.format(testNegativePositiveIntegerData[i]), expected[i], testName, file: file, line: line)
         }
     }
-    func _testNegativePositiveDouble<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #file, line: UInt = #line) where F.FormatInput == Double, F.FormatOutput == String {
+    func _testNegativePositiveDouble<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) where F.FormatInput == Double, F.FormatOutput == String {
         for i in 0..<testNegativePositiveDoubleData.count {
             XCTAssertEqual(style.format(testNegativePositiveDoubleData[i]), expected[i], testName, file: file, line: line)
         }
     }
 
-    func _testNegativePositiveDecimal<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #file, line: UInt = #line) where F.FormatInput == Decimal, F.FormatOutput == String {
+    func _testNegativePositiveDecimal<F: FormatStyle>(_ style: F, _ expected: [String], _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) where F.FormatInput == Decimal, F.FormatOutput == String {
         for i in 0..<testNegativePositiveDecimalData.count {
             XCTAssertEqual((testNegativePositiveDecimalData[i]).formatted(style), expected[i], testName, file: file, line: line)
         }
@@ -2092,7 +2092,7 @@ extension FormatStylePatternMatchingTests {
         range: Range<Int>,
         expectedUpperBound: Int?,
         expectedValue: Value?,
-        file: StaticString = #file, line: UInt = #line) where Consumer.RegexOutput == Value {
+        file: StaticString = #filePath, line: UInt = #line) where Consumer.RegexOutput == Value {
             let upperInString = expectedUpperBound != nil ? str.index(str.startIndex, offsetBy: expectedUpperBound!) : nil
             let rangeInString = str.index(str.startIndex, offsetBy: range.lowerBound)..<str.index(str.startIndex, offsetBy: range.upperBound)
             let startingAtInStr = startingAt != nil ? str.index(str.startIndex, offsetBy: startingAt!) : nil
@@ -2107,7 +2107,7 @@ extension FormatStylePatternMatchingTests {
         range: Range<String.Index>? = nil,
         expectedUpperBound: String.Index?,
         expectedValue: Value?,
-        file: StaticString = #file, line: UInt = #line) where Consumer.RegexOutput == Value {
+        file: StaticString = #filePath, line: UInt = #line) where Consumer.RegexOutput == Value {
         let resolvedRange = range ?? str.startIndex ..< str.endIndex
         let m = try? formatStyle.consuming(str, startingAt: startingAt ?? resolvedRange.lowerBound, in: resolvedRange)
         let upperBound = m?.upperBound

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -71,7 +71,7 @@ final class NumberParseStrategyTests : XCTestCase {
     }
 
     func testRoundtripParsing_percent() {
-        func _verifyRoundtripPercent(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Percent, _ testName: String = "", file: StaticString = #file, line: UInt = #line) {
+        func _verifyRoundtripPercent(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Percent, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
             for value in testData {
                 let str = style.format(value)
                 let parsed = try! Int(str, strategy: style.parseStrategy)
@@ -100,7 +100,7 @@ final class NumberParseStrategyTests : XCTestCase {
         _verifyRoundtripPercent(negativeData, percentStyle.notation(.scientific), "percent style, scientific notation")
         _verifyRoundtripPercent(negativeData, percentStyle.decimalSeparator(strategy: .always), "percent style, decimal display: always")
 
-        func _verifyRoundtripPercent(_ testData: [Double], _ style: FloatingPointFormatStyle<Double>.Percent, _ testName: String = "", file: StaticString = #file, line: UInt = #line) {
+        func _verifyRoundtripPercent(_ testData: [Double], _ style: FloatingPointFormatStyle<Double>.Percent, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
             for value in testData {
                 let str = style.format(value)
                 let parsed = try! Double(str, format: style, lenient: true)
@@ -128,7 +128,7 @@ final class NumberParseStrategyTests : XCTestCase {
             -87650000, -8765000, -876500, -87650, -8765, -876, -87, -8
         ]
 
-        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #file, line: UInt = #line) {
+        func _verifyRoundtripCurrency(_ testData: [Int], _ style: IntegerFormatStyle<Int>.Currency, _ testName: String = "", file: StaticString = #filePath, line: UInt = #line) {
             for value in testData {
                 let str = style.format(value)
                 let parsed = try! Int(str, strategy: style.parseStrategy)

--- a/Tests/FoundationInternationalizationTests/Formatting/ParseStrategy+RegexComponentTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/ParseStrategy+RegexComponentTests.swift
@@ -227,7 +227,7 @@ DEBIT    Mar 31/20    March Payment to BoA         -USD 52,249.98
 #endif
 
     func testVariousDatesAndTimes() {
-        func verify(_ str: String, _ strategy: Date.ParseStrategy, _ expected: String?, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ str: String, _ strategy: Date.ParseStrategy, _ expected: String?, file: StaticString = #filePath, line: UInt = #line) {
             let match = str.wholeMatch(of: strategy) // Regex<Date>.Match?
             if let expected {
                 guard let match else {
@@ -270,7 +270,7 @@ DEBIT    Mar 31/20    March Payment to BoA         -USD 52,249.98
     }
 
     func testMatchISO8601String() {
-        func verify(_ str: String, _ strategy: Date.ISO8601FormatStyle, _ expected: String?, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ str: String, _ strategy: Date.ISO8601FormatStyle, _ expected: String?, file: StaticString = #filePath, line: UInt = #line) {
 
             let match = str.wholeMatch(of: strategy) // Regex<Date>.Match?
             if let expected {

--- a/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleComponentsTests.swift
@@ -138,7 +138,7 @@ final class LocaleComponentsTests: XCTestCase {
     }
 
     func testCreation_identifier() {
-        func verify(_ identifier: String, file: StaticString = #file, line: UInt = #line, expected components: () -> Locale.Components ) {
+        func verify(_ identifier: String, file: StaticString = #filePath, line: UInt = #line, expected components: () -> Locale.Components ) {
             let comps = Locale.Components(identifier: identifier)
             let expected = components()
             XCTAssertEqual(comps, expected, "expect: \"\(expected.icuIdentifier)\", actual: \"\(comps.icuIdentifier)\"", file: file, line: line)
@@ -235,7 +235,7 @@ final class LocaleComponentsTests: XCTestCase {
     }
 
     func testCreation_roundTripLocale() {
-        func verify(_ identifier: String, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ identifier: String, file: StaticString = #filePath, line: UInt = #line) {
 
             let locale = Locale(identifier: identifier)
 
@@ -256,7 +256,7 @@ final class LocaleComponentsTests: XCTestCase {
 
     func testLocaleComponentInitNoCrash() {
         // Test that parsing invalid identifiers does not crash
-        func test(_ identifier: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ identifier: String, file: StaticString = #filePath, line: UInt = #line) {
             let comp = Locale.Components(identifier: identifier)
             XCTAssertNotNil(comp, file: file, line: line)
         }
@@ -268,7 +268,7 @@ final class LocaleComponentsTests: XCTestCase {
 
     func test_userPreferenceOverride() {
 
-        func verifyHourCycle(_ localeID: String, _ expectDefault: Locale.HourCycle?, shouldRespectUserPref: Bool, file: StaticString = #file, line: UInt = #line) {
+        func verifyHourCycle(_ localeID: String, _ expectDefault: Locale.HourCycle?, shouldRespectUserPref: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let loc = Locale(identifier: localeID)
             let nonCurrentDefault = Locale.Components(locale: loc)
             XCTAssertEqual(nonCurrentDefault.hourCycle, expectDefault,  "default did not match", file: file, line: line)
@@ -331,7 +331,7 @@ final class LocaleComponentsTests: XCTestCase {
 final class LocaleCodableTests: XCTestCase {
 
     // Test types that used to encode both `identifier` and `normalizdIdentifier` now only encodes `identifier`
-    func _testRoundtripCoding<T: Codable>(_ obj: T, identifier: String, normalizedIdentifier: String, file: StaticString = #file, line: UInt = #line) -> T? {
+    func _testRoundtripCoding<T: Codable>(_ obj: T, identifier: String, normalizedIdentifier: String, file: StaticString = #filePath, line: UInt = #line) -> T? {
         let previousEncoded = "{\"_identifier\":\"\(identifier)\",\"_normalizedIdentifier\":\"\(normalizedIdentifier)\"}"
         let previousEncodedData = previousEncoded.data(using: String._Encoding.utf8)!
         let decoder = JSONDecoder()
@@ -488,7 +488,7 @@ final class LocaleCodableTests: XCTestCase {
     }
 
     func test_decode_compatible_localeComponents() {
-        func expectDecode(_ encoded: String, _ expected: Locale.Components, file: StaticString = #file, line: UInt = #line) {
+        func expectDecode(_ encoded: String, _ expected: Locale.Components, file: StaticString = #filePath, line: UInt = #line) {
             guard let data = encoded.data(using: String._Encoding.utf8), let decoded = try? JSONDecoder().decode(Locale.Components.self, from: data) else {
                 XCTFail(file: file, line: line)
                 return
@@ -522,7 +522,7 @@ final class LocaleCodableTests: XCTestCase {
 
     func test_decode_compatible_language() {
 
-        func expectDecode(_ encoded: String, _ expected: Locale.Language, file: StaticString = #file, line: UInt = #line) {
+        func expectDecode(_ encoded: String, _ expected: Locale.Language, file: StaticString = #filePath, line: UInt = #line) {
             guard let data = encoded.data(using: String._Encoding.utf8), let decoded = try? JSONDecoder().decode(Locale.Language.self, from: data) else {
                 XCTFail(file: file, line: line)
                 return
@@ -540,7 +540,7 @@ final class LocaleCodableTests: XCTestCase {
     }
 
     func test_decode_compatible_languageComponents() {
-        func expectDecode(_ encoded: String, _ expected: Locale.Language.Components, file: StaticString = #file, line: UInt = #line) {
+        func expectDecode(_ encoded: String, _ expected: Locale.Language.Components, file: StaticString = #filePath, line: UInt = #line) {
             guard let data = encoded.data(using: String._Encoding.utf8), let decoded = try? JSONDecoder().decode(Locale.Language.Components.self, from: data) else {
                 XCTFail(file: file, line: line)
                 return
@@ -580,7 +580,7 @@ final class LocaleCodableTests: XCTestCase {
     }
 
     func test_encode_language() {
-        func expectEncode(_ lang: Locale.Language, _ expectedEncoded: String, file: StaticString = #file, line: UInt = #line) {
+        func expectEncode(_ lang: Locale.Language, _ expectedEncoded: String, file: StaticString = #filePath, line: UInt = #line) {
             guard let encoded = _encodeAsJSON(lang) else {
                 XCTFail(file: file, line: line)
                 return
@@ -625,7 +625,7 @@ final class LocaleCodableTests: XCTestCase {
     }
 
     func test_encode_languageComponents() {
-        func expectEncode(_ lang: Locale.Language.Components, _ expectedEncoded: String, file: StaticString = #file, line: UInt = #line) {
+        func expectEncode(_ lang: Locale.Language.Components, _ expectedEncoded: String, file: StaticString = #filePath, line: UInt = #line) {
             guard let encoded = _encodeAsJSON(lang) else {
                 XCTFail(file: file, line: line)
                 return
@@ -665,7 +665,7 @@ final class LocaleCodableTests: XCTestCase {
 
     func test_encode_localeComponents() {
 
-        func expectEncode(_ lang: Locale.Components, _ expectedEncoded: String, file: StaticString = #file, line: UInt = #line) {
+        func expectEncode(_ lang: Locale.Components, _ expectedEncoded: String, file: StaticString = #filePath, line: UInt = #line) {
             guard let encoded = _encodeAsJSON(lang) else {
                 XCTFail(file: file, line: line)
                 return

--- a/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleLanguageTests.swift
@@ -27,7 +27,7 @@ final class LocaleLanguageComponentsTests : XCTestCase {
                           expectedLanguageCode: String?,
                           expectedScriptCode: String?,
                           expectedRegionCode: String?,
-                          file: StaticString = #file, line: UInt = #line) {
+                          file: StaticString = #filePath, line: UInt = #line) {
         let comp = Locale.Language.Components(identifier: identifier)
         XCTAssertEqual(comp.languageCode?.identifier, expectedLanguageCode, file: file, line: line)
         XCTAssertEqual(comp.script?.identifier, expectedScriptCode, file: file, line: line)
@@ -60,7 +60,7 @@ final class LocaleLanguageComponentsTests : XCTestCase {
 
 class LocaleLanguageTests: XCTestCase {
 
-    func verify(_ identifier: String, expectedParent: Locale.Language, minBCP47: String, maxBCP47: String, langCode: Locale.LanguageCode?, script: Locale.Script?, region: Locale.Region?, lineDirection: Locale.LanguageDirection, characterDirection: Locale.LanguageDirection, file: StaticString = #file, line: UInt = #line) {
+    func verify(_ identifier: String, expectedParent: Locale.Language, minBCP47: String, maxBCP47: String, langCode: Locale.LanguageCode?, script: Locale.Script?, region: Locale.Region?, lineDirection: Locale.LanguageDirection, characterDirection: Locale.LanguageDirection, file: StaticString = #filePath, line: UInt = #line) {
         let lan = Locale.Language(identifier: identifier)
         XCTAssertEqual(lan.parent, expectedParent, "Parents should be equal", file: file, line: line)
         XCTAssertEqual(lan.minimalIdentifier, minBCP47, "minimalIdentifiers should be equal", file: file, line: line)
@@ -86,7 +86,7 @@ class LocaleLanguageTests: XCTestCase {
     }
 
     func testEquivalent() {
-        func verify(lang1: String, lang2: String, isEqual: Bool, file: StaticString = #file, line: UInt = #line) {
+        func verify(lang1: String, lang2: String, isEqual: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let language1 = Locale.Language(identifier: lang1)
             let language2 = Locale.Language(identifier: lang2)
 

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -135,7 +135,7 @@ final class LocaleTests : XCTestCase {
 
     func test_identifierTypesFromComponents() throws {
 
-        func verify(cldr: String, bcp47: String, icu: String, file: StaticString = #file, line: UInt = #line, _ components: () -> Locale.Components) {
+        func verify(cldr: String, bcp47: String, icu: String, file: StaticString = #filePath, line: UInt = #line, _ components: () -> Locale.Components) {
             let loc = Locale(components: components())
             let types: [Locale.IdentifierType] = [.cldr, .bcp47, .icu]
             let expected = [cldr, bcp47, icu]
@@ -244,7 +244,7 @@ final class LocaleTests : XCTestCase {
         }
     }
 
-    func verify(_ locID: String, cldr: String, bcp47: String, icu: String, file: StaticString = #file, line: UInt = #line) {
+    func verify(_ locID: String, cldr: String, bcp47: String, icu: String, file: StaticString = #filePath, line: UInt = #line) {
         let loc = Locale(identifier: locID)
         let types: [Locale.IdentifierType] = [.cldr, .bcp47, .icu]
         let expected = [cldr, bcp47, icu]
@@ -341,7 +341,7 @@ final class LocaleTests : XCTestCase {
     #endif
 
     func test_identifierCapturingPreferences() {
-        func expectIdentifier(_ localeIdentifier: String, preferences: LocalePreferences, expectedFullIdentifier: String, file: StaticString = #file, line: UInt = #line) {
+        func expectIdentifier(_ localeIdentifier: String, preferences: LocalePreferences, expectedFullIdentifier: String, file: StaticString = #filePath, line: UInt = #line) {
             let locale = Locale.localeAsIfCurrent(name: localeIdentifier, overrides: preferences)
             XCTAssertEqual(locale.identifier, localeIdentifier, file: file, line: line)
             XCTAssertEqual(locale.identifierCapturingPreferences, expectedFullIdentifier, file: file, line: line)
@@ -380,7 +380,7 @@ final class LocaleTests : XCTestCase {
 
 final class LocalePropertiesTests : XCTestCase {
 
-    func _verify(locale: Locale, expectedLanguage language: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil, region: Locale.Region? = nil, subdivision: Locale.Subdivision? = nil, measurementSystem: Locale.MeasurementSystem? = nil, calendar: Calendar.Identifier? = nil, hourCycle: Locale.HourCycle? = nil, currency: Locale.Currency? = nil, numberingSystem: Locale.NumberingSystem? = nil, numberingSystems: Set<Locale.NumberingSystem> = [], firstDayOfWeek: Locale.Weekday? = nil, collation: Locale.Collation? = nil, variant: Locale.Variant? = nil, file: StaticString = #file, line: UInt = #line) {
+    func _verify(locale: Locale, expectedLanguage language: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil, region: Locale.Region? = nil, subdivision: Locale.Subdivision? = nil, measurementSystem: Locale.MeasurementSystem? = nil, calendar: Calendar.Identifier? = nil, hourCycle: Locale.HourCycle? = nil, currency: Locale.Currency? = nil, numberingSystem: Locale.NumberingSystem? = nil, numberingSystems: Set<Locale.NumberingSystem> = [], firstDayOfWeek: Locale.Weekday? = nil, collation: Locale.Collation? = nil, variant: Locale.Variant? = nil, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(locale.language.languageCode, language, "languageCode should be equal", file: file, line: line)
         XCTAssertEqual(locale.language.script, script, "script should be equal", file: file, line: line)
         XCTAssertEqual(locale.language.region, languageRegion, "language region should be equal", file: file, line: line)
@@ -397,13 +397,13 @@ final class LocalePropertiesTests : XCTestCase {
         XCTAssertEqual(locale.variant, variant, "variant should be equal", file: file, line: line)
     }
 
-    func verify(_ identifier: String, expectedLanguage language: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil, region: Locale.Region? = nil, subdivision: Locale.Subdivision? = nil, measurementSystem: Locale.MeasurementSystem? = nil, calendar: Calendar.Identifier? = nil, hourCycle: Locale.HourCycle? = nil, currency: Locale.Currency? = nil, numberingSystem: Locale.NumberingSystem? = nil, numberingSystems: Set<Locale.NumberingSystem> = [], firstDayOfWeek: Locale.Weekday? = nil, collation: Locale.Collation? = nil, variant: Locale.Variant? = nil, file: StaticString = #file, line: UInt = #line) {
+    func verify(_ identifier: String, expectedLanguage language: Locale.LanguageCode? = nil, script: Locale.Script? = nil, languageRegion: Locale.Region? = nil, region: Locale.Region? = nil, subdivision: Locale.Subdivision? = nil, measurementSystem: Locale.MeasurementSystem? = nil, calendar: Calendar.Identifier? = nil, hourCycle: Locale.HourCycle? = nil, currency: Locale.Currency? = nil, numberingSystem: Locale.NumberingSystem? = nil, numberingSystems: Set<Locale.NumberingSystem> = [], firstDayOfWeek: Locale.Weekday? = nil, collation: Locale.Collation? = nil, variant: Locale.Variant? = nil, file: StaticString = #filePath, line: UInt = #line) {
         let loc = Locale(identifier: identifier)
         _verify(locale: loc, expectedLanguage: language, script: script, languageRegion: languageRegion, region: region, subdivision: subdivision, measurementSystem: measurementSystem, calendar: calendar, hourCycle: hourCycle, currency: currency, numberingSystem: numberingSystem, numberingSystems: numberingSystems, firstDayOfWeek: firstDayOfWeek, collation: collation, variant: variant, file: file, line: line)
     }
 
     func test_localeComponentsAndLocale() {
-        func verify(components: Locale.Components, identifier: String, file: StaticString = #file, line: UInt = #line) {
+        func verify(components: Locale.Components, identifier: String, file: StaticString = #filePath, line: UInt = #line) {
             let locFromComponents = Locale(components: components)
             let locFromIdentifier = Locale(identifier: identifier)
             _verify(locale: locFromComponents, expectedLanguage: locFromIdentifier.language.languageCode, script: locFromIdentifier.language.script, languageRegion: locFromIdentifier.language.region, region: locFromIdentifier.region, measurementSystem: locFromIdentifier.measurementSystem, calendar: locFromIdentifier.calendar.identifier, hourCycle: locFromIdentifier.hourCycle, currency: locFromIdentifier.currency, numberingSystem: locFromIdentifier.numberingSystem, numberingSystems: Set(locFromIdentifier.availableNumberingSystems), firstDayOfWeek: locFromIdentifier.firstDayOfWeek, collation: locFromIdentifier.collation, variant: locFromIdentifier.variant, file: file, line: line)
@@ -439,7 +439,7 @@ final class LocalePropertiesTests : XCTestCase {
 
     // Test retrieving user's preference values as set in the system settings
     func test_userPreferenceOverride_hourCycle() {
-        func verifyHourCycle(_ localeID: String, _ expectDefault: Locale.HourCycle, shouldRespectUserPref: Bool, file: StaticString = #file, line: UInt = #line) {
+        func verifyHourCycle(_ localeID: String, _ expectDefault: Locale.HourCycle, shouldRespectUserPref: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let loc = Locale(identifier: localeID)
             XCTAssertEqual(loc.hourCycle, expectDefault,  "default did not match", file: file, line: line)
 
@@ -472,7 +472,7 @@ final class LocalePropertiesTests : XCTestCase {
     }
 
     func test_userPreferenceOverride_measurementSystem() {
-        func verify(_ localeID: String, _ expected: Locale.MeasurementSystem, shouldRespectUserPref: Bool, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ localeID: String, _ expected: Locale.MeasurementSystem, shouldRespectUserPref: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let localeNoPref = Locale.localeAsIfCurrent(name: localeID, overrides: .init())
             XCTAssertEqual(localeNoPref.measurementSystem, expected, file: file, line: line)
 
@@ -586,13 +586,6 @@ final class LocalePropertiesTests : XCTestCase {
 // MARK: - Bridging Tests
 #if FOUNDATION_FRAMEWORK
 
-extension NSLocale {
-    fileprivate static var fakeCurrentLocale: NSLocale = NSLocale.current as NSLocale
-    @objc public class var _swizzledCurrentLocale: NSLocale {
-        return NSLocale.fakeCurrentLocale
-    }
-}
-
 final class LocaleBridgingTests : XCTestCase {
     
     @available(macOS, deprecated: 13)
@@ -692,7 +685,7 @@ final class LocaleBridgingTests : XCTestCase {
 #if FOUNDATION_FRAMEWORK
 extension LocaleTests {
     func test_userPreferenceOverride_firstWeekday() {
-        func verify(_ localeID: String, _ expected: Locale.Weekday, shouldRespectUserPrefForGregorian: Bool, shouldRespectUserPrefForIslamic: Bool, file: StaticString = #file, line: UInt = #line) {
+        func verify(_ localeID: String, _ expected: Locale.Weekday, shouldRespectUserPrefForGregorian: Bool, shouldRespectUserPrefForIslamic: Bool, file: StaticString = #filePath, line: UInt = #line) {
             let localeNoPref = Locale.localeAsIfCurrent(name: localeID, overrides: .init(firstWeekday: [:]))
             XCTAssertEqual(localeNoPref.firstDayOfWeek, expected, file: file, line: line)
 

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -21,6 +21,11 @@ import TestSupport
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
+@_nonSendable
+class Hello {
+    var str: NSMutableString = "hi"
+}
+
 @available(FoundationPreview 0.1, *)
 final class SortDescriptorTests: XCTestCase {
     struct NonNSObjectRoot {
@@ -34,6 +39,7 @@ final class SortDescriptorTests: XCTestCase {
             }
         }
 
+        var o = Hello()
         let number: Int
         let word: String
         let maybeWord: String?

--- a/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
+++ b/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
@@ -35,7 +35,7 @@ final class StringLocaleTests: XCTestCase {
         // declared twice on Darwin: once in FoundationInternationalization
         // and once in SDK. Therefore it is ambiguous when building the package
         // on Darwin. Workaround it by testing the internal implementation.
-        func test(_ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ string: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(string._capitalized(with: locale), expected, file: file, line: line)
         }
 
@@ -86,7 +86,7 @@ final class StringLocaleTests: XCTestCase {
 
     func testUppercase_localized() {
 
-        func test(_ localeID: String?, _ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ localeID: String?, _ string: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let locale: Locale?
             if let localeID {
                 locale = Locale(identifier: localeID)
@@ -129,7 +129,7 @@ final class StringLocaleTests: XCTestCase {
     }
 
     func testLowercase_localized() {
-        func test(_ localeID: String?, _ string: String, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func test(_ localeID: String?, _ string: String, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
             let locale: Locale?
             if let localeID {
                 locale = Locale(identifier: localeID)

--- a/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
+++ b/Tests/FoundationInternationalizationTests/TimeZoneTests.swift
@@ -58,7 +58,7 @@ final class TimeZoneTests : XCTestCase {
     }
 
     func testLocalizedName_103036605() {
-        func test(_ tzIdentifier: String, _ localeIdentifier: String, _ style: TimeZone.NameStyle, _ expected: String?, file: StaticString = #file, line: UInt = #line) {
+        func test(_ tzIdentifier: String, _ localeIdentifier: String, _ style: TimeZone.NameStyle, _ expected: String?, file: StaticString = #filePath, line: UInt = #line) {
             let tz = TimeZone(identifier: tzIdentifier)
             guard let expected else {
                 XCTAssertNil(tz, file: file, line: line)
@@ -93,7 +93,7 @@ final class TimeZoneTests : XCTestCase {
 
     func testTimeZoneName_103097012() {
 
-        func _verify(_ tz: TimeZone?, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #file, line: UInt = #line) {
+        func _verify(_ tz: TimeZone?, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #filePath, line: UInt = #line) {
             if let expectedOffset {
                 XCTAssertNotNil(tz, file: file, line: line)
                 XCTAssertEqual(tz!.secondsFromGMT(for: Date(timeIntervalSince1970: 0)), expectedOffset, file: file, line: line)
@@ -103,11 +103,11 @@ final class TimeZoneTests : XCTestCase {
             }
         }
 
-        func testIdentifier(_ tzID: String, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #file, line: UInt = #line) {
+        func testIdentifier(_ tzID: String, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #filePath, line: UInt = #line) {
             _verify(TimeZone(identifier: tzID), expectedOffset, createdId, file: file, line: line)
         }
 
-        func testAbbreviation(_ abb: String, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #file, line: UInt = #line) {
+        func testAbbreviation(_ abb: String, _ expectedOffset: Int?, _ createdId: String?, file: StaticString = #filePath, line: UInt = #line) {
             _verify(TimeZone(abbreviation: abb), expectedOffset, createdId, file: file, line: line)
 
         }
@@ -216,7 +216,7 @@ final class TimeZoneICUTests: XCTestCase {
 
         var gmt_calendar = Calendar(identifier: .gregorian)
         gmt_calendar.timeZone = .gmt
-        func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: TimeInterval, file: StaticString = #file, line: UInt = #line) {
+        func test(_ dateComponent: DateComponents, expectedRawOffset: Int, expectedDSTOffset: TimeInterval, file: StaticString = #filePath, line: UInt = #line) {
             let d = gmt_calendar.date(from: dateComponent)! // date in GMT
             let (rawOffset, dstOffset) = tz.rawAndDaylightSavingTimeOffset(for: d)
             XCTAssertEqual(rawOffset, expectedRawOffset, file: file, line: line)

--- a/Tests/FoundationMacrosTests/MacroTestUtilities.swift
+++ b/Tests/FoundationMacrosTests/MacroTestUtilities.swift
@@ -120,7 +120,7 @@ extension DiagnosticTest {
     }
 }
 
-func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String = "TestModule", testFileName: String = "test.swift", _ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #file, line: UInt = #line) {
+func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String = "TestModule", testFileName: String = "test.swift", _ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #filePath, line: UInt = #line) {
     let context = BasicMacroExpansionContext()
     let origSourceFile = Parser.parse(source: source)
     let expandedSourceFile: Syntax
@@ -146,7 +146,7 @@ func AssertMacroExpansion(macros: [String : Macro.Type], testModuleName: String 
     }
 }
 
-func AssertPredicateExpansion(_ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #file, line: UInt = #line) {
+func AssertPredicateExpansion(_ source: String, _ result: String = "", diagnostics: Set<DiagnosticTest> = [], file: StaticString = #filePath, line: UInt = #line) {
     AssertMacroExpansion(
         macros: ["Predicate": PredicateMacro.self],
         source,


### PR DESCRIPTION
Enable complete concurrency checking in Foundation, and Swift 6 mode for the unit tests.