### PR TITLE
FoundationEssentials: correct the entry spelling for iteration

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -368,7 +368,7 @@ enum _FileOperations {
                 stack.append(directory)
 
                 for entry in _Win32DirectoryContentsSequence(path: directory, appendSlashForDirectory: false, prefix: [directory]) {
-                    try entry.fileName.withNTPathRepresentation {
+                    try entry.fileNameWithPrefix.withNTPathRepresentation {
                         if entry.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY,
                                 entry.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != FILE_ATTRIBUTE_REPARSE_POINT {
                             stack.append(entry.fileNameWithPrefix)


### PR DESCRIPTION
When running the test suite we would hit an infinite loop due to the use of the relative path rather than the absolute path for accessing the attributes of the file entry.