### PR TITLE
Revert "[CMake] Add Locale_Notifications.swift"

### DIFF
--- a/Sources/FoundationEssentials/Locale/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Locale/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(FoundationEssentials PRIVATE
     Locale.swift
     Locale_Autoupdating.swift
     Locale_Cache.swift
-    Locale_Notifications.swift
     Locale_Preferences.swift
     Locale_Protocol.swift
     Locale_Unlocalized.swift)


### PR DESCRIPTION
Reverts apple/swift-foundation#726
`Locale_Notifications.swift` was removed in https://github.com/apple/swift-foundation/pull/744