### PR TITLE
Re-add sendable annotations

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -31,7 +31,7 @@ public enum AttributeScopes { }
 
 import Darwin
 internal import MachO.dyld
-@preconcurrency internal import ReflectionInternal
+internal import ReflectionInternal
 
 fileprivate struct ScopeDescription : Sendable {
     var attributes: [String : any AttributedStringKey.Type] = [:]

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+AttributeTransformation.swift
@@ -52,7 +52,9 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) {
+    ) 
+    where
+        K.Value : Sendable {
         if orig.range != changed.range || orig.attrName != changed.attrName {
             attrStr._guts.removeAttributeValue(forKey: K.self, in: orig.range._bstringRange) // If the range changed, we need to remove from the old range first.
         }
@@ -63,7 +65,7 @@ extension AttributedString {
         andChanged changed: AttributedString.SingleAttributeTransformer<K>,
         to attrStr: inout AttributedString,
         key: K.Type
-    ) {
+    ) where K.Value : Sendable {
         if orig.range != changed.range || orig.attrName != changed.attrName || orig.attr != changed.attr {
             if let newVal = changed.attr { // Then if there's a new value, we add it in.
                 // Unfortunately, we can't use the attrStr[range].set() provided by the AttributedStringProtocol, because we *don't know* the new type statically!
@@ -78,10 +80,13 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    @preconcurrency
     public func transformingAttributes<K>(
         _ k:  K.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where 
+        K.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -95,12 +100,16 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  K1.Type,
         _ k2: K2.Type,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where 
+        K1.Value : Sendable,
+        K2.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -118,6 +127,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -125,7 +135,11 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -147,6 +161,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -156,7 +171,12 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -182,6 +202,7 @@ extension AttributedString {
         return copy
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  K1.Type,
         _ k2: K2.Type,
@@ -193,7 +214,13 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable,
+        K5.Value : Sendable {
         let orig = AttributedString(_guts)
         var copy = orig
         copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
@@ -226,22 +253,30 @@ extension AttributedString {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributedString {
+    @preconcurrency
     public func transformingAttributes<K>(
         _ k: KeyPath<AttributeDynamicLookup, K>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K.Value : Sendable {
         self.transformingAttributes(K.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -249,10 +284,15 @@ extension AttributedString {
         _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -262,10 +302,16 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K2>,
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, c)
     }
 
+    @preconcurrency
     public func transformingAttributes<K1, K2, K3, K4, K5>(
         _ k:  KeyPath<AttributeDynamicLookup, K1>,
         _ k2: KeyPath<AttributeDynamicLookup, K2>,
@@ -277,7 +323,13 @@ extension AttributedString {
               inout AttributedString.SingleAttributeTransformer<K3>,
               inout AttributedString.SingleAttributeTransformer<K4>,
               inout AttributedString.SingleAttributeTransformer<K5>) -> Void
-    ) -> AttributedString {
+    ) -> AttributedString 
+    where
+        K1.Value : Sendable,
+        K2.Value : Sendable,
+        K3.Value : Sendable,
+        K4.Value : Sendable,
+        K5.Value : Sendable {
         self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, K5.self, c)
     }
 }

--- a/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedString+Runs+AttributeSlices.swift
@@ -100,11 +100,13 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
-    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> {
+    @preconcurrency
+    public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> where T.Value : Sendable {
         return AttributesSlice1<T>(runs: self)
     }
 
-    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> {
+    @preconcurrency
+    public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> where T.Value : Sendable {
         return AttributesSlice1<T>(runs: self)
     }
 }
@@ -205,23 +207,31 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>
-    ) -> AttributesSlice2<T, U> {
+    ) -> AttributesSlice2<T, U>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable {
         return AttributesSlice2<T, U>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey
     > (
         _ t: T.Type,
         _ u: U.Type
-    ) -> AttributesSlice2<T, U> {
+    ) -> AttributesSlice2<T, U>
+    where 
+        T.Value : Sendable,
+        U.Value : Sendable {
         return AttributesSlice2<T, U>(runs: self)
     }
 }
@@ -328,6 +338,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -336,10 +347,15 @@ extension AttributedString.Runs {
         _ t: KeyPath<AttributeDynamicLookup, T>,
         _ u: KeyPath<AttributeDynamicLookup, U>,
         _ v: KeyPath<AttributeDynamicLookup, V>
-    ) -> AttributesSlice3<T, U, V> {
+    ) -> AttributesSlice3<T, U, V>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -348,7 +364,11 @@ extension AttributedString.Runs {
         _ t: T.Type,
         _ u: U.Type,
         _ v: V.Type
-    ) -> AttributesSlice3<T, U, V> {
+    ) -> AttributesSlice3<T, U, V>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable {
         return AttributesSlice3<T, U, V>(runs: self)
     }
 }
@@ -464,6 +484,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -474,10 +495,16 @@ extension AttributedString.Runs {
         _ u: KeyPath<AttributeDynamicLookup, U>,
         _ v: KeyPath<AttributeDynamicLookup, V>,
         _ w: KeyPath<AttributeDynamicLookup, W>
-    ) -> AttributesSlice4<T, U, V, W> {
+    ) -> AttributesSlice4<T, U, V, W>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable {
         return AttributesSlice4<T, U, V, W>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -488,7 +515,12 @@ extension AttributedString.Runs {
         _ u: U.Type,
         _ v: V.Type,
         _ w: W.Type
-    ) -> AttributesSlice4<T, U, V, W> {
+    ) -> AttributesSlice4<T, U, V, W>
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable {
         return AttributesSlice4<T, U, V, W>(runs: self)
     }
 }
@@ -610,6 +642,7 @@ extension AttributedString.Runs {
         // down to the nearest valid indices.
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -622,10 +655,17 @@ extension AttributedString.Runs {
         _ v: KeyPath<AttributeDynamicLookup, V>,
         _ w: KeyPath<AttributeDynamicLookup, W>,
         _ x: KeyPath<AttributeDynamicLookup, X>
-    ) -> AttributesSlice5<T, U, V, W, X> {
+    ) -> AttributesSlice5<T, U, V, W, X> 
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable,
+        X.Value : Sendable {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 
+    @preconcurrency
     public subscript <
         T : AttributedStringKey,
         U : AttributedStringKey,
@@ -638,7 +678,13 @@ extension AttributedString.Runs {
         _ v: V.Type,
         _ w: W.Type,
         _ x: X.Type
-    ) -> AttributesSlice5<T, U, V, W, X> {
+    ) -> AttributesSlice5<T, U, V, W, X> 
+    where
+        T.Value : Sendable,
+        U.Value : Sendable,
+        V.Value : Sendable,
+        W.Value : Sendable,
+        X.Value : Sendable {
         return AttributesSlice5<T, U, V, W, X>(runs: self)
     }
 }

--- a/Sources/FoundationEssentials/Predicate/Archiving/PredicateExpressionConstruction.swift
+++ b/Sources/FoundationEssentials/Predicate/Archiving/PredicateExpressionConstruction.swift
@@ -12,7 +12,7 @@
 
 #if FOUNDATION_FRAMEWORK
 
-@preconcurrency internal import ReflectionInternal
+internal import ReflectionInternal
 
 @available(FoundationPredicate 0.1, *)
 enum PredicateCodableError : Error, CustomStringConvertible {

--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -11,8 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 /// A comparison algorithm for a given type.
+@preconcurrency
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public protocol SortComparator<Compared>: Hashable {
+public protocol SortComparator<Compared>: Hashable, Sendable {
     /// The type that the `SortComparator` provides a comparison for.
     associatedtype Compared
 
@@ -77,29 +78,26 @@ extension ComparisonResult {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-package struct AnySortComparator: SortComparator {
-    var _base: Any // internal for testing
-
-    private var hashableBase: AnyHashable
+package struct AnySortComparator: SortComparator, Sendable {
+    var _base: any Hashable & Sendable // internal for testing
 
     /// Takes `base` and two values to be compared and compares the two values
     /// using `base`.
-    private let _compare: (Any, Any, Any) -> ComparisonResult
+    private let _compare: @Sendable (Any, Any, Any) -> ComparisonResult
 
     /// Takes `base` inout, and a new `SortOrder` and changes `base`s `order`
     /// to match the new `SortOrder`.
-    private let setOrder: (inout Any, SortOrder) -> AnyHashable
+    private let setOrder: @Sendable (inout any Hashable & Sendable, SortOrder) -> any Hashable & Sendable
 
     /// Gets the current `order` property of `base`.
-    private let getOrder: (Any) -> SortOrder
+    private let getOrder: @Sendable (Any) -> SortOrder
 
-    package init<Comparator: SortComparator>(_ comparator: Comparator) {
-        self.hashableBase = AnyHashable(comparator)
+    package init<Comparator: SortComparator>(_ comparator: Comparator) where Comparator : Sendable {
         self._base = comparator
         self._compare = { (base: Any, lhs: Any, rhs: Any) -> ComparisonResult in
             (base as! Comparator).compare(lhs as! Comparator.Compared, rhs as! Comparator.Compared)
         }
-        self.setOrder = { (base: inout Any, newOrder: SortOrder) -> AnyHashable in
+        self.setOrder = { (base: inout any Hashable & Sendable, newOrder: SortOrder) -> AnyHashable in
             var typedBase = base as! Comparator
             typedBase.order = newOrder
             base = typedBase
@@ -115,7 +113,7 @@ package struct AnySortComparator: SortComparator {
             return getOrder(_base)
         }
         set {
-            hashableBase = setOrder(&_base, newValue)
+            _base = setOrder(&_base, newValue)
         }
     }
 
@@ -124,11 +122,18 @@ package struct AnySortComparator: SortComparator {
     }
 
     package func hash(into hasher: inout Hasher) {
-        hasher.combine(hashableBase)
+        hasher.combine(_base)
     }
 
     package static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.hashableBase == rhs.hashableBase
+        func compare<L : Equatable, R : Equatable>(_ l : L, _ r : R) -> Bool {
+            guard let rr = r as? L else {
+                return false
+            }
+            return l == rr
+        }
+        
+        return compare(lhs, rhs)
     }
 }
 
@@ -184,6 +189,8 @@ package struct OptionalComparator<Base: SortComparator>: SortComparator {
         return base.compare(lhs, rhs)
     }
 }
+
+extension OptionalComparator : Sendable where Base : Sendable { }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension Never: SortComparator {

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -248,6 +248,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
         self.init(keyPath as KeyPath<Compared, Value?>, order: order)
     }
     
+    #if FOUNDATION_FRAMEWORK
     @_alwaysEmitIntoClient
     @available(FoundationPreview 0.1, *)
     public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
@@ -441,6 +442,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
     }
+    #endif // FOUNDATION_FRAMEWORK
 
 
     /// Creates a `SortDescriptor` that orders values based on a `Value`'s

--- a/Sources/FoundationInternationalization/String/SortDescriptor.swift
+++ b/Sources/FoundationInternationalization/String/SortDescriptor.swift
@@ -18,15 +18,15 @@ import FoundationEssentials
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {    
     /// The set of supported safely serializable comparisons.
-    enum AllowedComparison: Hashable, Codable {
+    enum AllowedComparison: Hashable, Codable, Sendable {
         /// Compare `String` by retrieving from key path, using using the given standard string comparator.
-        case comparableString(String.StandardComparator, KeyPath<Compared, String>)
+        case comparableString(String.StandardComparator, KeyPath<Compared, String> & Sendable)
         
         /// Compare `String?` by retrieving from key path, using using the given standard string comparator.
-        case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?>)
+        case comparableOptionalString(String.StandardComparator, KeyPath<Compared, String?> & Sendable)
         
         /// Compares using `Swift.Comparable` implementation.
-        case comparable(AnySortComparator, PartialKeyPath<Compared>)
+        case comparable(AnySortComparator, PartialKeyPath<Compared> & Sendable)
         
 #if FOUNDATION_FRAMEWORK
         /// Compares using the `compare` selector on the given type.
@@ -233,6 +233,215 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
 
 
     // MARK: - Initializers for supported types.
+    
+    // A temporary workaround to a compiler bug that changes the ABI when adding the & Sendable constraint
+    // Should be removed and the related functions should be made public when rdar://131764614 is resolved
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init<Value>(_ keyPath: KeyPath<Compared, Value> & Sendable, order: SortOrder = .forward) where Value: Comparable {
+        self.init(keyPath as KeyPath<Compared, Value>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init<Value>(_ keyPath: KeyPath<Compared, Value?> & Sendable, order: SortOrder = .forward) where Value: Comparable {
+        self.init(keyPath as KeyPath<Compared, Value?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
+        self.init(keyPath as KeyPath<Compared, String>, comparator: comparator)
+    }
+    
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) {
+        self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator)
+    }
+    
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+        self.init(keyPath as KeyPath<Compared, String>, comparator: comparator, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    @available(FoundationPreview 0.1, *)
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+        self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Bool> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Bool>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Bool?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Bool?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Double> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Double>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Double?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Double?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Float> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Float>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Float?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Float?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int8>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int8?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int16>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int16?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int32>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int32?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int64>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int64?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Int?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Int?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt8> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt8>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt8?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt8?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt16> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt16>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt16?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt16?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt32> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt32>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt32?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt32?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt64> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt64>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt64?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt64?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UInt?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UInt?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Date> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Date>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, Date?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, Date?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UUID> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UUID>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, UUID?> & Sendable, order: SortOrder = .forward) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, UUID?>, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, String>, comparator: comparator)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, String>, comparator: comparator, order: order)
+    }
+    
+    @_alwaysEmitIntoClient
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+        self.init(keyPath as KeyPath<Compared, String?>, comparator: comparator, order: order)
+    }
+
 
     /// Creates a `SortDescriptor` that orders values based on a `Value`'s
     /// `Comparable` implementation.
@@ -244,12 +453,12 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
+    /*public*/ @usableFromInline init<Value>(_ keyPath: KeyPath<Compared, Value>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
         self.comparison = .comparable(
             AnySortComparator(ComparableComparator<Value>(order: order)),
-            keyPath
+            keyPath._unsafeAssumeSendable
         )
     }
 
@@ -266,12 +475,12 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
+    /*public*/ @usableFromInline init<Value>(_ keyPath: KeyPath<Compared, Value?>, order: SortOrder = .forward) where Value: Comparable {
         self.order = order
         self.keyString = nil
         self.comparison = .comparable(
             AnySortComparator(OptionalComparator(ComparableComparator<Value>(order: order))),
-            keyPath
+            keyPath._unsafeAssumeSendable
         )
     }
 
@@ -295,10 +504,10 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
-        self.comparison = .comparableString(comparator, keyPath)
+        self.comparison = .comparableString(comparator, keyPath._unsafeAssumeSendable)
     }
 
     /// Creates a `SortDescriptor` that orders optional values using the given
@@ -314,10 +523,10 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) {
         self.order = comparator.order
         self.keyString = nil
-        self.comparison = .comparableOptionalString(comparator, keyPath)
+        self.comparison = .comparableOptionalString(comparator, keyPath._unsafeAssumeSendable)
     }
 
     /// Creates a `SortDescriptor` that orders optional values using the given
@@ -334,12 +543,12 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
         comparator.order = order
-        self.comparison = .comparableString(comparator, keyPath)
+        self.comparison = .comparableString(comparator, keyPath._unsafeAssumeSendable)
     }
 
     /// Creates a `SortDescriptor` that orders optional values using the given
@@ -356,30 +565,30 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
     @available(FoundationPreview 0.1, *)
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
         comparator.order = order
-        self.comparison = .comparableOptionalString(comparator, keyPath)
+        self.comparison = .comparableOptionalString(comparator, keyPath._unsafeAssumeSendable)
     }
 #else
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator) {
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableString(comparator, keyPath)
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator) {
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator) {
         self.order = comparator.order
         self.keyString = nil
         self.comparison = .comparableOptionalString(comparator, keyPath)
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String> & Sendable, comparator: String.StandardComparator, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -388,7 +597,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     }
 
     /// Temporarily available as a replacement for `init(_:comparator:)` with a default argument.
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator, order: SortOrder) {
+    public init(_ keyPath: KeyPath<Compared, String?> & Sendable, comparator: String.StandardComparator, order: SortOrder) {
         self.order = order
         self.keyString = nil
         var comparator = comparator
@@ -408,7 +617,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Bool>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Bool>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -421,7 +630,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Bool?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Bool?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -431,7 +640,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Double>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Double>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -444,7 +653,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Double?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Double?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -454,7 +663,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Float>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Float>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -467,7 +676,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Float?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Float?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -477,7 +686,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int8>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int8>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -490,7 +699,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int8?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int8?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -501,7 +710,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int16>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int16>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -514,7 +723,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int16?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int16?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -524,7 +733,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int32>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int32>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -537,7 +746,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int32?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int32?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -547,7 +756,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int64>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int64>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -560,7 +769,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int64?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int64?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -570,7 +779,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -583,7 +792,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Int?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Int?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -593,7 +802,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt8>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt8>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -606,7 +815,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt8?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt8?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -616,7 +825,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt16>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt16>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -629,7 +838,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt16?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt16?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -639,7 +848,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt32>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt32>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -652,7 +861,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt32?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt32?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -662,7 +871,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt64>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt64>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -675,7 +884,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt64?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt64?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -685,7 +894,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -698,7 +907,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UInt?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UInt?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -708,7 +917,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Date>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Date>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -721,7 +930,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, Date?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, Date?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -731,7 +940,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UUID>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UUID>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -744,7 +953,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for the comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, UUID?>, order: SortOrder = .forward) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, UUID?>, order: SortOrder = .forward) where Compared: NSObject {
         self.init(uncheckedCompareBasedKeyPath: keyPath, order: order)
     }
 
@@ -757,7 +966,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(
             keyPath,
             comparator: comparator,
@@ -777,7 +986,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     /// - Parameters:
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard) where Compared: NSObject {
         self.init(
             keyPath,
             comparator: comparator,
@@ -792,7 +1001,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         guard let keyString = keyPath._kvcKeyPathString else {
             fatalError("""
             \(String(describing: Compared.self)) must be introspectable by \
@@ -823,7 +1032,7 @@ public struct SortDescriptor<Compared>: SortComparator, Codable, Sendable {
     ///   - keyPath: The key path to the field to use for comparison.
     ///   - comparator: The standard string comparator to use for comparison.
     ///   - order: The initial order to use for comparison.
-    public init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
+    /*public*/ @usableFromInline init(_ keyPath: KeyPath<Compared, String?>, comparator: String.StandardComparator = .localizedStandard, order: SortOrder) where Compared: NSObject {
         guard let keyString = keyPath._kvcKeyPathString else {
             fatalError("""
             \(String(describing: Compared.self)) must be introspectable by \

--- a/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
+++ b/Tests/FoundationEssentialsTests/PredicateCodableTests.swift
@@ -70,7 +70,7 @@ final class PredicateCodableTests: XCTestCase {
         var g: [Int]
         var h: Object2
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object>] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object> & Sendable] {
             [
                 "Object.f" : \.f,
                 "Object.g" : \.g,
@@ -85,7 +85,7 @@ final class PredicateCodableTests: XCTestCase {
         var a: Int
         var b: String
         
-        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2>] {
+        static var predicateCodableKeyPaths: [String : PartialKeyPath<PredicateCodableTests.Object2> & Sendable] {
             ["Object2.a" : \.a]
         }
     }


### PR DESCRIPTION
We previously reverted some sendable annotations in https://github.com/apple/swift-foundation/pull/679 due to a compiler bug around the IRGen for `KeyPath & Sendable` parameters. While the compiler bug is not yet resolved, this adds these annotations back in place using a workaround to prevent the compiler bug from causing issues on ABI stable platforms. This ensures that our public API is the most correct, and in the future when the bug is resolved we can remove the additional AEIC functions that serve as a workaround currently.