### PR TITLE
FoundationInternationalization: add `Android` imports

### DIFF
--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -14,7 +14,9 @@
 import FoundationEssentials
 #endif
 
-#if canImport(Glibc)
+#if os(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -15,7 +15,9 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
-#if canImport(Glibc)
+#if os(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -18,6 +18,8 @@ internal import _FoundationICU
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -16,6 +16,8 @@ import FoundationEssentials
 
 #if canImport(Darwin)
 import Darwin
+#elseif os(Android)
+import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)


### PR DESCRIPTION
This adds the missing imports for Android and enables building for Android.