### PR TITLE
[Windows] Standardize slashes before path processing

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -29,7 +29,11 @@ extension StringProtocol {
         // Standardize the path to use forward slashes before processing for consistency
         return self.replacing(._backslash, with: ._slash)
         #else
-        return String(self)
+        if let str = _specializingCast(self, to: String.self) {
+            return str
+        } else {
+            return String(self)
+        }
         #endif
     }
 }

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -473,15 +473,11 @@ extension String {
     // From swift-corelibs-foundation's NSTemporaryDirectory. Internal for now, pending a better public API.
     internal static var temporaryDirectoryPath: String {
         func normalizedPath(with path: String) -> String {
-            guard path.utf8.last != ._slash else {
-                return path
+            var result = path._standardizingSlashes()
+            guard result.utf8.last != ._slash else {
+                return result
             }
-            #if os(Windows)
-            guard path.utf8.last != ._backslash else {
-                return path
-            }
-            #endif
-            return path + "/"
+            return result + "/"
         }
 #if os(Windows)
         let cchLength: DWORD = GetTempPathW(0, nil)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -282,10 +282,16 @@ final class FileManagerTests : XCTestCase {
             try $0.createDirectory(atPath: "create_dir_test2/nested2", withIntermediateDirectories: true)
             XCTAssertEqual(try $0.contentsOfDirectory(atPath: "create_dir_test2").sorted(), ["nested", "nested2"])
             XCTAssertNoThrow(try $0.createDirectory(atPath: "create_dir_test2/nested2", withIntermediateDirectories: true))
+            
+            #if os(Windows)
+            try $0.createDirectory(atPath: "create_dir_test3\\nested", withIntermediateDirectories: true)
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "create_dir_test3"), ["nested"])
+            #endif
+            
             XCTAssertThrowsError(try $0.createDirectory(atPath: "create_dir_test", withIntermediateDirectories: false)) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
             }
-            XCTAssertThrowsError(try $0.createDirectory(atPath: "create_dir_test3/nested", withIntermediateDirectories: false)) {
+            XCTAssertThrowsError(try $0.createDirectory(atPath: "create_dir_test4/nested", withIntermediateDirectories: false)) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileNoSuchFile)
             }
             XCTAssertThrowsError(try $0.createDirectory(atPath: "preexisting_file", withIntermediateDirectories: false)) {


### PR DESCRIPTION
All of our `String`-based path processing assumes that the paths are standardized to forward slashes, however there are many sources (such as `FileManager`) where these paths may come in on Windows with backslashes resulting in incorrect path manipulation. This updates all of these functions to standardize to forward slashes where needed when performing path-related functions. On windows, these slashes will already be automatically changed back to backslashes if necessary by the file system representation functions.

_Note: this currently doesn't handle drive letters any differently than other path components. We can probably do better there, but this at least unblocks the toolchain work and gets us on-par with what SCL-F used to do_