### PR TITLE
[Windows] Fix Int32(bitPattern:) call failure

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -138,7 +138,7 @@ final class _ProcessInfo: Sendable {
 
     var processIdentifier: Int32 {
 #if os(Windows)
-        return Int32(GetProcessId(GetCurrentProcess()))
+        return Int32(bitPattern: UInt32(GetProcessId(GetCurrentProcess())))
 #else
         return Int32(getpid())
 #endif

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -138,7 +138,7 @@ final class _ProcessInfo: Sendable {
 
     var processIdentifier: Int32 {
 #if os(Windows)
-        return Int32(bitPattern: GetProcessId(GetCurrentProcess()))
+        return Int32(GetProcessId(GetCurrentProcess()))
 #else
         return Int32(getpid())
 #endif


### PR DESCRIPTION
The Windows toolchain build for x86 was failing with:

```
C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\swift-foundation\Sources\FoundationEssentials\ProcessInfo\ProcessInfo.swift:141:34: error: cannot convert value of type 'DWORD' (aka 'UInt') to expected argument type 'UInt32'
139 |     var processIdentifier: Int32 {
140 | #if os(Windows)
141 |         return Int32(bitPattern: GetProcessId(GetCurrentProcess()))
    |                                  `- error: cannot convert value of type 'DWORD' (aka 'UInt') to expected argument type 'UInt32'
142 | #else
143 |         return Int32(getpid())
```

[In SCL-F](https://github.com/apple/swift-corelibs-foundation/blob/ca3669eb9ac282c649e71824d9357dbe140c8251/Sources/Foundation/ProcessInfo.swift#L75) we just call `Int32(GetProcessId(GetCurrentProcess()))` instead which works so this changes the swift-foundation implementation to do the same so that it is compatible across architectures.