### PR TITLE
Decimal.init(string:) should return nil for invalid Decimal strings

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -345,6 +345,11 @@ extension Decimal {
                 return nil
             }
         }
+        if index == stringView.startIndex {
+            // If we weren't able to process any character
+            // the entire string isn't a valid decimal
+            return nil
+        }
         result.compact()
         // if we get to this point, and have NaN,
         // then the input string was probably "-0"

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -258,4 +258,14 @@ final class DecimalTests : XCTestCase {
         XCTAssertNotNil(decimal)
         XCTAssertEqual(decimal!.description, "3.14")
     }
+
+    func testStringNoMatch() {
+        // This test makes sure Decimal returns nil
+        // if the does not start with a number
+        var notDecimal = Decimal(string: "A Flamingo's head has to be upside down when it eats.")
+        XCTAssertNil(notDecimal)
+        // Same if the number does not appear at the beginning
+        notDecimal = Decimal(string: "Jump 22 Street")
+        XCTAssertNil(notDecimal)
+    }
 }


### PR DESCRIPTION
For binary compatibility, `Decimal.init(string:)` should return `nil` instead of `0` for totally invalid Decimal strings. 

resolves: rdar://130209835