### PR TITLE
Revert some Sendable fixes around KeyPath while we sort out a compiler bug with ABI stability

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -52,9 +52,7 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) 
-    where
-        K.Value : Sendable {
+    ) {
         if orig.range != changed.range || orig.attrName != changed.attrName {
             attrStr._guts.removeAttributeValue(forKey: K.self, in: orig.range._bstringRange) // If the range changed, we need to remove from the old range first.
         }
@@ -65,7 +63,7 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) where K.Value : Sendable {
+    ) {
         if orig.range != changed.range || orig.attrName != changed.attrName || orig.attr != changed.attr {
             if let newVal = changed.attr { // Then if there's a new value, we add it in.
                 // Unfortunately, we can't use the attrStr[range].set() provided by the AttributedStringProtocol, because we *don't know* the new type statically!
@@ -80,13 +78,10 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @preconcurrency
     public func transformingAttributes<K>(
         _ k:  K.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString 
-    where 
-        K.Value : Sendable {
+    ) -> AttributedString {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -100,16 +95,12 @@ extension AttributedString {
         return copy
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  K1.Type,
         _ k2: K2.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString 
-    where 
-        K1.Value : Sendable,
-        K2.Value : Sendable {
+    ) -> AttributedString {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -127,7 +118,6 @@ extension AttributedString {
         return copy
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -135,11 +125,7 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString 
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable {
+    ) -> AttributedString {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -161,7 +147,6 @@ extension AttributedString {
         return copy
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -171,12 +156,7 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable,
-        K4.Value : Sendable {
+    ) -> AttributedString {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -202,7 +182,6 @@ extension AttributedString {
         return copy
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -214,13 +193,7 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable,
-        K4.Value : Sendable,
-        K5.Value : Sendable {
+    ) -> AttributedString {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -253,30 +226,22 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
-    @preconcurrency
     public func transformingAttributes<K>(
         _ k: KeyPath<AttributeDynamicLookup, K>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString
-    where
-        K.Value : Sendable {
+    ) -> AttributedString {
         self.transformingAttributes(K.self, c)
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable {
+    ) -> AttributedString {
         self.transformingAttributes(K1.self, K2.self, c)
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -284,15 +249,10 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable {
+    ) -> AttributedString {
         self.transformingAttributes(K1.self, K2.self, K3.self, c)
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -302,16 +262,10 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable,
-        K4.Value : Sendable {
+    ) -> AttributedString {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, c)
     }
 
-    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -323,13 +277,7 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString 
-    where
-        K1.Value : Sendable,
-        K2.Value : Sendable,
-        K3.Value : Sendable,
-        K4.Value : Sendable,
-        K5.Value : Sendable {
+    ) -> AttributedString {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, K5.self, c)
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -100,13 +100,11 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    @preconcurrency
-    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> where T.Value : Sendable {
+    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> {
         return AttributesSlice1<T>(runs: self)
     }
 
-    @preconcurrency
-    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> where T.Value : Sendable {
+    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> {
         return AttributesSlice1<T>(runs: self)
     }
 }
@@ -207,31 +205,23 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>
-    ) -> AttributesSlice2<T, U>
-    where
-        T.Value : Sendable,
-        U.Value : Sendable {
+    ) -> AttributesSlice2<T, U> {
         return AttributesSlice2<T, U>(runs: self)
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: T.Type,
         _ u: U.Type
-    ) -> AttributesSlice2<T, U>
-    where 
-        T.Value : Sendable,
-        U.Value : Sendable {
+    ) -> AttributesSlice2<T, U> {
         return AttributesSlice2<T, U>(runs: self)
     }
 }
@@ -338,7 +328,6 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -347,15 +336,10 @@ extension AttributedString.Runs {
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>,
         _ v: KeyPath<AttributeDynamicLookup, V>
-    ) -> AttributesSlice3<T, U, V>
-    where
-        T.Value : Sendable,
-        U.Value : Sendable,
-        V.Value : Sendable {
+    ) -> AttributesSlice3<T, U, V> {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -364,11 +348,7 @@ extension AttributedString.Runs {
         _ t: T.Type,
         _ u: U.Type,
         _ v: V.Type
-    ) -> AttributesSlice3<T, U, V>
-    where
-        T.Value : Sendable,
-        U.Value : Sendable,
-        V.Value : Sendable {
+    ) -> AttributesSlice3<T, U, V> {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 }
@@ -484,7 +464,6 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -499,7 +478,6 @@ extension AttributedString.Runs {
         return AttributesSlice4<T, U, V, W>(runs: self)
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -632,7 +610,6 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -645,17 +622,10 @@ extension AttributedString.Runs {
         _ v: KeyPath<AttributeDynamicLookup, V>,
         _ w: KeyPath<AttributeDynamicLookup, W>,
         _ x: KeyPath<AttributeDynamicLookup, X>
-    ) -> AttributesSlice5<T, U, V, W, X> 
-    where
-        T.Value : Sendable,
-        U.Value : Sendable,
-        V.Value : Sendable,
-        W.Value : Sendable,
-        X.Value : Sendable {
+    ) -> AttributesSlice5<T, U, V, W, X> {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 
-    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -668,13 +638,7 @@ extension AttributedString.Runs {
         _ v: V.Type,
         _ w: W.Type,
         _ x: X.Type
-    ) -> AttributesSlice5<T, U, V, W, X> 
-    where
-        T.Value : Sendable,
-        U.Value : Sendable,
-        V.Value : Sendable,
-        W.Value : Sendable,
-        X.Value : Sendable {
+    ) -> AttributesSlice5<T, U, V, W, X> {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 }

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateCodableConfiguration.swift
@@ -17,8 +17,7 @@
 
 @available(FoundationPredicate 0.1, *)
 public protocol PredicateCodableKeyPathProviding {
-    //@preconcurrency
-    static var predicateCodableKeyPaths : [String : PartialKeyPath<Self> & Sendable] { get }
+    static var predicateCodableKeyPaths : [String : PartialKeyPath<Self>] { get }
 }
 
 @available(FoundationPredicate 0.1, *)
@@ -49,7 +48,7 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
     }
     
     enum AllowListKeyPath : Equatable, Sendable {
-        typealias Constructor = @Sendable (GenericArguments) -> (AnyKeyPath & Sendable)?
+        typealias Constructor = @Sendable (GenericArguments) -> AnyKeyPath?
         
         case concrete(AnyKeyPath & Sendable)
         case partial(PartialType, Constructor, String)
@@ -169,8 +168,7 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
         }
     }
     
-    @preconcurrency
-    public mutating func allowKeyPath(_ keyPath: AnyKeyPath & Sendable, identifier: String) {
+    public mutating func allowKeyPath(_ keyPath: AnyKeyPath, identifier: String) {
         keyPath._validateForPredicateUsage()
         for (id, existingKeyPath) in allowedKeyPaths {
             if id == identifier {
@@ -193,8 +191,7 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
         _allowType(type(of: keyPath).valueType, preferNewIdentifier: false)
     }
     
-    @preconcurrency
-    public mutating func disallowKeyPath(_ keyPath: AnyKeyPath & Sendable) {
+    public mutating func disallowKeyPath(_ keyPath: AnyKeyPath) {
         keyPath._validateForPredicateUsage()
         allowedKeyPaths = allowedKeyPaths.filter {
             $0.value != .concrete(keyPath)
@@ -262,7 +259,7 @@ public struct PredicateCodableConfiguration: Sendable, CustomDebugStringConverti
 
 @available(FoundationPredicate 0.1, *)
 extension PredicateCodableConfiguration {
-    func _identifier(for keyPath: AnyKeyPath & Sendable) -> String? {
+    func _identifier(for keyPath: AnyKeyPath) -> String? {
         let concreteIdentifier = allowedKeyPaths.first {
             $0.value == .concrete(keyPath)
         }?.key
@@ -289,7 +286,7 @@ extension PredicateCodableConfiguration {
         return nil
     }
     
-    func _keyPath(for identifier: String, rootType: Any.Type) -> (AnyKeyPath & Sendable)? {
+    func _keyPath(for identifier: String, rootType: Any.Type) -> AnyKeyPath? {
         guard let value = allowedKeyPaths[identifier] else {
             return nil
         }
@@ -421,7 +418,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E>(_: E.Type) -> AnyKeyPath {
                 \Array<E>.count
             }
             return _openExistential(elementType.swiftType, do: project)
@@ -431,7 +428,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E>(_: E.Type) -> AnyKeyPath {
                 \Array<E>.isEmpty
             }
             return _openExistential(elementType.swiftType, do: project)
@@ -441,7 +438,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E>(_: E.Type) -> AnyKeyPath {
                 \Array<E>.first
             }
             return _openExistential(elementType.swiftType, do: project)
@@ -451,7 +448,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E>(_: E.Type) -> AnyKeyPath {
                 \Array<E>.last
             }
             return _openExistential(elementType.swiftType, do: project)
@@ -463,7 +460,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E: Hashable>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E: Hashable>(_: E.Type) -> AnyKeyPath {
                 \Set<E>.count
             }
             return project(elementType)
@@ -473,7 +470,7 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<E: Hashable>(_: E.Type) -> AnyKeyPath & Sendable {
+            func project<E: Hashable>(_: E.Type) -> AnyKeyPath {
                 \Set<E>.isEmpty
             }
             return project(elementType)
@@ -485,8 +482,8 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<K: Hashable>(_: K.Type) -> AnyKeyPath & Sendable {
-                func project2<V>(_: V.Type) -> AnyKeyPath & Sendable {
+            func project<K: Hashable>(_: K.Type) -> AnyKeyPath {
+                func project2<V>(_: V.Type) -> AnyKeyPath {
                     \Dictionary<K, V>.count
                 }
                 return _openExistential(genericArgs[1].swiftType, do: project2)
@@ -498,8 +495,8 @@ extension PredicateCodableConfiguration {
                 return nil
             }
             
-            func project<K: Hashable>(_: K.Type) -> AnyKeyPath & Sendable {
-                func project2<V>(_: V.Type) -> AnyKeyPath & Sendable {
+            func project<K: Hashable>(_: K.Type) -> AnyKeyPath {
+                func project2<V>(_: V.Type) -> AnyKeyPath {
                     \Dictionary<K, V>.isEmpty
                 }
                 return _openExistential(genericArgs[1].swiftType, do: project2)

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -172,8 +172,7 @@ extension PredicateExpressions {
         arg
     }
     
-    @preconcurrency
-    public static func build_KeyPath<Root, Value>(root: Root, keyPath: Swift.KeyPath<Root.Output, Value> & Sendable) -> PredicateExpressions.KeyPath<Root, Value> {
+    public static func build_KeyPath<Root, Value>(root: Root, keyPath: Swift.KeyPath<Root.Output, Value>) -> PredicateExpressions.KeyPath<Root, Value> {
         KeyPath(root: root, keyPath: keyPath)
     }
 

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -20,8 +20,7 @@ import FoundationEssentials
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct KeyPathComparator<Compared>: SortComparator {
     /// The key path to the property to be used for comparisons.
-    @preconcurrency
-    public let keyPath: PartialKeyPath<Compared> & Sendable
+    public let keyPath: PartialKeyPath<Compared>
 
     public var order: SortOrder {
         get {
@@ -34,7 +33,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
 
     var comparator: AnySortComparator
 
-    private let extractField: @Sendable (Compared) -> Any
+    private let extractField: (Compared) -> Any
 
     /// Get the field at `cachedOffset` if there is one, otherwise
     /// access the field directly through the keypath.
@@ -61,8 +60,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) {
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) {
         self.keyPath = keyPath
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
@@ -99,8 +97,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) {
+    public init<Value: Comparable>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) {
         self.keyPath = keyPath
         if Value.self is String.Type {
 #if FOUNDATION_FRAMEWORK
@@ -133,8 +130,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
-    @preconcurrency
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -159,8 +155,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     /// - Parameters:
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
-    @preconcurrency
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator) where Comparator.Compared == Value {
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -180,8 +175,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(comparator)
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)
@@ -205,8 +199,7 @@ public struct KeyPathComparator<Compared>: SortComparator {
     ///   - keyPath: The key path to the value used for the comparison.
     ///   - comparator: The `SortComparator` used to order values.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?> & Sendable, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
+    public init<Value, Comparator: SortComparator> (_ keyPath: KeyPath<Compared, Value?>, comparator: Comparator, order: SortOrder) where Comparator.Compared == Value {
         self.keyPath = keyPath
         self.comparator = AnySortComparator(OptionalComparator(comparator))
         let cachedOffset = MemoryLayout<Compared>.offset(of: keyPath)

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -18,15 +18,15 @@ import FoundationEssentials
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {    
     /// The set of supported safely serializable comparisons.
-    enum AllowedComparison: Hashable, Codable, Sendable {
+    enum AllowedComparison: Hashable, Codable {
         /// Compare `String` by retrieving from key path, using using the given standard string comparator.
-        case comparableString(String.StandardComparator, KeyPath<Compared, String> & Sendable)
+        case comparableString(String.StandardComparator, KeyPath<Compared, String>)
         
         /// Compare `String?` by retrieving from key path, using using the given standard string comparator.
-        case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?> & Sendable)
+        case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?>)
         
         /// Compares using `Swift.Comparable` implementation.
-        case comparable(AnySortComparator, PartialKeyPath<Compared> & Sendable)
+        case comparable(AnySortComparator, PartialKeyPath<Compared>)
         
 #if FOUNDATION_FRAMEWORK
         /// Compares using the `compare` selector on the given type.
@@ -243,9 +243,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init<Value>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) where Value: Comparable {
+    public init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
         self.comparison = .comparable(
@@ -266,9 +265,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init<Value>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) where Value: Comparable {
+    public init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
         self.comparison = .comparable(
@@ -296,9 +294,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableString(comparator, keyPath)
@@ -316,9 +313,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableOptionalString(comparator, keyPath)
@@ -337,9 +333,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -360,9 +355,8 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -371,21 +365,21 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     }
 #else
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator) {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableString(comparator, keyPath)
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator) {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableOptionalString(comparator, keyPath)
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -394,7 +388,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -414,8 +408,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Bool> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Bool>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -428,8 +421,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Bool?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Bool?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -439,8 +431,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Double> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Double>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -453,8 +444,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Double?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Double?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -464,8 +454,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Float> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Float>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -478,8 +467,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Float?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Float?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -489,8 +477,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int8>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -503,8 +490,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int8?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -515,8 +501,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int16>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -529,8 +514,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int16?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -540,8 +524,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int32>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -554,8 +537,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int32?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -565,8 +547,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int64>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -579,8 +560,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int64?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -590,8 +570,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -604,8 +583,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Int?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Int?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -615,8 +593,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt8>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -629,8 +606,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt8?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -640,8 +616,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt16>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -654,8 +629,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt16?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -665,8 +639,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt32>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -679,8 +652,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt32?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -690,8 +662,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt64>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -704,8 +675,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt64?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -715,8 +685,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -729,8 +698,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UInt?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UInt?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -740,8 +708,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Date> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Date>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -754,8 +721,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, Date?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, Date?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -765,8 +731,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UUID> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UUID>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -779,8 +744,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, UUID?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, UUID?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -793,8 +757,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(
             keyPath,
             comparator: comparator,
@@ -814,8 +777,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(
             keyPath,
             comparator: comparator,
@@ -830,8 +792,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         guard let keyString = keyPath._kvcKeyPathString else {
             fatalError("""
             \(String(describing: Compared.self)) must be introspectable by \
@@ -862,8 +823,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    @preconcurrency
-    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         guard let keyString = keyPath._kvcKeyPathString else {
             fatalError("""
             \(String(describing: Compared.self)) must be introspectable by \

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -70,7 +70,7 @@ final class PredicateCodableTests: XCTestCase {
         var g: [Int]
         var h: Object2
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object> & Sendable] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object>] {
             [
                 "Object.f" : \.f,
                 "Object.g" : \.g,
@@ -85,7 +85,7 @@ final class PredicateCodableTests: XCTestCase {
         var a: Int
         var b: String
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2> & Sendable] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2>] {
             ["Object2.a" : \.a]
         }
     }


### PR DESCRIPTION
We found some ABI stability issues with `Sendable` and `@preconcurrency` adoption in areas where we use key paths. This patch reverts those while we figure out what's going wrong.