### PR TITLE
Limit IntegerParseStrategy's fallback Double path to lossless integer range

### DIFF
--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -40,6 +40,10 @@ extension IntegerParseStrategy: ParseStrategy {
             }
             return exact
         } else if let v = parser.parseAsDouble(trimmedString) {
+            guard v.magnitude <= Double(sign: .plus, exponent: Double.significandBitCount + 1, significand: 1) else {
+                throw CocoaError(CocoaError.formatting, userInfo: [
+                    NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the lossless floating-point range" ])
+            }
             guard let exact = Format.FormatInput(exactly: v) else {
                 throw CocoaError(CocoaError.formatting, userInfo: [
                     NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the valid bounds of the specified output type" ])

--- a/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/IntegerParseStrategy.swift
@@ -40,7 +40,7 @@ extension IntegerParseStrategy: ParseStrategy {
             }
             return exact
         } else if let v = parser.parseAsDouble(trimmedString) {
-            guard v.magnitude <= Double(sign: .plus, exponent: Double.significandBitCount + 1, significand: 1) else {
+            guard v.magnitude < Double(sign: .plus, exponent: Double.significandBitCount + 1, significand: 1) else {
                 throw CocoaError(CocoaError.formatting, userInfo: [
                     NSDebugDescriptionErrorKey: "Cannot parse \(value). The number does not fall within the lossless floating-point range" ])
             }

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -222,17 +222,17 @@ final class NumberParseStrategyTests : XCTestCase {
             // TODO: Parse integers greater than Int64
             let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(try parseStrategy.parse(UInt64.min.formatted(format)), UInt64.min)
-            //XCTAssertEqual(try parseStrategy.parse(UInt64.max.formatted(format)), UInt64.max)
+            XCTAssertEqual(      try parseStrategy.parse(UInt64.min.formatted(format)), UInt64.min)
+            XCTAssertThrowsError(try parseStrategy.parse(UInt64.max.formatted(format)))
             XCTAssertThrowsError(try parseStrategy.parse("-1"))
             XCTAssertThrowsError(try parseStrategy.parse("18446744073709551616"))
             
             // TODO: Parse integers greater than Int64
             let maxInt64 = UInt64(Int64.max)
-            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 0).formatted(format)), maxInt64 + 0) // not a Double
-            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 1).formatted(format)), maxInt64 + 1) // exact Double
-            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 2).formatted(format)), maxInt64 + 2) // not a Double
-            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 3).formatted(format)), maxInt64 + 3) // not a Double
+            XCTAssertEqual(      try parseStrategy.parse((maxInt64 + 0).formatted(format)), maxInt64) // not a Double
+            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 1).formatted(format)))           // exact Double
+            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 2).formatted(format)))           // not a Double
+            XCTAssertThrowsError(try parseStrategy.parse((maxInt64 + 3).formatted(format)))           // not a Double
         }
     }
     

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -210,6 +210,25 @@ final class NumberParseStrategyTests : XCTestCase {
             XCTAssertThrowsError(try parseStrategy.parse("128"))
         }
     }
