### PR TITLE
[CMake] Autolink static libraries for foundation_static build

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -70,6 +70,13 @@ target_link_libraries(FoundationEssentials PUBLIC
     _CShims
     _FoundationCollections)
 
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CShims>")
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCollections>")
+endif()
+
 target_link_options(FoundationEssentials PRIVATE
     "SHELL:-no-toolchain-stdlib-rpath")
 

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -39,6 +39,13 @@ target_link_libraries(FoundationInternationalization PUBLIC
     _CShims
     _FoundationICU)
 
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_options(FoundationInternationalization PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CShims>")
+    target_compile_options(FoundationInternationalization PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
+endif()
+
 target_link_options(FoundationInternationalization PRIVATE
     "SHELL:-no-toolchain-stdlib-rpath")
 


### PR DESCRIPTION
For private dependencies, the compiler needs to know to link the extra static libraries when building against the static stdlib. These extra flags ensure that when linking against `libFoundationEssentials.a` that the compiler also links `lib_CShims.a` and `lib_FoundationCollections.a` and that when linking against `libFoundationInternationalization.a` that the compiler also links `lib_CShims.a` and `lib_FoundatonICU.a`