### PR TITLE
Correct rpaths in cmake files

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -70,6 +70,9 @@ target_link_libraries(FoundationEssentials PUBLIC
     _CShims
     _FoundationCollections)
 
+target_link_options(FoundationEssentials PRIVATE
+    "SHELL:-no-toolchain-stdlib-rpath")
+
 set_target_properties(FoundationEssentials PROPERTIES
     INSTALL_RPATH "$ORIGIN")
 

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -39,6 +39,9 @@ target_link_libraries(FoundationInternationalization PUBLIC
     _CShims
     _FoundationICU)
 
+target_link_options(FoundationInternationalization PRIVATE
+    "SHELL:-no-toolchain-stdlib-rpath")
+
 set_target_properties(FoundationInternationalization PROPERTIES
     INSTALL_RPATH "$ORIGIN")
 

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,6 +43,12 @@ target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntaxBuilder
 )
 
+target_link_options(FoundationMacros PRIVATE
+    "SHELL:-no-toolchain-stdlib-rpath")
+
+set_target_properties(FoundationMacros PROPERTIES
+    INSTALL_RPATH "$ORIGIN")
+
 target_compile_options(FoundationMacros PRIVATE -parse-as-library)
 target_compile_options(FoundationMacros PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"


### PR DESCRIPTION
This fix ensures that `FoundationEssentials`/`FoundationInternationalization`/`FoundationMacros` do not have an rpath entry pointing into the build folder using a setting that we already use on the `main` branch of swift-corelibs-foundation today. Additionally, this adds `$ORIGIN` as an rpath for `FoundationMacros`.

Before this change, we had:

```
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/linux/libFoundationEssentials.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [/Repos/swift-dev/build/buildbot_linux/swift-linux-aarch64/lib/swift/linux:$ORIGIN]
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/linux/libFoundationInternationalization.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [/Repos/swift-dev/build/buildbot_linux/swift-linux-aarch64/lib/swift/linux:$ORIGIN]
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/host/plugins/libFoundationMacros.so | grep RUNPATH       
 0x000000000000001d (RUNPATH)            Library runpath: [/Repos/swift-dev/build/buildbot_linux/swift-linux-aarch64/lib/swift/linux]
```

But with this change we now have:

```
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/linux/libFoundationEssentials.so | grep RUNPATH                                                                                                 
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/linux/libFoundationInternationalization.so | grep RUNPATH   
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d swift-nightly-install/usr/lib/swift/host/plugins/libFoundationMacros.so | grep RUNPATH       
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```

Which matches the rpath in the existing Swift toolchain:

```
root@swift-ci-ubuntu-22:/Repos/swift-dev/swift# readelf -d /opt/swift/5.8.1/usr/lib/swift/linux/libFoundation.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```