### PR TITLE
[CMake] Update CMake build to account for _CShims --> _FoundationCShims rename

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -12,7 +12,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_subdirectory(_CShims)
+add_subdirectory(_FoundationCShims)
 add_subdirectory(FoundationMacros)
 add_subdirectory(FoundationEssentials)
 add_subdirectory(FoundationInternationalization)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -67,12 +67,12 @@ target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_availabil
 target_compile_options(FoundationEssentials PRIVATE -package-name "SwiftFoundation")
 
 target_link_libraries(FoundationEssentials PUBLIC
-    _CShims
+    _FoundationCShims
     _FoundationCollections)
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CShims>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCShims>")
     target_compile_options(FoundationEssentials PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCollections>")
 endif()

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -36,12 +36,12 @@ target_compile_options(FoundationInternationalization PRIVATE -package-name "Swi
 
 target_link_libraries(FoundationInternationalization PUBLIC
     FoundationEssentials
-    _CShims
+    _FoundationCShims
     _FoundationICU)
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationInternationalization PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CShims>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCShims>")
     target_compile_options(FoundationInternationalization PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
 endif()

--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -12,14 +12,14 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_library(_CShims STATIC
+add_library(_FoundationCShims STATIC
     platform_shims.c
     string_shims.c
     uuid.c)
 
-target_include_directories(_CShims PUBLIC include)
+target_include_directories(_FoundationCShims PUBLIC include)
 
-set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _CShims)
+set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _FoundationCShims)
 
 if(BUILD_SHARED_LIBS)
     set(install_directory swift)
@@ -31,11 +31,11 @@ endif()
 install(DIRECTORY
             include/
         DESTINATION
-            lib/${install_directory}/_CShims)
+            lib/${install_directory}/_FoundationCShims)
 
 if(NOT BUILD_SHARED_LIBS)
     get_swift_host_os(swift_os)
-    install(TARGETS _CShims
+    install(TARGETS _FoundationCShims
         ARCHIVE DESTINATION lib/${install_directory}/${swift_os}
         LIBRARY DESTINATION lib/${install_directory}/${swift_os}
         RUNTIME DESTINATION bin)


### PR DESCRIPTION
Now that `_CShims` has been renamed to `_FoundationCShims`, we need to update the cmake files to account for this rename