### PR TITLE
Bin compat: NSDecimalString should accept dictionary in addition to locale

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Compatibility.swift
@@ -409,8 +409,24 @@ public func _NSDecimalCompact(_ number: UnsafeMutablePointer<Decimal>) {
     _ decimal: UnsafePointer<Decimal>,
     _ locale: Any? = nil
 ) -> String {
-    let useLocale = locale as? Locale
-    return decimal.pointee._toString(with: useLocale)
+    var decimalSeparator = "."
+    if let useLocale = locale as? Locale,
+       let separator = useLocale.decimalSeparator {
+        decimalSeparator = separator
+    }
+#if FOUNDATION_FRAMEWORK
+    if let dictionary = locale as? [AnyHashable : Any] {
+        // NSDecimal favored NSLocale.Key.decimalSeparator if
+        // both keys are present.
+        if let separator = dictionary["NSDecimalSeparator"] as? String {
+            decimalSeparator = separator
+        }
+        if let separator = dictionary[NSLocale.Key.decimalSeparator.rawValue] as? String {
+            decimalSeparator = separator
+        }
+    }
+#endif
+    return decimal.pointee._toString(withDecimalSeparator: decimalSeparator)
 }
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -29,7 +29,7 @@ extension Decimal : CustomStringConvertible {
     }
 
     public var description: String {
-        return self._toString()
+        return self._toString(withDecimalSeparator: ".")
     }
 }
 

--- a/Sources/FoundationEssentials/Decimal/Decimal.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal.swift
@@ -187,7 +187,14 @@ extension Decimal {
 #else
     @_spi(SwiftCorelibsFoundation)
     public func toString(with locale: Locale? = nil) -> String {
-        _toString(with: locale)
+        let separator: String
+        if let locale = locale,
+           let localizedSeparator = locale.decimalSeparator {
+            separator = localizedSeparator
+        } else {
+            separator = "."
+        }
+        return _toString(withDecimalSeparator: separator)
     }
     
     @_spi(SwiftCorelibsFoundation)
@@ -199,7 +206,7 @@ extension Decimal {
         _decimal(from: stringView, decimalSeparator: decimalSeparator, matchEntireString: matchEntireString).asOptional
     }
 #endif
-    internal func _toString(with locale: Locale? = nil) -> String {
+    internal func _toString(withDecimalSeparator separator: String) -> String {
         if self.isNaN {
             return "NaN"
         }
@@ -207,13 +214,6 @@ extension Decimal {
             return "0"
         }
         var buffer = ""
-        let separator: String
-        if let locale = locale,
-           let localizedSeparator = locale.decimalSeparator {
-            separator = String(localizedSeparator.reversed())
-        } else {
-            separator = "."
-        }
         var copy = self
         while copy._exponent > 0 {
             buffer += "0"

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -112,10 +112,10 @@ final class DecimalTests : XCTestCase {
 
     func test_DescriptionWithLocale() {
         let decimal = Decimal(string: "-123456.789")!
-        XCTAssertEqual(decimal._toString(with: nil), "-123456.789")
-        let en = decimal._toString(with: Locale(identifier: "en_GB"))
+        XCTAssertEqual(decimal._toString(withDecimalSeparator: "."), "-123456.789")
+        let en = decimal._toString(withDecimalSeparator: Locale(identifier: "en_GB").decimalSeparator!)
         XCTAssertEqual(en, "-123456.789")
-        let fr = decimal._toString(with: Locale(identifier: "fr_FR"))
+        let fr = decimal._toString(withDecimalSeparator: Locale(identifier: "fr_FR").decimalSeparator!)
         XCTAssertEqual(fr, "-123456,789")
     }
 
@@ -1222,10 +1222,10 @@ final class DecimalTests : XCTestCase {
     #else
     func test_toString() {
         let decimal = Decimal(string: "-123456.789")!
-        XCTAssertEqual(decimal.toString(with: nil), "-123456.789")
-        let en = decimal.toString(with: Locale(identifier: "en_GB"))
+        XCTAssertEqual(decimal._toString(withDecimalSeparator: "."), "-123456.789")
+        let en = decimal._toString(withDecimalSeparator: Locale(identifier: "en_GB").decimalSeparator!)
         XCTAssertEqual(en, "-123456.789")
-        let fr = decimal.toString(with: Locale(identifier: "fr_FR"))
+        let fr = decimal._toString(withDecimalSeparator: Locale(identifier: "fr_FR").decimalSeparator!)
         XCTAssertEqual(fr, "-123456,789")
     }
 


### PR DESCRIPTION
NSDecimalString historically accepted Any as the second parameter, which could be either a Locale or a Dictionary. We should keep that behavior.