### PR TITLE
FoundationEssentials: initial pass to add Android support

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 internal import os
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(CRT)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -12,6 +12,8 @@
 
 #if canImport(os)
 internal import os
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(CRT)

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -18,6 +18,8 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -19,6 +19,9 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
+import unistd
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -17,8 +17,15 @@
 @usableFromInline let memset = ucrt.memset
 @usableFromInline let memcpy = ucrt.memcpy
 @usableFromInline let memcmp = ucrt.memcmp
-#endif
-#if canImport(Glibc)
+#elseif os(Android)
+import Bionic
+@usableFromInline let calloc = Bionic.calloc
+@usableFromInline let malloc = Bionic.malloc
+@usableFromInline let free = Bionic.free
+@usableFromInline let memset = Bionic.memset
+@usableFromInline let memcpy = Bionic.memcpy
+@usableFromInline let memcmp = Bionic.memcmp
+#elseif canImport(Glibc)
 @usableFromInline let calloc = Glibc.calloc
 @usableFromInline let malloc = Glibc.malloc
 @usableFromInline let free = Glibc.free

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WinSDK)

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -15,6 +15,8 @@ internal import _ForSwiftFoundation
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -10,7 +10,9 @@
  //===----------------------------------------------------------------------===//
 
 // Import for POSIXErrorCode
-#if canImport(Glibc)
+#if os(Android)
+import Android
+#elseif canImport(Glibc)
 @preconcurrency import Glibc 
 #elseif canImport(Darwin)
 @preconcurrency import Darwin

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -18,6 +18,9 @@ internal import os
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
+import unistd
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -17,6 +17,9 @@ internal import DarwinPrivate.sys.content_protection
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
+import posix_filesystem
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -12,6 +12,9 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
+import unistd
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -23,6 +23,8 @@ internal import QuarantinePrivate
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -109,6 +109,9 @@ struct _Win32DirectoryContentsSequence: Sequence {
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
+import posix_filesystem.dirent
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims
@@ -315,7 +318,7 @@ extension Sequence<_FTSSequence.Element> {
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)
     typealias DirectoryEntryPtr = UnsafeMutablePointer<DIR>
-    #elseif canImport(Glibc)
+    #elseif os(Android) || canImport(Glibc)
     typealias DirectoryEntryPtr = OpaquePointer
     #endif
     

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -15,6 +15,8 @@ internal import os
 #if FOUNDATION_FRAMEWORK && canImport(C.os.lock)
 internal import C.os.lock
 #endif
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WinSDK)
@@ -27,7 +29,7 @@ package struct LockedState<State> {
     private struct _Lock {
 #if canImport(os)
         typealias Primitive = os_unfair_lock
-#elseif canImport(Glibc)
+#elseif os(Android) || canImport(Glibc)
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
         typealias Primitive = SRWLOCK
@@ -39,7 +41,7 @@ package struct LockedState<State> {
         fileprivate static func initialize(_ platformLock: PlatformLock) {
 #if canImport(os)
             platformLock.initialize(to: os_unfair_lock())
-#elseif canImport(Glibc)
+#elseif os(Android) || canImport(Glibc)
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
@@ -47,7 +49,7 @@ package struct LockedState<State> {
         }
 
         fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-#if canImport(Glibc)
+#if os(Android) || canImport(Glibc)
             pthread_mutex_destroy(platformLock)
 #endif
             platformLock.deinitialize(count: 1)
@@ -56,7 +58,7 @@ package struct LockedState<State> {
         static fileprivate func lock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_lock(platformLock)
-#elseif canImport(Glibc)
+#elseif os(Android) || canImport(Glibc)
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
@@ -66,7 +68,7 @@ package struct LockedState<State> {
         static fileprivate func unlock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_unlock(platformLock)
-#elseif canImport(Glibc)
+#elseif os(Android) || canImport(Glibc)
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -14,6 +14,9 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
+import unistd
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)
@@ -158,7 +161,7 @@ final class _ProcessInfo: Sendable {
     }
 
     var userName: String {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
         // Darwin and Linux
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
@@ -193,7 +196,7 @@ final class _ProcessInfo: Sendable {
     }
 
     var fullUserName: String {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
            let fullname = upwd.pointee.pw_gecos {

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 internal import os
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import unistd
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(ucrt)

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -11,6 +11,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WinSDK)
@@ -22,7 +24,7 @@ internal import threads
 #endif
 
 struct _ThreadLocal {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
     fileprivate typealias PlatformKey = pthread_key_t
 #elseif USE_TSS
     fileprivate typealias PlatformKey = tss_t
@@ -34,7 +36,7 @@ struct _ThreadLocal {
         fileprivate let key: PlatformKey
         
         init() {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
             var key = PlatformKey()
             pthread_key_create(&key, nil)
             self.key = key
@@ -50,7 +52,7 @@ struct _ThreadLocal {
     
     private static subscript(_ key: PlatformKey) -> UnsafeMutableRawPointer? {
         get {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
             pthread_getspecific(key)
 #elseif USE_TSS
             tss_get(key)
@@ -60,7 +62,7 @@ struct _ThreadLocal {
         }
         
         set {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc)
             pthread_setspecific(key, newValue)
 #elseif USE_TSS
             tss_set(key, newValue)


### PR DESCRIPTION
This adds the necessary guards and includes for the Android modules. While the module does not compile currently due to nullability differences (and in some cases missing declarations), this at least brings the module to a point where we can start working on the errors and differences to create a maintainable codebase for Android.