### PR TITLE
Decimal.init(sign:exponent:significand:) should clamp exponent

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -17,12 +17,12 @@ internal import _ForSwiftFoundation
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension Decimal : CustomStringConvertible {
     public init?(string: __shared String, locale: __shared Locale? = nil) {
-        // Substitute the decimal sign if needed
-        var decimalString = string
-        if let decimalSeparator = locale?.decimalSeparator {
-            decimalString = decimalString.replacing(decimalSeparator, with: ".")
-        }
-        guard let value = Decimal.decimal(from: decimalString.utf8, matchEntireString: false).result else {
+        let decimalSeparator = locale?.decimalSeparator ?? "."
+        guard let value = Decimal.decimal(
+            from: string.utf8,
+            decimalSeparator: decimalSeparator.utf8,
+            matchEntireString: false
+        ).result else {
             return nil
         }
         self = value
@@ -239,7 +239,7 @@ extension Decimal /* : FloatingPoint */ {
         self = significand
         do {
             self = try significand._multiplyByPowerOfTen(
-                power: exponent, roundingMode: .plain)
+                power: Int(Int16(clamping: exponent)), roundingMode: .plain)
         } catch {
             guard let actual = error as? Decimal._CalculationError else {
                 self = .nan

--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -223,6 +223,7 @@ extension Decimal {
 
     internal static func decimal(
         from stringView: String.UTF8View,
+        decimalSeparator: String.UTF8View,
         matchEntireString: Bool
     ) -> (result: Decimal?, processedLength: Int) {
         func multiplyBy10AndAdd(
@@ -245,6 +246,20 @@ extension Decimal {
                 stringView.formIndex(after: &i)
             }
             return i
+        }
+
+        func stringViewContainsDecimalSeparator(at index: String.UTF8View.Index) -> Bool {
+            for indexOffset in 0 ..< decimalSeparator.count {
+                let stringIndex = stringView.index(index, offsetBy: indexOffset)
+                let decimalIndex = decimalSeparator.index(
+                    decimalSeparator.startIndex,
+                    offsetBy: indexOffset
+                )
+                if stringView[stringIndex] != decimalSeparator[decimalIndex] {
+                    return false
+                }
+            }
+            return true
         }
 
         var result = Decimal()
@@ -298,8 +313,8 @@ extension Decimal {
             result = product
         }
         // Get the decimal point
-        if index != stringView.endIndex && stringView[index] == UInt8._period {
-            stringView.formIndex(after: &index)
+        if index != stringView.endIndex && stringViewContainsDecimalSeparator(at: index) {
+            stringView.formIndex(&index, offsetBy: decimalSeparator.count)
             // Continue to build the mantissa
             while index != stringView.endIndex,
                   let digitValue = stringView[index].digitValue {

--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -1075,7 +1075,9 @@ extension FixedWidthInteger {
 extension Decimal {
     init?(entire string: String) {
         guard let value = Decimal.decimal(
-            from: string.utf8, matchEntireString: true
+            from: string.utf8,
+            decimalSeparator: ".".utf8,
+            matchEntireString: true
         ).result else {
             return nil
         }


### PR DESCRIPTION
While I was here: imported more Decimal tests from swift-corelibs-foundation

