### PR TITLE
Disable testResolveSymlinksViaGetAttrList() on non-Darwin

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -686,6 +686,9 @@ final class FileManagerTests : XCTestCase {
     }
     
     func testResolveSymlinksViaGetAttrList() throws {
+        #if !canImport(Darwin)
+        throw XCTSkip("This test is not applicable on this platform")
+        #else
         try FileManagerPlayground {
             "destination"
         }.test {
@@ -694,6 +697,7 @@ final class FileManagerTests : XCTestCase {
             let resolved = absolutePath._resolvingSymlinksInPath() // Call internal function to avoid path standardization
             XCTAssertEqual(resolved, $0.currentDirectoryPath.appendingPathComponent("destination").withFileSystemRepresentation { String(cString: $0!) })
         }
+        #endif
     }
     
     #if os(macOS) && FOUNDATION_FRAMEWORK


### PR DESCRIPTION
This test attempts to test an optimization that is only present on Darwin (using `getattrlist` to resolve symlinks when possible). I encountered a situation on Windows on my local device where calling this function would standardize other portions of the path resulting in test failures. Since this test isn't applicable on non-Darwin anyways, this disables the test to ensure we don't hit accidental failures depending on local device setups.

In my device's case, the expected destination path was

```
C:\\Users\\jmschonfeld\\AppData\\Local\\Temp\\FileManagerPlayground_F2BEE091-140C-478E-91B2-1EBB08B88E5C\\destination
```

However calling this function was standardizing this to

```
C:\\Users\\JMSCHO~1\\AppData\\Local\\Temp\\FileManagerPlayground_F2BEE091-140C-478E-91B2-1EBB08B88E5C\\destination
```