### PR TITLE
Fix AttributedString slicing behavior on range expressions

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributedString.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString.swift
@@ -292,8 +292,9 @@ extension AttributedString {
 
     public mutating func replaceSubrange(_ range: some RangeExpression<Index>, with s: some AttributedStringProtocol) {
         ensureUniqueReference()
-        // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
-        let subrange = range.relative(to: unicodeScalars)._bstringRange
+        // Note: slicing generally allows sub-Character ranges, but we need to resolve range
+        // expressions using the characters view, to remain consistent with the stdlib.
+        let subrange = range.relative(to: characters)._bstringRange
         _guts.replaceSubrange(subrange, with: s)
     }
 }
@@ -327,14 +328,16 @@ extension AttributedString {
 extension AttributedString {
     public subscript(bounds: some RangeExpression<Index>) -> AttributedSubstring {
         get {
-            // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
-            let bounds = bounds.relative(to: unicodeScalars)
+            // Note: slicing generally allows sub-Character ranges, but we need to resolve range
+            // expressions using the characters view, to remain consistent with the stdlib.
+            let bounds = bounds.relative(to: characters)
             return AttributedSubstring(_guts, in: bounds._bstringRange)
         }
         _modify {
             ensureUniqueReference()
-            // Note: we allow sub-Character ranges, so we must use `unicodeScalars` here, not `characters`.
-            let bounds = bounds.relative(to: unicodeScalars)
+            // Note: slicing generally allows sub-Character ranges, but we need to resolve range
+            // expressions using the characters view, to remain consistent with the stdlib.
+            let bounds = bounds.relative(to: characters)
             var substr = AttributedSubstring(_guts, in: bounds._bstringRange)
             let ident = Self._nextModifyIdentity
             substr._identity = ident
@@ -348,6 +351,10 @@ extension AttributedString {
             yield &substr
         }
         set {
+            // Note: slicing generally allows sub-Character ranges, but we need to resolve range
+            // expressions using the characters view, to remain consistent with the stdlib.
+            let bounds = bounds.relative(to: characters)
+
             // FIXME: Why is this allowed if _modify traps on replacement?
             self.replaceSubrange(bounds, with: newValue)
         }


### PR DESCRIPTION
`AttributedString` goes out of its way to emulate the stdlib’s behavior for `String` slicing. Unfortunately, it went a little overboard:

```swift
import Foundation

let str1 = "F\u{301}a\u{308}n\u{303}c\u{327}y\u{30a}" // "F́äñçẙ"
let str2 = AttributedString(str1)

let substr1 = str1[...str1.startIndex] // “F\u{301}”
let substr2 = str2[...str2.startIndex] // “F”
```

We expect slicing on range expressions to always produce  consistent results between `String` and `AttributedString`.

When slicing character-based string views on `…str.startIndex`, we naturally expect the range expression to cover the entire first `Character`, and that is precisely what `String` does.

`AttributedString`’s default view is not as obviously `Character`-based as `String` is, but emulating the stdlib’s behavior is much preferable than to allow such simple, character-aligned range expressions to slice the attributed string at random sub-character positions.

rdar://129804049