### PR TITLE
Use .mappedIfSafe in DataIOTests.test_largeFile

### DIFF
--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -209,19 +209,19 @@ class DataIOTests : XCTestCase {
         let data = generateTestData(count: size)
         
         try data.write(to: url)
-        let read = try! Data(contentsOf: url)
-        
+        let read = try! Data(contentsOf: url, options: .mappedIfSafe)
+
         // No need to compare the contents, but do compare the size
         XCTAssertEqual(data.count, read.count)
         
 #if FOUNDATION_FRAMEWORK
         // Try the NSData path
-        let readNS = try! NSData(contentsOf: url) as Data
+        let readNS = try! NSData(contentsOf: url, options: .mappedIfSafe) as Data
         XCTAssertEqual(data.count, readNS.count)
 #endif
 
         cleanup(at: url)
-#endif
+#endif // !os(watchOS)
     }
     
     func test_writeToSpecialFile() throws {


### PR DESCRIPTION
DataIOTests.test_largeFile reads a larger than 2GB file twice into the memory. Adding `.mappedIfSafe` option when reading Data to prevent the test getting killed due to memory usage.

resolves: rdar://130769047