### PR TITLE
FoundationEssentials: correct callbacks for `moveItem(atPath:toPath:)`

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -176,7 +176,7 @@ extension _FileManagerImpl {
                     var pwszFullPath: PWSTR? = nil
                     _ = PathAllocCombine(item.fileName, $0, PATHCCH_ALLOW_LONG_PATHS, &pwszFullPath)
                     defer { LocalFree(pwszFullPath) }
-                    return String(decodingCString: pwszFullPath!, as: UTF16.self).standardizingPath
+                    return String(decodingCString: pwszFullPath!, as: UTF16.self).standardizingPath.replacing("\\", with: "/")
                  })
             }
         }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -374,11 +374,11 @@ final class FileManagerTests : XCTestCase {
             XCTAssertEqual(try $0.subpathsOfDirectory(atPath: ".").sorted(), ["dir2", "dir2/bar", "dir2/foo", "other_file"])
             XCTAssertEqual($0.contents(atPath: "dir2/foo"), data)
 
-            let rootDir = $0.currentDirectoryPath
+            let rootDir = URL(fileURLWithPath: $0.currentDirectoryPath).path
             XCTAssertEqual($0.delegateCaptures.shouldMove, [.init("\(rootDir)/dir", "\(rootDir)/dir2")])
-            
+
             try $0.moveItem(atPath: "does_not_exist", toPath: "dir3")
-            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterCopyError, [])
+            XCTAssertEqual($0.delegateCaptures.shouldProceedAfterMoveError, [.init("\(rootDir)/does_not_exist", "\(rootDir)/dir3", code: .fileNoSuchFile)])
 
             try $0.moveItem(atPath: "dir2", toPath: "other_file")
             XCTAssertTrue($0.delegateCaptures.shouldProceedAfterMoveError.contains(.init("\(rootDir)/dir2", "\(rootDir)/other_file", code: .fileWriteFileExists)))


### PR DESCRIPTION
In the case that the destination exists, we should check for continue after error. If the source does not exist, simply do nothing.

Furthermore, adjust the test to ensure that we are using the path spelling rather than the FSR.