### PR TITLE
Ensure EOPNOTSUPP thrown via Data reading from a socket does not crash

### DIFF
--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -89,12 +89,16 @@ extension CocoaError {
     // MARK: Error Creation with errno
     
     private static func _errorWithErrno(_ errno: Int32, reading: Bool, variant: String?, userInfo: [String : AnyHashable]) -> CocoaError {
-        guard let code = POSIXError.Code(rawValue: errno) else {
-            fatalError("Invalid posix errno \(errno)")
-        }
-        
         var userInfo = userInfo
-        userInfo[NSUnderlyingErrorKey] = POSIXError(code)
+        
+        // (130280235) POSIXError.Code does not have a case for EOPNOTSUPP
+        if errno != EOPNOTSUPP {
+            guard let code = POSIXError.Code(rawValue: errno) else {
+                fatalError("Invalid posix errno \(errno)")
+            }
+            
+            userInfo[NSUnderlyingErrorKey] = POSIXError(code)
+        }
         if let variant {
             userInfo[NSUserStringVariantErrorKey] = [variant]
         }

--- a/Tests/FoundationEssentialsTests/DataTests.swift
+++ b/Tests/FoundationEssentialsTests/DataTests.swift
@@ -1831,6 +1831,17 @@ extension DataTests {
         dataII.replaceSubrange(0..<1, with: Data())
         XCTAssertEqual(dataII[0], 0x02)
     }
+    
+    func testEOPNOTSUPP() throws {
+        #if !canImport(Darwin) && !os(Linux)
+        throw XCTSkip("POSIXError.Code is not supported on this platform")
+        #else
+        // Opening a socket via open(2) on Darwin can result in the EOPNOTSUPP error code
+        // Validate that this does not crash despite missing a case in POSIXError.Code
+        let error = CocoaError.errorWithFilePath("/foo/bar", errno: EOPNOTSUPP, reading: true)
+        XCTAssertEqual(error.filePath, "/foo/bar")
+        #endif
+    }
 }
 
 #if FOUNDATION_FRAMEWORK // FIXME: Re-enable tests once range(of:) is implemented


### PR DESCRIPTION
On some platforms like Darwin, attempting to read `Data` from a path representing a socket can cause the `EOPNOTSUPP` error to be thrown, but `POSIXError.Code` is missing a case for this errno so we hit an assertion failure in our code. This patch works around this case to avoid the crash by dropping the posix info from the produced error while still asserting for other invalid errno's to catch cases where we incorrectly capture `errno`