### PR TITLE
Re-enable tests for Duration based DiscreteFormatStyle conformances on 32 bit platforms

### DIFF
--- a/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationTimeFormatStyleTests.swift
@@ -555,8 +555,6 @@ final class DurationTimeAttributedStyleTests : XCTestCase {
 
 // MARK: DiscreteFormatStyle conformance test
 
-// This test requires 64-bit integers
-#if arch(x86_64) || arch(arm64)
 @available(FoundationPreview 0.4, *)
 final class TestDurationTimeDiscreteConformance : XCTestCase {
     func testBasics() throws {
@@ -666,4 +664,3 @@ final class TestDurationTimeDiscreteConformance : XCTestCase {
         }
     }
 }
-#endif // arch(x86_64) || arch(arm64)

--- a/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
+++ b/Tests/FoundationInternationalizationTests/Formatting/DurationUnitsFormatStyleTests.swift
@@ -1115,8 +1115,6 @@ final class DurationUnitAttributedFormatStyleTests : XCTestCase {
 
 // MARK: DiscreteFormatStyle conformance test
 
-// This test requires 64-bit integers
-#if arch(x86_64) || arch(arm64)
 @available(FoundationPreview 0.4, *)
 final class TestDurationUnitsDiscreteConformance : XCTestCase {
     func testBasics() throws {
@@ -1415,4 +1413,3 @@ extension Duration {
         (.zero - abs(self))...abs(self)
     }
 }
-#endif // arch(x86_64) || arch(arm64)


### PR DESCRIPTION
This test was unnecessary disabled for 32 bit platforms.