### PR TITLE
FoundationEssentials: relax error handling for `SHGetFolderPath`

### DIFF
--- a/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+WindowsSearchPaths.swift
+++ b/Sources/FoundationEssentials/FileManager/SearchPaths/FileManager+WindowsSearchPaths.swift
@@ -14,12 +14,12 @@
 
 import WinSDK
 
-private func _url(for id: KNOWNFOLDERID) -> URL {
+private func _url(for id: KNOWNFOLDERID) -> URL? {
     var pszPath: PWSTR?
     let hr: HRESULT = withUnsafePointer(to: id) { id in
         SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nil, &pszPath)
     }
-    precondition(SUCCEEDED(hr), "SHGetKnownFolderPath failed \(String(hr, radix: 16))")
+    guard SUCCEEDED(hr) else { return nil }
     defer { CoTaskMemFree(pszPath) }
     return URL(filePath: String(decodingCString: pszPath!, as: UTF16.self), directoryHint: .isDirectory)
 }
@@ -27,7 +27,8 @@ private func _url(for id: KNOWNFOLDERID) -> URL {
 func _WindowsSearchPathURL(for directory: FileManager.SearchPathDirectory, in domain: FileManager.SearchPathDomainMask) -> URL? {
     switch (directory, domain) {
     case (.autosavedInformationDirectory, .userDomainMask):
-        _url(for: FOLDERID_LocalAppData).appending(component: "Autosave Information", directoryHint: .isDirectory)
+        _url(for: FOLDERID_LocalAppData)?
+            .appending(component: "Autosave Information", directoryHint: .isDirectory)
 
     case (.desktopDirectory, .userDomainMask):
         _url(for: FOLDERID_Desktop)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -726,7 +726,6 @@ final class FileManagerTests : XCTestCase {
             .downloadsDirectory,
             .moviesDirectory,
             .musicDirectory,
-            .picturesDirectory,
             .sharedPublicDirectory
         ], exists: true)
         
@@ -774,6 +773,12 @@ final class FileManagerTests : XCTestCase {
         // .trashDirectory is unavailable on watchOS/tvOS and only produces paths on macOS (the framework build) + non-Darwin
         #if !os(watchOS) && !os(tvOS)
         assertSearchPaths([.trashDirectory], exists: (isMacOS && isFramework) || (!isDarwin && !isWindows))
+        #endif
+
+        // .picturesDirectory does not exist in CI, though it does exist in user
+        // desktop scenarios.
+        #if !os(Windows)
+        assertSearchPaths([.picturesDirectory], exists: true)
         #endif
         
         // .applicationScriptsDirectory is only available on macOS and only produces paths in the framework build


### PR DESCRIPTION
When running in CI, we would see failures due to the environment variables being changed. This relaxes the precondition to allow the test failure to propagate.