### PR TITLE
FoundationCShims: introduce `TARGET_OS_ANDROID`

### DIFF
--- a/Sources/_FoundationCShims/include/_CShimsTargetConditionals.h
+++ b/Sources/_FoundationCShims/include/_CShimsTargetConditionals.h
@@ -47,4 +47,10 @@
 #define TARGET_OS_WASI 0
 #endif
 
+#if defined(__ANDROID__)
+#define TARGET_OS_ANDROID 1
+#else
+#define TARGET_OS_ANDROID 0
+#endif
+
 #endif // _C_SHIMS_TARGET_CONDITIONALS_H


### PR DESCRIPTION
Add the target conditional to identify android which is required to enable the package to build for Android.