### PR TITLE
Enable an extra FileManager copyItem test

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -405,11 +405,8 @@ final class FileManagerTests : XCTestCase {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
             }
             
-            #if canImport(Darwin)
-            // Not supported on linux because it ends up trying to set attributes that are currently unimplemented
             try $0.copyItem(atPath: "dir", toPath: "other_file")
             XCTAssertTrue($0.delegateCaptures.shouldProceedAfterCopyError.contains(.init("dir", "other_file", code: .fileWriteFileExists)))
-            #endif
         }
     }
     


### PR DESCRIPTION
With https://github.com/apple/swift-foundation/pull/644 resolved, we can now enable this test as it now behaves as expected on non-Darwin platforms