### PR TITLE
FoundationEssentialsTests: repair the test suite on Windows

### DIFF
--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -338,8 +338,12 @@ final class StringTests : XCTestCase {
         func assertCString(_ ptr: UnsafePointer<CChar>, equals other: String, file: StaticString = #filePath, line: UInt = #line) {
             XCTAssertEqual(String(cString: ptr), other, file: file, line: line)
         }
-        
+
+#if os(Windows)
+        let original = #"\Path1\Path Two\Path Three\Some Really Long File Name Section.txt"#
+#else
         let original = "/Path1/Path Two/Path Three/Some Really Long File Name Section.txt"
+#endif
         original.withFileSystemRepresentation {
             XCTAssertNotNil($0)
             assertCString($0!, equals: original)


### PR DESCRIPTION
We would use the Unix (non-portable) arc separator (`/`). On Windows, we need to ensure that we account for the proper arc separator (`\`) when checking the FSR of the string.