### PR TITLE
[CMake] Copy headers to known directory for direct client test builds

### DIFF
--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -27,6 +27,12 @@ else()
     set(install_directory swift_static)
 endif()
 
+# Copy Headers to known directory for direct client (XCTest) test builds
+file(COPY
+        include/
+    DESTINATION
+        ${CMAKE_BINARY_DIR}/_CModulesForClients/_FoundationCShims)
+
 # Install headers
 install(DIRECTORY
             include/


### PR DESCRIPTION
This copies the public headers to a known location in the build tree so that direct clients (before installation) can specify that directory as an include path when not building via a CMake dependency