### PR TITLE
(132084216) Make AnySortComparator.== not infinitely recursive

### DIFF
--- a/Sources/FoundationEssentials/SortComparator.swift
+++ b/Sources/FoundationEssentials/SortComparator.swift
@@ -133,7 +133,7 @@ package struct AnySortComparator: SortComparator, Sendable {
             return l == rr
         }
         
-        return compare(lhs, rhs)
+        return compare(lhs._base, rhs._base)
     }
 }
 

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -50,5 +50,17 @@ class SortComparatorTests: XCTestCase {
         XCTAssertEqual(
             compareOptions.compare("test2", "test005"),
             "test2".compare("test005", options: [.numeric]))
-    }    
+    }
+    
+    func testAnySortComparatorEquality() {
+        let a = AnySortComparator(ComparableComparator<Int>())
+        let b = AnySortComparator(ComparableComparator<Int>(order: .reverse))
+        let c = AnySortComparator(ComparableComparator<Double>())
+        XCTAssertEqual(a, a)
+        XCTAssertEqual(b, b)
+        XCTAssertEqual(c, c)
+        XCTAssertNotEqual(a, b)
+        XCTAssertNotEqual(b, c)
+        XCTAssertNotEqual(a, c)
+    }
 }

--- a/Tests/FoundationEssentialsTests/SortComparatorTests.swift
+++ b/Tests/FoundationEssentialsTests/SortComparatorTests.swift
@@ -53,14 +53,14 @@ class SortComparatorTests: XCTestCase {
     }
     
     func testAnySortComparatorEquality() {
-        let a = AnySortComparator(ComparableComparator<Int>())
-        let b = AnySortComparator(ComparableComparator<Int>(order: .reverse))
-        let c = AnySortComparator(ComparableComparator<Double>())
-        XCTAssertEqual(a, a)
-        XCTAssertEqual(b, b)
-        XCTAssertEqual(c, c)
-        XCTAssertNotEqual(a, b)
-        XCTAssertNotEqual(b, c)
-        XCTAssertNotEqual(a, c)
+        let a: ComparableComparator<Int> = ComparableComparator<Int>()
+        let b: ComparableComparator<Int> = ComparableComparator<Int>(order: .reverse)
+        let c: ComparableComparator<Double> = ComparableComparator<Double>()
+        XCTAssertEqual(AnySortComparator(a), AnySortComparator(a))
+        XCTAssertEqual(AnySortComparator(b), AnySortComparator(b))
+        XCTAssertEqual(AnySortComparator(c), AnySortComparator(c))
+        XCTAssertNotEqual(AnySortComparator(a), AnySortComparator(b))
+        XCTAssertNotEqual(AnySortComparator(b), AnySortComparator(c))
+        XCTAssertNotEqual(AnySortComparator(a), AnySortComparator(c))
     }
 }


### PR DESCRIPTION
With https://github.com/apple/swift-foundation/pull/740 I accidentally introduced a bug that made `AnySortComparator.==` infinitely recursive. This updates the `==` function to compare the underlying `_base` properties instead of recursing by comparing `lhs` and `rhs` themselves