### PR TITLE
Install _CShims in static swift build

### DIFF
--- a/Sources/_CShims/CMakeLists.txt
+++ b/Sources/_CShims/CMakeLists.txt
@@ -33,3 +33,11 @@ install(DIRECTORY
         DESTINATION
             lib/${install_directory}/_CShims)
 
+if(NOT BUILD_SHARED_LIBS)
+    get_swift_host_os(swift_os)
+    install(TARGETS _CShims
+        ARCHIVE DESTINATION lib/${install_directory}/${swift_os}
+        LIBRARY DESTINATION lib/${install_directory}/${swift_os}
+        RUNTIME DESTINATION bin)
+endif()
+


### PR DESCRIPTION
For the static swift build, we need to install not only the shared libraries but also the static libraries that we need to link against. swift-foundation only has one such library (_CShims) so this adds an additional install step to install _CShims for only the static swift build (it gets statically linked into the `FoundationEssentials` and `FoundationInternationalization` shared libraries in the non-static build)