### PR TITLE
[CMake] Update swift-collections to 1.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (_SwiftCollections_SourceDIR)
 else()
     FetchContent_Declare(SwiftCollections
         GIT_REPOSITORY https://github.com/apple/swift-collections.git
-        GIT_TAG 1.1.1)
+        GIT_TAG 1.1.2)
 endif()
 FetchContent_MakeAvailable(SwiftFoundationICU SwiftCollections)
 


### PR DESCRIPTION
swift-collections v1.1.2 has a handful of CMake changes necessary for the swift-foundation build. This won't impact the swift toolchain build, but will update the version of swift-collections used when building swift-foundation in isolation and fetching swift-collections via dependency management.