### PR TITLE
Re-Add Synchronization Import on non-Darwin

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -79,11 +79,9 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCollections>")
 endif()
 
-target_link_options(FoundationEssentials PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(FoundationEssentials PROPERTIES
-    INSTALL_RPATH "$ORIGIN")
+    INSTALL_RPATH "$ORIGIN"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS FoundationEssentials)
 _swift_foundation_install_target(FoundationEssentials)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -78,7 +78,7 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationEssentials PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCollections>")
     target_compile_options(FoundationEssentials PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend Synchronization>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 
 set_target_properties(FoundationEssentials PROPERTIES

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -77,6 +77,8 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCShims>")
     target_compile_options(FoundationEssentials PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCollections>")
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend Synchronization>")
 endif()
 
 set_target_properties(FoundationEssentials PROPERTIES

--- a/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateExpression.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if FOUNDATION_FRAMEWORK
+#if canImport(Synchronization) && (!canImport(Darwin) || FOUNDATION_FRAMEWORK)
 internal import Synchronization
 #endif
 
@@ -85,14 +85,14 @@ public struct PredicateError: Error, Hashable, CustomDebugStringConvertible {
 extension PredicateExpressions {
     public struct VariableID: Hashable, Codable, Sendable {
         let id: UInt
-        #if FOUNDATION_FRAMEWORK
+        #if canImport(Synchronization) && (!canImport(Darwin) || FOUNDATION_FRAMEWORK)
         private static let nextID = Atomic<UInt>(0)
         #else
         private static let nextID = LockedState(initialState: UInt(0))
         #endif
         
         init() {
-            #if FOUNDATION_FRAMEWORK
+            #if canImport(Synchronization) && (!canImport(Darwin) || FOUNDATION_FRAMEWORK)
             self.id = Self.nextID.wrappingAdd(1, ordering: .relaxed).oldValue
             #else
             self.id = Self.nextID.withLock { value in

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -46,11 +46,9 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
 endif()
 
-target_link_options(FoundationInternationalization PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(FoundationInternationalization PROPERTIES
-    INSTALL_RPATH "$ORIGIN")
+    INSTALL_RPATH "$ORIGIN"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS FoundationInternationalization)
 _swift_foundation_install_target(FoundationInternationalization)

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -44,6 +44,8 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationCShims>")
     target_compile_options(FoundationInternationalization PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 
 set_target_properties(FoundationInternationalization PROPERTIES

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,11 +43,9 @@ target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntaxBuilder
 )
 
-target_link_options(FoundationMacros PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(FoundationMacros PROPERTIES
-    INSTALL_RPATH "$ORIGIN")
+    INSTALL_RPATH "$ORIGIN"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 target_compile_options(FoundationMacros PRIVATE -parse-as-library)
 target_compile_options(FoundationMacros PRIVATE


### PR DESCRIPTION
Previously, we had issues with import `Synchronization` in the toolchain - this was due to the rpaths of the produced libraries. We previously applied `-no-toolchain-stdlib-rpath` so that the rpath of the libraries in the build folder had no rpaths set. When the libraries are installed into the toolchain, `$ORIGIN` was appended which is correct for the installed library. However, XCTest's tests link against these libraries directly in the build folder before they are installed. Loading the stdlib worked because XCTest's tests also link the stdlib and so the library was found in the cache, however since XCTest's tests do not link `Synchronization` it wasn't found in the cache and since the rpaths list was empty the library couldn't be found.

Instead, we now remove the `-no-toolchain-stdlib-rpath` argument so that the libraries in the build directory have rpaths pointing to the swift build folder. However, we also now set `INSTALL_REMOVE_ENVIRONMENT_RPATH` to `ON` so that when copying to the installation folder, this path is _replaced_ by `$ORIGIN` instead of just appending the `$ORIGIN` path to the list so that the produced toolchain doesn't contain local rpaths.

This should also resolve a related warning in the macro due to the lack of rpaths while loading the macro from the build folder to build FoundationEssentials itself:

```
/home/build-user/swift-foundation/Sources/FoundationEssentials/Predicate/Expression.swift:32:14: warning: external macro implementation type 'FoundationMacros.ExpressionMacro' could not be found for macro 'Expression'; failed to load library plugin '/home/build-user/build/buildbot_linux/foundation-linux-x86_64/lib/libFoundationMacros.so' in plugin server '/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/host/libSwiftInProcPluginServer.so'; loader error: libswift_StringProcessing.so: cannot open shared object file: No such file or directory
```