### PR TITLE
[CMake] Include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ list(APPEND _SwiftFoundation_availability_macros
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.3:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=FoundationPredicateRegex 0.4:macOS 10000, iOS 10000, tvOS 10000, watchOS 10000\">")
 
+include(GNUInstallDirs)
 include(SwiftFoundationSwiftSupport)
 
 add_subdirectory(Sources)


### PR DESCRIPTION
The GNUInstallDirs module sets CMAKE_INSTALL_BINDIR which is used on Windows as the destination for installed .dll files. This addresses issues that I saw when building a Windows toolchain where the .dll files were not installed into the toolchain previously, but with this change are correctly installed into the bin directory.