### PR TITLE
FoundationEssentials: ensure that the path exists before iteration

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -159,6 +159,13 @@ extension _FileManagerImpl {
     
     func subpathsOfDirectory(atPath path: String) throws -> [String] {
 #if os(Windows)
+        try path.withNTPathRepresentation {
+            var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = .init()
+            guard GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) else {
+                throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
+            }
+        }
+
         var results: [String] = []
         for item in _Win32DirectoryContentsSequence(path: path, appendSlashForDirectory: true) {
             results.append(item.fileName)


### PR DESCRIPTION
When performing a `subpathsOfDirectory`, ensure that the path exists. On the non-Windows path, `_FTSSequence` will perform the initial `statvfs` during construction which obscured this requirement. We instead explicitly inline this call in the implementation. This repairs further test failures.