### PR TITLE
Pull in swift-corelibs-foundation Decimal improvements

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -236,13 +236,24 @@ extension Decimal /* : FloatingPoint */ {
     }
 
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(
-            _exponent: Int32(exponent) + significand._exponent,
-            _length: significand._length,
-            _isNegative: sign == .plus ? 0 : 1,
-            _isCompact: significand._isCompact,
-            _reserved: 0,
-            _mantissa: significand._mantissa)
+        self = significand
+        do {
+            self = try significand._multiplyByPowerOfTen(
+                power: exponent, roundingMode: .plain)
+        } catch {
+            guard let actual = error as? Decimal._CalculationError else {
+                self = .nan
+                return
+            }
+            if actual == .underflow {
+                self = 0
+            } else {
+                self = .nan
+            }
+        }
+        if sign == .minus {
+            negate()
+        }
     }
 
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -283,7 +283,7 @@ extension Decimal /* : FloatingPoint */ {
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
         return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -350,6 +350,33 @@ extension Decimal /* : FloatingPoint */ {
     public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
 
     public var nextUp: Decimal {
+        if _isNegative == 1 {
+            if _exponent > -128 &&
+               (_mantissa.0, _mantissa.1, _mantissa.2, _mantissa.3) == (0x999a, 0x9999, 0x9999, 0x9999) &&
+               (_mantissa.4, _mantissa.5, _mantissa.6, _mantissa.7) == (0x9999, 0x9999, 0x9999, 0x1999) {
+                return Decimal(
+                    _exponent: _exponent &- 1,
+                    _length: 8,
+                    _isNegative: 1,
+                    _isCompact: 1,
+                    _reserved: 0,
+                    _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+                )
+            }
+        } else {
+            if _exponent < 127 &&
+               (_mantissa.0, _mantissa.1, _mantissa.2, _mantissa.3) == (0xffff, 0xffff, 0xffff, 0xffff) &&
+               (_mantissa.4, _mantissa.5, _mantissa.6, _mantissa.7) == (0xffff, 0xffff, 0xffff, 0xffff) {
+                return Decimal(
+                    _exponent: _exponent &+ 1,
+                    _length: 8,
+                    _isNegative: 0,
+                    _isCompact: 1,
+                    _reserved: 0,
+                    _mantissa: (0x999a, 0x9999, 0x9999, 0x9999, 0x9999, 0x9999, 0x9999, 0x1999)
+                )
+            }
+        }
         return self + ulp
     }
 

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -683,7 +683,7 @@ extension Decimal : SignedNumeric {
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : Strideable {
     public func distance(to other: Decimal) -> Decimal {
-        return self - other
+        return other - self
     }
 
     public func advanced(by n: Decimal) -> Decimal {

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -339,25 +339,11 @@ extension Decimal /* : FloatingPoint */ {
     public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
 
     public var nextUp: Decimal {
-        return self + Decimal(
-            _exponent: _exponent,
-            _length: 1,
-            _isNegative: 0,
-            _isCompact: 1,
-            _reserved: 0,
-            _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
-        )
+        return self + ulp
     }
 
     public var nextDown: Decimal {
-        return self - Decimal(
-            _exponent: _exponent,
-            _length: 1,
-            _isNegative: 0,
-            _isCompact: 1,
-            _reserved: 0,
-            _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
-        )
+        return -(-self).nextUp
     }
 
     public func isEqual(to other: Decimal) -> Bool {

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -287,19 +287,10 @@ extension Decimal /* : FloatingPoint */ {
         if isZero {
             exponent = .min
         } else {
-            let significand = Decimal(
-                _exponent: 0, _length: _length,
-                _isNegative: 0, _isCompact: 0, _reserved: 0,
-                _mantissa: _mantissa
-            )
-            let maxPowerOfTen = powerOfTen.count
-            let powerOfTen = powerOfTen.firstIndex {
-                var value = Decimal()
-                try? value.copyVariableLengthInteger($0)
-                print("Checking: \(value.description)")
-                return value > significand
-            } ?? maxPowerOfTen
-            exponent = _exponent &- Int32(maxPowerOfTen &- powerOfTen)
+            let shift = _powersOfTenDividingUInt128Max.firstIndex {
+                return significand > $0
+            } ?? _powersOfTenDividingUInt128Max.count
+            exponent = _exponent &- Int32(shift)
         }
 
         return Decimal(
@@ -715,3 +706,65 @@ extension Decimal : Strideable {
         return self + n
     }
 }
+
+// Max power
+private extension Decimal {
+    // Creates a value with zero exponent.
+    // (Used by `_powersOfTenDividingUInt128Max`.)
+    init(
+        _length: UInt32,
+        _isCompact: UInt32,
+        _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)
+    ) {
+        self.init(
+            _exponent: 0,
+            _length: _length,
+            _isNegative: 0,
+            _isCompact: _isCompact,
+            _reserved: 0,
+            _mantissa: _mantissa
+        )
+    }
+}
+
+private let _powersOfTenDividingUInt128Max = [
+    /* 10**00 dividing UInt128.max is deliberately omitted. */
+    /* 10**01 */ Decimal(_length: 8, _isCompact: 1, _mantissa: (0x9999, 0x9999, 0x9999, 0x9999, 0x9999, 0x9999, 0x9999, 0x1999)),
+    /* 10**02 */ Decimal(_length: 8, _isCompact: 1, _mantissa: (0xf5c2, 0x5c28, 0xc28f, 0x28f5, 0x8f5c, 0xf5c2, 0x5c28, 0x028f)),
+    /* 10**03 */ Decimal(_length: 8, _isCompact: 1, _mantissa: (0x1893, 0x5604, 0x2d0e, 0x9db2, 0xa7ef, 0x4bc6, 0x8937, 0x0041)),
+    /* 10**04 */ Decimal(_length: 8, _isCompact: 1, _mantissa: (0x0275, 0x089a, 0x9e1b, 0x295e, 0x10cb, 0xbac7, 0x8db8, 0x0006)),
+    /* 10**05 */ Decimal(_length: 7, _isCompact: 1, _mantissa: (0x3372, 0x80dc, 0x0fcf, 0x8423, 0x1b47, 0xac47, 0xa7c5,0)),
+    /* 10**06 */ Decimal(_length: 7, _isCompact: 1, _mantissa: (0x3858, 0xf349, 0xb4c7, 0x8d36, 0xb5ed, 0xf7a0, 0x10c6,0)),
+    /* 10**07 */ Decimal(_length: 7, _isCompact: 1, _mantissa: (0xec08, 0x6520, 0x787a, 0xf485, 0xabca, 0x7f29, 0x01ad,0)),
+    /* 10**08 */ Decimal(_length: 7, _isCompact: 1, _mantissa: (0x4acd, 0x7083, 0xbf3f, 0x1873, 0xc461, 0xf31d, 0x002a,0)),
+    /* 10**09 */ Decimal(_length: 7, _isCompact: 1, _mantissa: (0x5447, 0x8b40, 0x2cb9, 0xb5a5, 0xfa09, 0x4b82, 0x0004,0)),
+    /* 10**10 */ Decimal(_length: 6, _isCompact: 1, _mantissa: (0xa207, 0x5ab9, 0xeadf, 0x5ef6, 0x7f67, 0x6df3,0,0)),
+    /* 10**11 */ Decimal(_length: 6, _isCompact: 1, _mantissa: (0xf69a, 0xef78, 0x4aaf, 0xbcb2, 0xbff0, 0x0afe,0,0)),
+    /* 10**12 */ Decimal(_length: 6, _isCompact: 1, _mantissa: (0x7f0f, 0x97f2, 0xa111, 0x12de, 0x7998, 0x0119,0,0)),
+    /* 10**13 */ Decimal(_length: 6, _isCompact: 0, _mantissa: (0x0cb4, 0xc265, 0x7681, 0x6849, 0x25c2, 0x001c,0,0)),
+    /* 10**14 */ Decimal(_length: 6, _isCompact: 1, _mantissa: (0x4e12, 0x603d, 0x2573, 0x70d4, 0xd093, 0x0002,0,0)),
+    /* 10**15 */ Decimal(_length: 5, _isCompact: 1, _mantissa: (0x87ce, 0x566c, 0x9d58, 0xbe7b, 0x480e,0,0,0)),
+    /* 10**16 */ Decimal(_length: 5, _isCompact: 1, _mantissa: (0xda61, 0x6f0a, 0xf622, 0xaca5, 0x0734,0,0,0)),
+    /* 10**17 */ Decimal(_length: 5, _isCompact: 1, _mantissa: (0x4909, 0xa4b4, 0x3236, 0x77aa, 0x00b8,0,0,0)),
+    /* 10**18 */ Decimal(_length: 5, _isCompact: 1, _mantissa: (0xa0e7, 0x43ab, 0xd1d2, 0x725d, 0x0012,0,0,0)),
+    /* 10**19 */ Decimal(_length: 5, _isCompact: 1, _mantissa: (0xc34a, 0x6d2a, 0x94fb, 0xd83c, 0x0001,0,0,0)),
+    /* 10**20 */ Decimal(_length: 4, _isCompact: 1, _mantissa: (0x46ba, 0x2484, 0x4219, 0x2f39,0,0,0,0)),
+    /* 10**21 */ Decimal(_length: 4, _isCompact: 1, _mantissa: (0xd3df, 0x83a6, 0xed02, 0x04b8,0,0,0,0)),
+    /* 10**22 */ Decimal(_length: 4, _isCompact: 1, _mantissa: (0x7b96, 0x405d, 0xe480, 0x0078,0,0,0,0)),
+    /* 10**23 */ Decimal(_length: 4, _isCompact: 1, _mantissa: (0x5928, 0xa009, 0x16d9, 0x000c,0,0,0,0)),
+    /* 10**24 */ Decimal(_length: 4, _isCompact: 1, _mantissa: (0x88ea, 0x299a, 0x357c, 0x0001,0,0,0,0)),
+    /* 10**25 */ Decimal(_length: 3, _isCompact: 1, _mantissa: (0xda7d, 0xd0f5, 0x1ef2,0,0,0,0,0)),
+    /* 10**26 */ Decimal(_length: 3, _isCompact: 1, _mantissa: (0x95d9, 0x4818, 0x0318,0,0,0,0,0)),
+    /* 10**27 */ Decimal(_length: 3, _isCompact: 0, _mantissa: (0xdbc8, 0x3a68, 0x004f,0,0,0,0,0)),
+    /* 10**28 */ Decimal(_length: 3, _isCompact: 1, _mantissa: (0xaf94, 0xec3d, 0x0007,0,0,0,0,0)),
+    /* 10**29 */ Decimal(_length: 2, _isCompact: 1, _mantissa: (0xf7f5, 0xcad2,0,0,0,0,0,0)),
+    /* 10**30 */ Decimal(_length: 2, _isCompact: 1, _mantissa: (0x4bfe, 0x1448,0,0,0,0,0,0)),
+    /* 10**31 */ Decimal(_length: 2, _isCompact: 1, _mantissa: (0x3acc, 0x0207,0,0,0,0,0,0)),
+    /* 10**32 */ Decimal(_length: 2, _isCompact: 1, _mantissa: (0xec47, 0x0033,0,0,0,0,0,0)),
+    /* 10**33 */ Decimal(_length: 2, _isCompact: 1, _mantissa: (0x313a, 0x0005,0,0,0,0,0,0)),
+    /* 10**34 */ Decimal(_length: 1, _isCompact: 1, _mantissa: (0x84ec,0,0,0,0,0,0,0)),
+    /* 10**35 */ Decimal(_length: 1, _isCompact: 1, _mantissa: (0x0d4a,0,0,0,0,0,0,0)),
+    /* 10**36 */ Decimal(_length: 1, _isCompact: 0, _mantissa: (0x0154,0,0,0,0,0,0,0)),
+    /* 10**37 */ Decimal(_length: 1, _isCompact: 1, _mantissa: (0x0022,0,0,0,0,0,0,0)),
+    /* 10**38 */ Decimal(_length: 1, _isCompact: 1, _mantissa: (0x0003,0,0,0,0,0,0,0))
+]

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -272,7 +272,7 @@ extension Decimal /* : FloatingPoint */ {
 
     public var significand: Decimal {
         return Decimal(
-            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _exponent: 0, _length: _length, _isNegative: 0, _isCompact: _isCompact,
             _reserved: 0, _mantissa: _mantissa)
     }
 

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -20,7 +20,7 @@ import Glibc
 import CRT
 #endif
 
-internal let powerOfTen: [Decimal.VariableLengthInteger] = [
+private let powerOfTen: [Decimal.VariableLengthInteger] = [
     /*^00*/ [0x0001],
     /*^01*/ [0x000a],
     /*^02*/ [0x0064],

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -20,7 +20,7 @@ import Glibc
 import CRT
 #endif
 
-private let powerOfTen: [Decimal.VariableLengthInteger] = [
+internal let powerOfTen: [Decimal.VariableLengthInteger] = [
     /*^00*/ [0x0001],
     /*^01*/ [0x000a],
     /*^02*/ [0x0064],
@@ -650,7 +650,11 @@ extension Decimal {
         }
     }
 
-    private mutating func copyVariableLengthInteger(_ source: VariableLengthInteger) throws {
+    internal mutating func copyVariableLengthInteger(_ source: VariableLengthInteger) throws {
+        guard source.count <= Decimal.maxSize else {
+            throw _CalculationError.overflow
+        }
+        self._length = UInt32(source.count)
         switch source.count {
         case 0:
             self._mantissa = (0, 0, 0, 0, 0, 0, 0, 0)

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -948,10 +948,8 @@ extension Decimal {
                     carry = acc >> 16
                     // FIXME: Check if truncate is okay here
                     result[j + i] = UInt16(truncatingIfNeeded:acc) & 0xFFFF
-                } else {
-                    if !(carry == 0 && (rhs[j] == 0 || lhs[i] == 0)) {
-                        throw _CalculationError.overflow
-                    }
+                } else if carry != 0 || (rhs[j] > 0 && lhs[i] > 0) {
+                    throw _CalculationError.overflow
                 }
             }
 

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -966,4 +966,9 @@ final class DecimalTests : XCTestCase {
         let b = Decimal.greatestFiniteMagnitude
         XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
     }
+
+    func test_ULP() {
+        let x = 0.1 as Decimal
+        XCTAssertFalse(x.ulp > x)
+    }
 }

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -983,6 +983,18 @@ final class DecimalTests : XCTestCase {
         XCTAssertNotEqual(x.nextDown, x)
         XCTAssertNotEqual(x.nextUp, x)
 
+        // For similar reasons, '3.40282366920938463463374607431768211455',
+        // which has the same significand as 'Decimal.greatestFiniteMagnitude',
+        // is an important value to test because the distance to the next
+        // representable value is more than 'ulp' and instead requires
+        // incrementing '_exponent'.
+        x = Decimal(string: "3.40282366920938463463374607431768211455")!
+        XCTAssertEqual(x.ulp, Decimal(string: "0.00000000000000000000000000000000000001")!)
+        XCTAssertEqual(x.nextUp, Decimal(string: "3.4028236692093846346337460743176821146")!)
+        x = Decimal(string: "3.4028236692093846346337460743176821146")!
+        XCTAssertEqual(x.ulp, Decimal(string: "0.0000000000000000000000000000000000001")!)
+        XCTAssertEqual(x.nextDown, Decimal(string: "3.40282366920938463463374607431768211455")!)
+
         x = 1
         XCTAssertEqual(x.ulp, Decimal(string: "1e-38")!)
         XCTAssertEqual(x.nextDown, x - Decimal(string: "1e-38")!)

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -802,6 +802,7 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
         XCTAssertTrue(Decimal.nan.magnitude.isNaN)
+        XCTAssertEqual(Decimal.leastFiniteMagnitude.magnitude, -Decimal.leastFiniteMagnitude)
 
         do {
             // SR-13015
@@ -969,16 +970,25 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(x.nextDown, x - Decimal(string: "1e127")!)
         XCTAssertTrue(x.nextUp.isNaN)
 
+        // '4' is an important value to test because the max supported
+        // significand of this type is not 10 ** 38 - 1 but rather 2 ** 128 - 1,
+        // for which reason '4.ulp' is not equal to '1.ulp' despite having the
+        // same decimal exponent.
+        x = 4
+        XCTAssertEqual(x.ulp, Decimal(string: "1e-37")!)
+        XCTAssertEqual(x.nextDown, x - Decimal(string: "1e-37")!)
+        XCTAssertEqual(x.nextUp, x + Decimal(string: "1e-37")!)
+        XCTAssertEqual(x.nextDown.nextUp, x)
+        XCTAssertEqual(x.nextUp.nextDown, x)
+        XCTAssertNotEqual(x.nextDown, x)
+        XCTAssertNotEqual(x.nextUp, x)
+
         x = 1
         XCTAssertEqual(x.ulp, Decimal(string: "1e-38")!)
         XCTAssertEqual(x.nextDown, x - Decimal(string: "1e-38")!)
         XCTAssertEqual(x.nextUp, x + Decimal(string: "1e-38")!)
-
-        x = .leastNonzeroMagnitude
-        // XCTAssertEqual(x.ulp, x)        // SR-6671
-        // XCTAssertEqual(x.nextDown, 0)   // SR-6671
-        // XCTAssertEqual(x.nextUp, x + x) // SR-6671
-        XCTAssertNotEqual(x.ulp, 0)
+        XCTAssertEqual(x.nextDown.nextUp, x)
+        XCTAssertEqual(x.nextUp.nextDown, x)
         XCTAssertNotEqual(x.nextDown, x)
         XCTAssertNotEqual(x.nextUp, x)
 
@@ -986,10 +996,20 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(x.ulp, Decimal(string: "1e-128")!)
         XCTAssertEqual(x.nextDown, -Decimal(string: "1e-128")!)
         XCTAssertEqual(x.nextUp, Decimal(string: "1e-128")!)
+        XCTAssertEqual(x.nextDown.nextUp, x)
+        XCTAssertEqual(x.nextUp.nextDown, x)
+        XCTAssertNotEqual(x.nextDown, x)
+        XCTAssertNotEqual(x.nextUp, x)
 
         x = -1
-        XCTAssertEqual(x.ulp, (1 as Decimal).ulp)
-        XCTAssertEqual(x.nextDown, -((1 as Decimal).nextUp))
-        XCTAssertEqual(x.nextUp, -((1 as Decimal).nextDown))
+        XCTAssertEqual(x.ulp, Decimal(string: "1e-38")!)
+        XCTAssertEqual(x.nextDown, x - Decimal(string: "1e-38")!)
+        XCTAssertEqual(x.nextUp, x + Decimal(string: "1e-38")!)
+        let y = x - x.ulp + x.ulp
+        XCTAssertEqual(x, y)
+        XCTAssertEqual(x.nextDown.nextUp, x)
+        XCTAssertEqual(x.nextUp.nextDown, x)
+        XCTAssertNotEqual(x.nextDown, x)
+        XCTAssertNotEqual(x.nextUp, x)
     }
 }

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -944,6 +944,11 @@ final class DecimalTests : XCTestCase {
     }
 
     func test_Significand() {
+        let x = -42 as Decimal
+        XCTAssertEqual(x.significand.sign, .plus)
+        let y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y.sign, .minus)
+
         let a = Decimal.leastNonzeroMagnitude
         XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
         let b = Decimal.greatestFiniteMagnitude

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -951,4 +951,12 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(d8?.description, "-1")
         XCTAssertEqual(d8?._length, 1)
     }
+
+    func test_Strideable() {
+        let x = 42 as Decimal
+        XCTAssertEqual(x.distance(to: 43), 1)
+        XCTAssertEqual(x.advanced(by: 1), 43)
+        XCTAssertEqual(x.distance(to: 41), -1)
+        XCTAssertEqual(x.advanced(by: -1), 41)
+    }
 }

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -907,4 +907,48 @@ final class DecimalTests : XCTestCase {
             XCTAssertEqual(Decimal(d).description, try XCTUnwrap(Decimal(string: s)).description)
         }
     }
+
+    func test_initExactly() {
+        // This really requires some tests using a BinaryInteger of bitwidth > 128 to test failures.
+        let d1 = Decimal(exactly: UInt64.max)
+        XCTAssertNotNil(d1)
+        XCTAssertEqual(d1?.description, UInt64.max.description)
+        XCTAssertEqual(d1?._length, 4)
+
+        let d2 = Decimal(exactly: Int64.min)
+        XCTAssertNotNil(d2)
+        XCTAssertEqual(d2?.description, Int64.min.description)
+        XCTAssertEqual(d2?._length, 4)
+
+        let d3 = Decimal(exactly: Int64.max)
+        XCTAssertNotNil(d3)
+        XCTAssertEqual(d3?.description, Int64.max.description)
+        XCTAssertEqual(d3?._length, 4)
+
+        let d4 = Decimal(exactly: Int32.min)
+        XCTAssertNotNil(d4)
+        XCTAssertEqual(d4?.description, Int32.min.description)
+        XCTAssertEqual(d4?._length, 2)
+
+        let d5 = Decimal(exactly: Int32.max)
+        XCTAssertNotNil(d5)
+        XCTAssertEqual(d5?.description, Int32.max.description)
+        XCTAssertEqual(d5?._length, 2)
+
+        let d6 = Decimal(exactly: 0)
+        XCTAssertNotNil(d6)
+        XCTAssertEqual(d6, Decimal.zero)
+        XCTAssertEqual(d6?.description, "0")
+        XCTAssertEqual(d6?._length, 0)
+
+        let d7 = Decimal(exactly: 1)
+        XCTAssertNotNil(d7)
+        XCTAssertEqual(d7?.description, "1")
+        XCTAssertEqual(d7?._length, 1)
+
+        let d8 = Decimal(exactly: -1)
+        XCTAssertNotNil(d8)
+        XCTAssertEqual(d8?.description, "-1")
+        XCTAssertEqual(d8?._length, 1)
+    }
 }

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -191,21 +191,6 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(11, sm5)
         XCTAssertEqual(12, sm6)
         XCTAssertEqual(13, sm7)
-
-        let ulp = explicit.ulp
-        XCTAssertEqual(0x7f, ulp.exponent)
-        XCTAssertEqual(8, ulp._length)
-        XCTAssertEqual(0, ulp._isNegative)
-        XCTAssertEqual(1, ulp._isCompact)
-        XCTAssertEqual(0, ulp._reserved)
-        XCTAssertEqual(1, ulp._mantissa.0)
-        XCTAssertEqual(0, ulp._mantissa.1)
-        XCTAssertEqual(0, ulp._mantissa.2)
-        XCTAssertEqual(0, ulp._mantissa.3)
-        XCTAssertEqual(0, ulp._mantissa.4)
-        XCTAssertEqual(0, ulp._mantissa.5)
-        XCTAssertEqual(0, ulp._mantissa.6)
-        XCTAssertEqual(0, ulp._mantissa.7)
     }
 
     func test_ScanDecimal() throws {
@@ -812,9 +797,7 @@ final class DecimalTests : XCTestCase {
         XCTAssertTrue(Decimal(2) < Decimal(3))
         XCTAssertTrue(Decimal(3) > Decimal(2))
         XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
-        XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
-        XCTAssertEqual(Decimal(2), Decimal(3).nextDown)
-        XCTAssertEqual(Decimal(-476), Decimal(1024).distance(to: Decimal(1500)))
+        XCTAssertEqual(Decimal(476), Decimal(1024).distance(to: Decimal(1500)))
         XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
@@ -968,7 +951,40 @@ final class DecimalTests : XCTestCase {
     }
 
     func test_ULP() {
-        let x = 0.1 as Decimal
+        var x = 0.1 as Decimal
         XCTAssertFalse(x.ulp > x)
+
+        x = .nan
+        XCTAssertTrue(x.ulp.isNaN)
+        XCTAssertTrue(x.nextDown.isNaN)
+        XCTAssertTrue(x.nextUp.isNaN)
+
+        x = .greatestFiniteMagnitude
+        XCTAssertEqual(x.ulp, Decimal(string: "1e127")!)
+        XCTAssertEqual(x.nextDown, x - Decimal(string: "1e127")!)
+        XCTAssertTrue(x.nextUp.isNaN)
+
+        x = 1
+        XCTAssertEqual(x.ulp, Decimal(string: "1e-38")!)
+        XCTAssertEqual(x.nextDown, x - Decimal(string: "1e-38")!)
+        XCTAssertEqual(x.nextUp, x + Decimal(string: "1e-38")!)
+
+        x = .leastNonzeroMagnitude
+        // XCTAssertEqual(x.ulp, x)        // SR-6671
+        // XCTAssertEqual(x.nextDown, 0)   // SR-6671
+        // XCTAssertEqual(x.nextUp, x + x) // SR-6671
+        XCTAssertNotEqual(x.ulp, 0)
+        XCTAssertNotEqual(x.nextDown, x)
+        XCTAssertNotEqual(x.nextUp, x)
+
+        x = 0
+        XCTAssertEqual(x.ulp, Decimal(string: "1e-128")!)
+        XCTAssertEqual(x.nextDown, -Decimal(string: "1e-128")!)
+        XCTAssertEqual(x.nextUp, Decimal(string: "1e-128")!)
+
+        x = -1
+        XCTAssertEqual(x.ulp, (1 as Decimal).ulp)
+        XCTAssertEqual(x.nextDown, -((1 as Decimal).nextUp))
+        XCTAssertEqual(x.nextUp, -((1 as Decimal).nextDown))
     }
 }

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -126,8 +126,8 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(0, m5)
         XCTAssertEqual(0, m6)
         XCTAssertEqual(0, m7)
-        XCTAssertEqual(8, NSDecimalMaxSize)
-        XCTAssertEqual(32767, NSDecimalNoScale)
+        XCTAssertEqual(8, Decimal.maxSize)
+        XCTAssertEqual(32767, CShort.max)
         XCTAssertFalse(zero.isNormal)
         XCTAssertTrue(zero.isFinite)
         XCTAssertTrue(zero.isZero)
@@ -207,7 +207,7 @@ final class DecimalTests : XCTestCase {
             ( 12.34, " 01234e-02", "12.34"),
         ]
         for testCase in testCases {
-            let (expected, string, expectedString) = testCase
+            let (expected, string, _) = testCase
             let decimal = Decimal(string:string)!
             let aboutOne = Decimal(expected) / decimal
             let approximatelyRight = aboutOne >= Decimal(0.99999) && aboutOne <= Decimal(1.00001)
@@ -296,8 +296,9 @@ final class DecimalTests : XCTestCase {
         var aNormalized = a
         var bNormalized = b
 
-        let normalizeError = NSDecimalNormalize(&aNormalized, &bNormalized, .plain)
-        XCTAssertEqual(normalizeError, NSDecimalNumber.CalculationError.lossOfPrecision)
+        lossPrecision = try Decimal._normalize(
+            a: &aNormalized, b: &bNormalized, roundingMode: .plain)
+        XCTAssertTrue(lossPrecision)
 
         XCTAssertEqual(aNormalized.exponent, -31)
         XCTAssertEqual(aNormalized._mantissa.0, 0)

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -959,4 +959,11 @@ final class DecimalTests : XCTestCase {
         XCTAssertEqual(x.distance(to: 41), -1)
         XCTAssertEqual(x.advanced(by: -1), 41)
     }
+
+    func test_Significand() {
+        let a = Decimal.leastNonzeroMagnitude
+        XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
+        let b = Decimal.greatestFiniteMagnitude
+        XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
+    }
 }


### PR DESCRIPTION
This patch pulls in numerous improvements and bug fixes to `Decimal` in `swift-corelibs-foundation`. Each commit in this PR corresponds to a (hand applied, modified if necessary) commit from the original `swift-corelibs-foundation` repo.