### PR TITLE
Mark Bundle stub as package instead of public

### DIFF
--- a/Sources/FoundationEssentials/Bundle+Stub.swift
+++ b/Sources/FoundationEssentials/Bundle+Stub.swift
@@ -12,7 +12,7 @@
 
 #if !FOUNDATION_FRAMEWORK
 
-public struct Bundle: Hashable, Equatable, Sendable {
+package struct Bundle: Hashable, Equatable, Sendable {
     public static let main: Bundle = Bundle()
 
     public var localizations: [String] { return [] }


### PR DESCRIPTION
This is only an implementation detail and we don't want it to become ambiguous with the `Bundle` from SCL-F currently