### PR TITLE
Fix URL percent-decoding of %00

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -956,7 +956,7 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.queryItems, expected)
     }
 
-    func testURLComponentsLookalikeIPLiteral () {
+    func testURLComponentsLookalikeIPLiteral() {
         // We should consider a lookalike IP literal invalid (note accent on the first bracket)
         let fakeIPLiteral = "[́::1]"
         let fakeURLString = "http://\(fakeIPLiteral):80/"
@@ -967,5 +967,11 @@ final class URLTests : XCTestCase {
         var comp2 = URLComponents()
         comp2.host = fakeIPLiteral
         XCTAssertNil(comp2.string)
+    }
+
+    func testURLComponentsDecodingNULL() {
+        let comp = URLComponents(string: "http://example.com/my\u{0}path")!
+        XCTAssertEqual(comp.percentEncodedPath, "/my%00path")
+        XCTAssertEqual(comp.path, "/my\u{0}path")
     }
 }


### PR DESCRIPTION
`URLParser`'s percent-decoding function used `String(validatingUTF8:)`, which would truncate the string if we had just decoded `%00` to NULL. Instead of using a NULL-terminated `OutputBuffer`, I switched to using `String(_validating:as:)`, which handles/accepts NULL characters in the buffer.