### PR TITLE
Slices of no copy Data bridged to and back incorrectly account for the start index

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -817,6 +817,11 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         static func canStore(count: Int) -> Bool {
             return count < HalfInt.max
         }
+        
+        @inlinable // This is @inlinable as trivially computable.
+        static func canStore(range: Range<Int>) -> Bool {
+            return range.lowerBound < HalfInt.max && range.upperBound < HalfInt.max
+        }
 
         @inlinable // This is @inlinable as a convenience initializer.
         init(_ buffer: UnsafeRawBufferPointer) {
@@ -1375,7 +1380,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
                 self = .empty
             } else if range.startIndex == 0 {
                 self.init(storage, count: range.count)
-            } else if InlineSlice.canStore(count: range.count) {
+            } else if InlineSlice.canStore(range: range) {
                 self = .slice(InlineSlice(storage, range: range))
             } else {
                 self = .large(LargeSlice(storage, range: range))

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -1120,6 +1120,12 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             self.storage = storage
             self.slice = RangeReference(0..<count)
         }
+        
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, range: Range<Int>) {
+            self.storage = storage
+            self.slice = RangeReference(range)
+        }
 
         @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
         mutating func ensureUniqueReference() {
@@ -1360,6 +1366,19 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
                 self = .slice(InlineSlice(storage, count: count))
             } else {
                 self = .large(LargeSlice(storage, count: count))
+            }
+        }
+        
+        @inlinable
+        init(_ storage: __DataStorage, range: Range<Int>) {
+            if range.count == 0 {
+                self = .empty
+            } else if range.startIndex == 0 {
+                self.init(storage, count: range.count)
+            } else if InlineSlice.canStore(count: range.count) {
+                self = .slice(InlineSlice(storage, range: range))
+            } else {
+                self = .large(LargeSlice(storage, range: range))
             }
         }
 


### PR DESCRIPTION
when bridging back from objc the start index was not correctly re-constructed into the slices of no copy datas. This adds functionality for that.

resolves rdar://130106808