### PR TITLE
build: install linker files for installed targets

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -59,3 +59,5 @@ install(TARGETS FoundationMacros
     ARCHIVE DESTINATION lib/swift/host/plugins
     LIBRARY DESTINATION lib/swift/host/plugins
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES $<TARGET_LINKER_FILE:FoundationMacros>
+  DESTINATION lib)

--- a/cmake/modules/SwiftFoundationSwiftSupport.cmake
+++ b/cmake/modules/SwiftFoundationSwiftSupport.cmake
@@ -50,5 +50,6 @@ function(_swift_foundation_install_target module)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
     DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
     RENAME ${SwiftFoundation_MODULE_TRIPLE}.swiftmodule)
-
+  install(FILES $<TARGET_LINKER_FILE:${module}>
+    DESTINATION lib)
 endfunction()


### PR DESCRIPTION
Ensure that we install any linker files for the modules which are required on certain platforms.