### PR TITLE
Limit JSONDecoder's fallback Double path to lossless integer range

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
+++ b/Sources/FoundationEssentials/JSON/JSON5Scanner.swift
@@ -1167,7 +1167,7 @@ internal func _parseJSON5Integer<Result: FixedWidthInteger>(
         digitsToParse = digitsToParse.dropFirst(2)
         return _parseHexIntegerDigits(digitsToParse, isNegative: isNegative)
     } else {
-        return _parseIntegerDigits(codeUnits, isNegative: isNegative)
+        return _parseIntegerDigits(digitsToParse, isNegative: isNegative)
     }
 }
 


### PR DESCRIPTION
Hello again, friends!

This patch is the sequel to (#667) that fixes JSONDecoder's Int64 clamping-esque behavior (#613). 

It also fixes a bug in \_parseJSON5Integer(\_:isHex:), which forgot to drop the sign for decimal inputs.