### PR TITLE
Follow up fix for buffer overflow

### DIFF
--- a/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
+++ b/Sources/FoundationInternationalization/ICU/ICU+Foundation.swift
@@ -104,7 +104,7 @@ internal func _withFixedUCharBuffer(size: Int32 = ULOC_FULLNAME_CAPACITY + ULOC_
 /// Allocate a buffer with `size` `CChar`s and execute the given block.
 /// The closure should return the actual length of the string, or nil if there is an error in the ICU call or the result is zero length.
 internal func _withResizingCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeMutablePointer<CChar>, Int32, inout UErrorCode) -> Int32?) -> String? {
-    withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(initialSize)) {
+    withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(initialSize + 1)) {
         buffer in
         var status = U_ZERO_ERROR
         if let len = body(buffer.baseAddress!, initialSize, &status) {
@@ -114,7 +114,7 @@ internal func _withResizingCharBuffer(initialSize: Int32 = 32, _ body: (UnsafeMu
                     var innerStatus = U_ZERO_ERROR
                     if let innerLen = body(innerBuffer.baseAddress!, len + 1, &innerStatus) {
                         if innerStatus.isSuccess && innerLen > 0 {
-                            buffer[Int(innerLen)] = 0
+                            innerBuffer[Int(innerLen)] = 0
                             return String(validatingUTF8: innerBuffer.baseAddress!)
                         }
                     }

--- a/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
+++ b/Tests/FoundationInternationalizationTests/StringTests+Locale.swift
@@ -143,6 +143,7 @@ final class StringLocaleTests: XCTestCase {
 
         test(nil, "ᾈ", "ᾀ")     // 0x1F88
         test("en", "ᾈ", "ᾀ")
+        test("en", "SOMEVERYVERYVERYVERYVERYVERYVERYVERYVERYLONGSTRING", "someveryveryveryveryveryveryveryveryverylongstring")
         test("el_GR", "ᾈ", "ᾀ")
 
         // Turkik
@@ -153,6 +154,13 @@ final class StringLocaleTests: XCTestCase {
         test(nil, "İİ", "i̇i̇")
         test("en", "İİ", "i̇i̇")
         test("tr", "İİ", "ii")
+    }
+
+    func testFuzzFailure() throws {
+        let input = String(data: Data(base64Encoded: "77+977+977+977+977+977+977+977+977+977+9Cg==")!, encoding: .utf8)!
+        _ = input.lowercased(with: Locale(identifier: "en_US"))
+        _ = input.capitalized(with: Locale(identifier: "en_US"))
+        _ = input.capitalized(with: Locale(identifier: "en_US"))
     }
 }
 


### PR DESCRIPTION
Start the outer buffer with the capacity of `initialSize + 1` so later we can null terminate on the index of `initialSize`, assuming the return length is smaller or equal to `initialSize`. We don't bother to verify the assumption since that'd be a user error.

Also fix a terrible copy-pasta error: We should null-terminate the inner buffer, not the outer buffer.

Fixed 129806508