### PR TITLE
Revert "build: install linker files for installed targets (#753)"

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -57,5 +57,3 @@ install(TARGETS FoundationMacros
     ARCHIVE DESTINATION lib/swift/host/plugins
     LIBRARY DESTINATION lib/swift/host/plugins
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES $<TARGET_LINKER_FILE:FoundationMacros>
-  DESTINATION lib)

--- a/cmake/modules/SwiftFoundationSwiftSupport.cmake
+++ b/cmake/modules/SwiftFoundationSwiftSupport.cmake
@@ -50,6 +50,5 @@ function(_swift_foundation_install_target module)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
     DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
     RENAME ${SwiftFoundation_MODULE_TRIPLE}.swiftmodule)
-  install(FILES $<TARGET_LINKER_FILE:${module}>
-    DESTINATION lib)
+
 endfunction()


### PR DESCRIPTION
This reverts commit 590caaa097729a5f745636561846f523104744af.

This introduces a failure in the Ubuntu 20.04 test suite (e.g. https://ci.swift.org/job/oss-swift-pr-test-ubuntu-20_04/7131/).