+    
+    func testIntegerParseStrategyDoesNotRoundLargeIntegersToNearestDouble() {
+        XCTAssertEqual(Double.significandBitCount, 52, "Double can represent each integer in -2^53 ... 2^53")
+        let locale = Locale(identifier: "en_US")
+        
+        do {
+            let format: IntegerFormatStyle<Int64> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertNotEqual(try? parseStrategy.parse("-9223372036854776832"), -9223372036854775808) // -2^63 - 1024 (Double: -2^63)
+            XCTAssertNil(     try? parseStrategy.parse("-9223372036854776833"))                       // -2^63 - 1025 (Double: -2^63 - 2048)
+        }
+        
+        do {
+            let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertNotEqual(try? parseStrategy.parse( "9223372036854776832"),  9223372036854775808) // +2^63 + 1024 (Double: +2^63)
+            XCTAssertNotEqual(try? parseStrategy.parse( "9223372036854776833"),  9223372036854777856) // +2^63 + 1025 (Double: +2^63 + 2048)
+        }
+    }
 }
 
 final class NumberExtensionParseStrategyTests: XCTestCase {

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -219,18 +219,20 @@ final class NumberParseStrategyTests : XCTestCase {
         }
         
         do {
+            // TODO: Parse integers greater than Int64
             let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
             XCTAssertEqual(try parseStrategy.parse(UInt64.min.formatted(format)), UInt64.min)
-            XCTAssertEqual(try parseStrategy.parse(UInt64.max.formatted(format)), UInt64.max)
+            //XCTAssertEqual(try parseStrategy.parse(UInt64.max.formatted(format)), UInt64.max)
             XCTAssertThrowsError(try parseStrategy.parse("-1"))
             XCTAssertThrowsError(try parseStrategy.parse("18446744073709551616"))
-
+            
+            // TODO: Parse integers greater than Int64
             let maxInt64 = UInt64(Int64.max)
             XCTAssertEqual(try parseStrategy.parse((maxInt64 + 0).formatted(format)), maxInt64 + 0) // not a Double
-            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 1).formatted(format)), maxInt64 + 1) // exact Double
-            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 2).formatted(format)), maxInt64 + 2) // not a Double
-            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 3).formatted(format)), maxInt64 + 3) // not a Double
+            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 1).formatted(format)), maxInt64 + 1) // exact Double
+            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 2).formatted(format)), maxInt64 + 2) // not a Double
+            //XCTAssertEqual(try parseStrategy.parse((maxInt64 + 3).formatted(format)), maxInt64 + 3) // not a Double
         }
     }
     

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -192,22 +192,45 @@ final class NumberParseStrategyTests : XCTestCase {
     func testNumericBoundsParsing() throws {
         let locale = Locale(identifier: "en_US")
         do {
-            let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
-            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
-            XCTAssertEqual(try parseStrategy.parse(0.formatted(format)), 0)
-            let aboveInt64Max = UInt64(Int64.max) + 1
-            XCTAssertEqual(try parseStrategy.parse(aboveInt64Max.formatted(format)), aboveInt64Max)
-            XCTAssertThrowsError(try parseStrategy.parse("-1"))
-            XCTAssertThrowsError(try parseStrategy.parse("-1,000,000"))
-        }
-        
-        do {
             let format: IntegerFormatStyle<Int8> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
             XCTAssertEqual(try parseStrategy.parse(Int8.min.formatted(format)), Int8.min)
             XCTAssertEqual(try parseStrategy.parse(Int8.max.formatted(format)), Int8.max)
             XCTAssertThrowsError(try parseStrategy.parse("-129"))
             XCTAssertThrowsError(try parseStrategy.parse("128"))
+        }
+        
+        do {
+            let format: IntegerFormatStyle<Int64> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertEqual(try parseStrategy.parse(Int64.min.formatted(format)), Int64.min)
+            XCTAssertEqual(try parseStrategy.parse(Int64.max.formatted(format)), Int64.max)
+            XCTAssertThrowsError(try parseStrategy.parse("-9223372036854775809"))
+            XCTAssertThrowsError(try parseStrategy.parse("9223372036854775808"))
+        }
+        
+        do {
+            let format: IntegerFormatStyle<UInt8> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertEqual(try parseStrategy.parse(UInt8.min.formatted(format)), UInt8.min)
+            XCTAssertEqual(try parseStrategy.parse(UInt8.max.formatted(format)), UInt8.max)
+            XCTAssertThrowsError(try parseStrategy.parse("-1"))
+            XCTAssertThrowsError(try parseStrategy.parse("256"))
+        }
+        
+        do {
+            let format: IntegerFormatStyle<UInt64> = .init(locale: locale)
+            let parseStrategy = IntegerParseStrategy(format: format, lenient: true)
+            XCTAssertEqual(try parseStrategy.parse(UInt64.min.formatted(format)), UInt64.min)
+            XCTAssertEqual(try parseStrategy.parse(UInt64.max.formatted(format)), UInt64.max)
+            XCTAssertThrowsError(try parseStrategy.parse("-1"))
+            XCTAssertThrowsError(try parseStrategy.parse("18446744073709551616"))
+
+            let maxInt64 = UInt64(Int64.max)
+            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 0).formatted(format)), maxInt64 + 0) // not a Double
+            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 1).formatted(format)), maxInt64 + 1) // exact Double
+            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 2).formatted(format)), maxInt64 + 2) // not a Double
+            XCTAssertEqual(try parseStrategy.parse((maxInt64 + 3).formatted(format)), maxInt64 + 3) // not a Double
         }
     }
     

--- a/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/NumberParseStrategyTests.swift
@@ -237,9 +237,11 @@ final class NumberParseStrategyTests : XCTestCase {
     }
     
     func testIntegerParseStrategyDoesNotRoundLargeIntegersToNearestDouble() {
+        XCTAssertEqual(Double("9007199254740992"), Double(exactly: UInt64(1) << 53)!) // +2^53 + 0 -> +2^53
+        XCTAssertEqual(Double("9007199254740993"), Double(exactly: UInt64(1) << 53)!) // +2^53 + 1 -> +2^53
         XCTAssertEqual(Double.significandBitCount, 52, "Double can represent each integer in -2^53 ... 2^53")
         let locale = Locale(identifier: "en_US")
-        
+
         do {
             let format: IntegerFormatStyle<Int64> = .init(locale: locale)
             let parseStrategy = IntegerParseStrategy(format: format, lenient: true)


### PR DESCRIPTION
Hello friends, we meet again!

I've come to propose some changes to IntegerParseStrategy's fallback Double path. Ideally, it should never need to go through Double, but that is out-of-scope for this contribution. Today, I'll only suggest that you reject magnitudes >=(2^53).

In short, Double is a 52-bit window that slides around. The greater the value, the greater the distance between adjacent values. This distance is <=(1) for values in [-2^53, 2^53]. Outside this range, the parseAsDouble(_:) rounds its input String to the nearest Double before the  Double is passed to BinaryInteger.init(exactly:). The lossless range is, therefore, 52 bits since ±(2^53) may represent ±(2^53+1) rounded towards zero. The rounding error is ±(1024) when parsing UInt64 values through Double. Here's a brief illustration:

```swift
Double("9223372036854775808") // 2^63
Double("9223372036854776832") // 2^63 + 1024 becomes 2^63
Double("9223372036854776833") // 2^63 + 1025 becomes 2^63 + 2048
Double("9223372036854777856") // 2^63 + 2048
```

### Proposed solution

Reject magnitudes >=(2^53) in IntegerParseStrategy's fallback Double path.

### Additional comments

1. This rounding issue is similar to the one mentioned in (#613) but w.r.t. IntegerParseStrategy rather than JSONDecoder.
2. This path may or may not do something when limited to values that fit in an Int64. Somebody more familiar with ICU may know. In either case, this contribution adds tests that exemplify the rounding errors that Double may cause.
