### PR TITLE
Potential stack buffer overflow in `_withFixedCharBuffer`

### DIFF
--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -114,6 +114,7 @@ internal func _withResizingCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeMu
                     var innerStatus = U_ZERO_ERROR
                     if let innerLen = body(innerBuffer.baseAddress!, len + 1, &innerStatus) {
                         if innerStatus.isSuccess && innerLen > 0 {
+                            buffer[Int(innerLen)] = 0
                             return String(validatingUTF8: innerBuffer.baseAddress!)
                         }
                     }
@@ -122,6 +123,7 @@ internal func _withResizingCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeMu
                     return nil
                 }
             } else if status.isSuccess && len > 0 {
+                buffer[Int(len)] = 0
                 return String(validatingUTF8: buffer.baseAddress!)
             }
         }
@@ -137,7 +139,7 @@ internal func _withFixedCharBuffer(size: Int32 = ULOC_FULLNAME_CAPACITY + ULOC_K
         var status = U_ZERO_ERROR
         if let len = body(buffer.baseAddress!, size, &status) {
             if status.isSuccess && len > 0 {
-                buffer[Int(len + 1)] = 0
+                buffer[Int(len)] = 0
                 return String(validatingUTF8: buffer.baseAddress!)
             }
         }

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -1615,7 +1615,9 @@ extension Locale {
     }
 
     internal static func keywordValue(identifier: String, key: String) -> String? {
-        return _withFixedCharBuffer(size: ULOC_KEYWORD_AND_VALUES_CAPACITY) { buffer, size, status in
+        // Unlike other many ICU variables, `ULOC_KEYWORD_AND_VALUES_CAPACITY` does not include null-termination.
+        // Manually add one here.
+        return _withFixedCharBuffer(size: ULOC_KEYWORD_AND_VALUES_CAPACITY + 1) { buffer, size, status in
             return uloc_getKeywordValue(identifier, key, buffer, size, &status)
         }
     }

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -581,6 +581,11 @@ final class LocalePropertiesTests : XCTestCase {
 
         verify("ar_EG@calendar=ethioaa;collation=dict;currency=frf;fw=fri;hours=h11;measure=uksystem;numbers=traditio;rg=uszzzz;sd=usca", expectedLanguage: "ar", script: "arab", languageRegion: "EG", region: "us", subdivision: "usca", measurementSystem: .uk, calendar: .ethiopicAmeteAlem, hourCycle: .zeroToEleven, currency: "FRF", numberingSystem: "traditio", numberingSystems: [ "traditio", "latn", "arab" ], firstDayOfWeek: .friday, collation: "dict")
     }
+
+    func test_longLocaleKeywordValues() {
+        let x = Locale.keywordValue(identifier: "ar_EG@vt=kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk", key: "vt")
+        XCTAssertEqual(x, "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk")
+    }
 }
 
 // MARK: - Bridging Tests


### PR DESCRIPTION
In `_withFixedCharBuffer` helper, we allocate a buffer with the requested size + 1 (for null-termination). With the assumption that the closure's return value `len <= the requested size`, the null-terminated character should be on index `len`, not `len + 1`.

Fixes rdar://129154192