### PR TITLE
Use correct calculation for Date's current time

### DIFF
--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -229,7 +229,7 @@ extension Date {
         li.LowPart = ft.dwLowDateTime
         li.HighPart = ft.dwHighDateTime
         // FILETIME represents 100-ns intervals since January 1, 1601 (UTC)
-        return TimeInterval((li.QuadPart - 1164447360_000_000) / 1_000_000_000)
+        return TimeInterval(Double(li.QuadPart) / 10_000_000.0 - Self.timeIntervalBetween1601AndReferenceDate)
 #else
         var ts: timespec = timespec()
         clock_gettime(CLOCK_REALTIME, &ts)

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -127,6 +127,11 @@ final class DateTests : XCTestCase {
         XCTAssertEqual("<description unavailable>", date.description)
 #endif
     }
+    
+    func testNowIsAfterReasonableDate() {
+        let date = Date.now
+        XCTAssert(date.timeIntervalSinceReferenceDate > 742700000.0)
+    }
 }
 
 // MARK: - Bridging

--- a/Tests/FoundationEssentialsTests/DateTests.swift
+++ b/Tests/FoundationEssentialsTests/DateTests.swift
@@ -130,7 +130,8 @@ final class DateTests : XCTestCase {
     
     func testNowIsAfterReasonableDate() {
         let date = Date.now
-        XCTAssert(date.timeIntervalSinceReferenceDate > 742700000.0)
+        XCTAssert(date.timeIntervalSinceReferenceDate > 742100000.0) // "2024-07-08T02:53:20Z"
+        XCTAssert(date.timeIntervalSinceReferenceDate < 3896300000.0) // "2124-06-21T01:33:20Z"
     }
 }
 


### PR DESCRIPTION
Correct the constant value used for Date's current time calculation, and put in a smoke test for the result. Also, use `Double` here so we get sub-1s precision.