### PR TITLE
Fix calloc build failure on macOS

### DIFF
--- a/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
+++ b/Sources/FoundationEssentials/String/StringProtocol+Essentials.swift
@@ -13,6 +13,12 @@
 internal import _ForSwiftFoundation
 #endif
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 // These provides concrete implementations for String and Substring, enhancing performance over generic StringProtocol.
 
 @available(FoundationPreview 0.4, *)


### PR DESCRIPTION
This resolves a build failure on macOS that was accidentally introduced by https://github.com/apple/swift-foundation/pull/670