### PR TITLE
Avoid checking filesystem when constructing path errors

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -907,7 +907,7 @@ public struct URL: Equatable, Sendable, Hashable {
     internal init?(_fileManagerFailableFileURLWithPath path: __shared String) {
         #if FOUNDATION_FRAMEWORK
         guard foundation_swift_url_enabled() else {
-            let url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
+            let url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: path.utf8.last == ._slash))
             guard unsafeBitCast(url, to: UnsafeRawPointer?.self) != nil else {
                 return nil
             }
@@ -915,7 +915,8 @@ public struct URL: Equatable, Sendable, Hashable {
             return
         }
         #endif
-        self.init(filePath: path, directoryHint: .checkFileSystem)
+        // Infer from the path to prevent a file system check for what is likely a non-existant, malformed, or inaccessible path
+        self.init(filePath: path, directoryHint: .inferFromPath)
     }
 
     /// Initializes a newly created URL using the contents of the given data, relative to a base URL.


### PR DESCRIPTION
When we throw a path-based error from `FileManager`, we attempt to construct a URL from this path to include in the user info dictionary which ends up checking the file system. This file system check is mostly unnecessary since it's highly likely that the file either doesn't exist, is inaccessible, or the path is malformed. Instead, let's infer whether the file is a directory via the path itself as a best effort attempt to improve performance while creating these errors