### PR TITLE
Enable reading files of indeterminate length on Linux

### DIFF
--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -236,6 +236,17 @@ class DataIOTests : XCTestCase {
         XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: path))
         #endif
     }
+    
+    func test_zeroSizeFile() throws {
+        #if !os(Linux)
+        throw XCTSkip("This test is only applicable on Linux")
+        #else
+        // Some files in /proc report a file size of 0 bytes via a stat call
+        // Ensure that these files can still be read despite appearing to be empty
+        let maps = try String(contentsOfFile: "/proc/self/maps", encoding: String._Encoding.utf8)
+        XCTAssertFalse(maps.isEmpty)
+        #endif
+    }
 
     // MARK: - String Path Tests
     func testStringDeletingLastPathComponent() {


### PR DESCRIPTION
Some files on Linux (such as those in `/proc`) report a size of `0` when stat-ing the files. However, these files do have contents, but the length is not able to be predetermined. On Linux, we now always attempt a read in chunks even if the file reports as empty and grow our buffer as necessary to accommodate the resulting size.