### PR TITLE
FoundationEssentials: adjust error code constants for Windows

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -129,6 +129,14 @@ extension CocoaError {
         )
     }
 
+    static func errorWithFilePath(_ code: CocoaError.Code, _ path: String, variant: String? = nil, userInfo: [String : AnyHashable] = [:]) -> CocoaError {
+        var info: [String:AnyHashable] = userInfo.addingUserInfo(forPath: path)
+        if let variant {
+            info[NSUserStringVariantErrorKey] = [variant]
+        }
+        return CocoaError(code, userInfo: info)
+    }
+
 #if os(Windows)
     static func errorWithFilePath(_ path: PathOrURL, win32 dwError: DWORD, reading: Bool, variant: String? = nil, userInfo: [String : AnyHashable] = [:]) -> CocoaError {
         switch path {


### PR DESCRIPTION
The Windows API calls return `ERROR_TOO_MANY_OPEN_FILES` (4) which is "The system cannot open the file.". One of the tests ensures that the return code is 260 which does not match reality.