### PR TITLE
Fix CMake availability macro typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ foreach(version ${_SwiftFoundation_versions})
         endif()
 
         list(APPEND _SwiftFoundation_availability_macros
-            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=${name} ${version}=${release}\">")
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend \"AvailabilityMacro=${name} ${version}:${release}\">")
     endforeach()
 endforeach()
 


### PR DESCRIPTION
Fixes a minor typo introduced in the CMake files in https://github.com/apple/swift-foundation/pull/760