### PR TITLE
Data/copyBytes(to:from:) slice offset fix

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2219,7 +2219,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             guard !r.isEmpty else { return 0 }
             copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.upperBound - r.lowerBound))
         } else {
-            copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt)
+            copyRange = startIndex..<(startIndex + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt))
         }
 
         guard !copyRange.isEmpty else { return 0 }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -444,6 +444,18 @@ class DataTests : XCTestCase {
         }
     }
 
+    func testCopyBytes_fromSubSequenceToGenericBuffer() {
+        let source = Data([1, 3, 5, 7, 9])[1..<3]
+        var destination = Array<UInt8>(repeating: 8, count: 4)
+        
+        destination.withUnsafeMutableBufferPointer {
+            let count = source.copyBytes(to: $0)
+            XCTAssertEqual(count, 2)
+        }
+        
+        XCTAssertEqual(destination, [3, 5, 8, 8])
+    }
+
     func test_genericBuffers() {
         let a : [Int32] = [1, 0, 1, 0, 1]
         var data = a.withUnsafeBufferPointer {


### PR DESCRIPTION
This patch fixes (#638) and adds a regression test.