### PR TITLE
Prevent `IntegerParseStrategy` from crashing when encountering OOB numbers

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -34,9 +34,17 @@ extension IntegerParseStrategy: ParseStrategy {
         }
         let trimmedString = value._trimmingWhitespace()
         if let v = parser.parseAsInt(trimmedString) {
-            return Format.FormatInput(v)
+            guard let exact = Format.FormatInput(exactly: v) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
+            }
+            return exact
         } else if let v = parser.parseAsDouble(trimmedString) {
-            return Format.FormatInput(clamping: Int64(v))
+            guard let exact = Format.FormatInput(exactly: v) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])
+            }
+            return exact
         } else {
             let exampleString = formatStyle.format(123)
             throw CocoaError(CocoaError.formatting, userInfo: [

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -188,6 +188,28 @@ final class NumberParseStrategyTests : XCTestCase {
         XCTAssertEqual(try! strategy.parse("-1,234.56 US dollars"), Decimal(string: "-1234.56")!)
         XCTAssertEqual(try! strategy.parse("-USD\u{00A0}1,234.56"), Decimal(string: "-1234.56")!)
     }
+    
+    func testNumericBoundsParsing() throws {
+        let locale = Locale(identifier: "en_US")
+        do {
+            let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertEqual(try parseStrategy.parse(0.formatted(format)), 0)
+            let aboveInt64Max = UInt64(Int64.max) + 1
+            XCTAssertEqual(try parseStrategy.parse(aboveInt64Max.formatted(format)), aboveInt64Max)
+            XCTAssertThrowsError(try parseStrategy.parse("-1"))
+            XCTAssertThrowsError(try parseStrategy.parse("-1,000,000"))
+        }
+        
+        do {
+            let format: IntegerFormatStyle<Int8> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertEqual(try parseStrategy.parse(Int8.min.formatted(format)), Int8.min)
+            XCTAssertEqual(try parseStrategy.parse(Int8.max.formatted(format)), Int8.max)
+            XCTAssertThrowsError(try parseStrategy.parse("-129"))
+            XCTAssertThrowsError(try parseStrategy.parse("128"))
+        }
+    }
 }
 
 final class NumberExtensionParseStrategyTests: XCTestCase {


### PR DESCRIPTION
Internally, `IntegerParseStrategy` currently parses as `Int64` or `Double` (since that's what ICU supports) and then casts to the format output type. However, if the format output type is an unsigned integer or an integer of width less than 64 bits, this causes a crash. We should instead detect this and throw an error during parsing if the parsed number does not fit within the bounds of the specified output type.