### PR TITLE
FoundationEssentials: make build on Android

### DIFF
--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -11,7 +11,7 @@
 
 // Import for POSIXErrorCode
 #if os(Android)
-import Android
+@preconcurrency import Android
 #elseif canImport(Glibc)
 @preconcurrency import Glibc 
 #elseif canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -165,8 +165,8 @@ struct _FTSSequence: Sequence {
                 state = .error(errno, String(cString: path))
                 return
             }
-            
-            state = [UnsafeMutablePointer(mutating: path), nil].withUnsafeBufferPointer{ dirList in
+
+            state = [UnsafeMutablePointer(mutating: path), nil].withUnsafeBufferPointer { dirList in
                 guard let stream = fts_open(dirList.baseAddress!, opts, nil) else {
                     return .error(errno, String(cString: path))
                 }
@@ -299,13 +299,13 @@ extension Sequence<_FTSSequence.Element> {
                 case FTS_NSOK: fallthrough      // No stat(2) information was requested, but that's OK.
                 case FTS_SL: fallthrough        // Symlink.
                 case FTS_SLNONE:                // Symlink with no target.
-                    return .entry(String(cString: ent.ftsEnt.fts_path))
+                    return .entry(String(cString: ent.ftsEnt.fts_path!))
                     
                 // Error returns
                 case FTS_DNR: fallthrough   // Directory cannot be read.
                 case FTS_ERR: fallthrough   // Some error occurred, but we don't know what.
                 case FTS_NS:                // No stat(2) information is available.
-                    let path = String(cString: ent.ftsEnt.fts_path)
+                    let path = String(cString: ent.ftsEnt.fts_path!)
                     return .error(ent.ftsEnt.fts_errno, path)
                     
                 default: return nil

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -520,13 +520,14 @@ enum _FileOperations {
                 throw CocoaError.removeFileError(err, errPath)
                 
             case let .entry(entry):
+                let fts_path = entry.ftsEnt.fts_path!
                 switch Int32(entry.ftsEnt.fts_info) {
                 case FTS_DEFAULT, FTS_F, FTS_NSOK, FTS_SL, FTS_SLNONE:
-                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    let currentPathStr = resolve(path: String(cString: fts_path))
                     guard fileManager?._shouldRemoveItemAtPath(currentPathStr) ?? true else {
                         break
                     }
-                    if unlink(entry.ftsEnt.fts_path) != 0 {
+                    if unlink(fts_path) != 0 {
                         let error = CocoaError.removeFileError(errno, currentPathStr)
                         if !(fileManager?._shouldProceedAfter(error: error, removingItemAtPath: currentPathStr) ?? false) {
                             throw error
@@ -538,20 +539,20 @@ enum _FileOperations {
                         isFirst = false
                         break
                     }
-                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    let currentPathStr = resolve(path: String(cString: fts_path))
                     if !(fileManager?._shouldRemoveItemAtPath(currentPathStr) ?? true) {
                         iterator.skipDescendants(of: entry, skipPostProcessing: true)
                     }
                 case FTS_DP:
-                    if rmdir(entry.ftsEnt.fts_path) != 0 {
-                        let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    if rmdir(fts_path) != 0 {
+                        let currentPathStr = resolve(path: String(cString: fts_path))
                         let error = CocoaError.removeFileError(errno, currentPathStr)
                         if !(fileManager?._shouldProceedAfter(error: error, removingItemAtPath: currentPathStr) ?? false) {
                             throw error
                         }
                     }
                 case FTS_DNR, FTS_ERR, FTS_NS:
-                    let currentPathStr = resolve(path: String(cString: entry.ftsEnt.fts_path))
+                    let currentPathStr = resolve(path: String(cString: fts_path))
                     throw CocoaError.removeFileError(entry.ftsEnt.fts_errno, currentPathStr)
                 default:
                     break
@@ -866,12 +867,12 @@ enum _FileOperations {
             return
         }
         
-        let total = fileInfo.st_size
-        let chunkSize = Int(fileInfo.st_blksize)
-        var current = 0
+        let total: Int = Int(fileInfo.st_size)
+        let chunkSize: Int = Int(fileInfo.st_blksize)
+        var current: off_t = 0
         
         while current < total {
-            guard sendfile(dstfd, srcfd, &current, Swift.min(total - current, chunkSize)) != -1 else {
+            guard sendfile(dstfd, srcfd, &current, Swift.min(total - Int(current), chunkSize)) != -1 else {
                 try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
                 return
             }
@@ -894,11 +895,12 @@ enum _FileOperations {
                     throw CocoaError.errorWithFilePath(path, errno: errno, reading: true)
                     
                 case let .entry(entry):
-                    let trimmedPathPtr = entry.ftsEnt.fts_path.advanced(by: srcLen)
+                    let fts_path = entry.ftsEnt.fts_path!
+                    let trimmedPathPtr = fts_path.advanced(by: srcLen)
                     Platform.copyCString(dst: dstAppendPtr, src: trimmedPathPtr, size: remainingBuffer)
                     
                     // we don't want to ask the delegate on the way back -up- the hierarchy if they want to copy a directory they've already seen and therefore already said "YES" to.
-                    guard entry.ftsEnt.fts_info == FTS_DP || delegate.shouldPerformOnItemAtPath(String(cString: entry.ftsEnt.fts_path), to: String(cString: buffer.baseAddress!)) else {
+                    guard entry.ftsEnt.fts_info == FTS_DP || delegate.shouldPerformOnItemAtPath(String(cString: fts_path), to: String(cString: buffer.baseAddress!)) else {
                         if entry.ftsEnt.fts_info == FTS_D {
                             iterator.skipDescendants(of: entry, skipPostProcessing: true)
                         }
@@ -911,29 +913,29 @@ enum _FileOperations {
                     case FTS_D:
                         // Directory being visited in pre-order - create it with whatever default perms will be on the destination.
                         #if canImport(Darwin)
-                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_DATA | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
-                            try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                        if copyfile(fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_DATA | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                            try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #else
                         do {
                             try fileManager.createDirectory(atPath: String(cString: buffer.baseAddress!), withIntermediateDirectories: true)
                         } catch {
-                            try delegate.throwIfNecessary(error, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                            try delegate.throwIfNecessary(error, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #endif
                         
                     case FTS_DP:
                         // Directory being visited in post-order - copy the permissions over.
                         #if canImport(Darwin)
-                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_METADATA | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
-                            try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                        if copyfile(fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_METADATA | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                            try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #else
                         do {
-                            let attributes = try fileManager.attributesOfItem(atPath: String(cString: entry.ftsEnt.fts_path))
+                            let attributes = try fileManager.attributesOfItem(atPath: String(cString: fts_path))
                             try fileManager.setAttributes(attributes, ofItemAtPath: String(cString: buffer.baseAddress!))
                         } catch {
-                            try delegate.throwIfNecessary(error, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                            try delegate.throwIfNecessary(error, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #endif
                         
@@ -947,18 +949,18 @@ enum _FileOperations {
                         } else {
                             flags = COPYFILE_DATA | COPYFILE_METADATA | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags
                         }
-                        if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(flags)) != 0 {
-                            try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                        if copyfile(fts_path, buffer.baseAddress!, nil, copyfile_flags_t(flags)) != 0 {
+                            try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #else
                         try withUnsafeTemporaryAllocation(of: CChar.self, capacity: FileManager.MAX_PATH_SIZE) { tempBuff in
                             tempBuff.initialize(repeating: 0)
                             defer { tempBuff.deinitialize() }
-                            let len = readlink(entry.ftsEnt.fts_path, tempBuff.baseAddress!, FileManager.MAX_PATH_SIZE - 1)
+                            let len = readlink(fts_path, tempBuff.baseAddress!, FileManager.MAX_PATH_SIZE - 1)
                             if len >= 0, symlink(tempBuff.baseAddress!, buffer.baseAddress!) != -1 {
                                 return
                             }
-                            try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                            try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         }
                         #endif
                         
@@ -966,15 +968,15 @@ enum _FileOperations {
                     case FTS_F:                     // Regular file.
                         if delegate.copyData {
                             #if canImport(Darwin)
-                            if copyfile(entry.ftsEnt.fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_CLONE | COPYFILE_ALL | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
-                                try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                            if copyfile(fts_path, buffer.baseAddress!, nil, copyfile_flags_t(COPYFILE_CLONE | COPYFILE_ALL | COPYFILE_EXCL | COPYFILE_NOFOLLOW | extraFlags)) != 0 {
+                                try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                             }
                             #else
-                            try Self._copyRegularFile(entry.ftsEnt.fts_path, buffer.baseAddress!, delegate: delegate)
+                            try Self._copyRegularFile(fts_path, buffer.baseAddress!, delegate: delegate)
                             #endif
                         } else {
-                            if link(entry.ftsEnt.fts_path, buffer.baseAddress!) != 0 {
-                                try delegate.throwIfNecessary(errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                            if link(fts_path, buffer.baseAddress!) != 0 {
+                                try delegate.throwIfNecessary(errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                             }
                         }
                         
@@ -982,7 +984,7 @@ enum _FileOperations {
                     case FTS_DNR: fallthrough   // Directory cannot be read.
                     case FTS_ERR: fallthrough   // Some error occurred, but we don't know what.
                     case FTS_NS:                // No stat(2) information is available.
-                        try delegate.throwIfNecessary(entry.ftsEnt.fts_errno, String(cString: entry.ftsEnt.fts_path), String(cString: buffer.baseAddress!))
+                        try delegate.throwIfNecessary(entry.ftsEnt.fts_errno, String(cString: fts_path), String(cString: buffer.baseAddress!))
                         
                     default: break
                     }


### PR DESCRIPTION
This adjusts the API usage to account for differences on Android. The biggest source of difference is the nullability, particularly in the `fts` APIs. Unfortunately, `MMAP_FAILED` is not imported by the clang importer due to the casting involved so we manually inline the constant at the single site.