### PR TITLE
[CMake] Add Locale_Notifications.swift

### DIFF
--- a/Sources/FoundationEssentials/Locale/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Locale/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(FoundationEssentials PRIVATE
     Locale.swift
     Locale_Autoupdating.swift
     Locale_Cache.swift
+    Locale_Notifications.swift
     Locale_Preferences.swift
     Locale_Protocol.swift
     Locale_Unlocalized.swift)


### PR DESCRIPTION
This adds a forgotten file to the `CMakeLists.txt` file to get the CMake build working again