### PR TITLE
FoundationEssentials: handle canonical and non-canonical paths

### DIFF
--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -29,7 +29,7 @@ extension String {
         }
 
         var iter = self.utf8.makeIterator()
-        let bLeadingSlash = if iter.next() == ._slash, iter.next()?.isLetter ?? false, iter.next() == ._colon { true } else { false }
+        let bLeadingSlash = if [._slash, ._backslash].contains(iter.next()), iter.next()?.isLetter ?? false, iter.next() == ._colon { true } else { false }
 
         // Strip the leading `/` on a RFC8089 path (`/[drive-letter]:/...` ).  A
         // leading slash indicates a rooted path on the drive for the current


### PR DESCRIPTION
In the case that the path is canonicalised, the `/` would be replaced with `\`. The leading `\` would interfere with our ability to recognise the absolute path representation and thus get the wrong response.