### PR TITLE
Enable reading attributes of directory on Windows

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -555,7 +555,7 @@ extension _FileManagerImpl {
     func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
 #if os(Windows)
         return try path.withNTPathRepresentation { pwszPath in
-            let hFile = CreateFileW(pwszPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil, OPEN_EXISTING, 0, nil)
+            let hFile = CreateFileW(pwszPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nil)
             if hFile == INVALID_HANDLE_VALUE {
                 throw CocoaError.errorWithFilePath(path, win32: GetLastError(), reading: true)
             }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -864,4 +864,39 @@ final class FileManagerTests : XCTestCase {
             try $0.setAttributes(attrs, ofItemAtPath: "foo")
         }
     }
+    
+    func testAttributesOfItemAtPath() throws {
+        try FileManagerPlayground {
+            "file"
+            File("fileWithContents", contents: randomData())
+            Directory("directory") {
+                "file"
+            }
+        }.test {
+            do {
+                let attrs = try $0.attributesOfItem(atPath: "file")
+                XCTAssertEqual(attrs[.size] as? UInt, 0)
+                XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeRegular)
+            }
+            
+            do {
+                let attrs = try $0.attributesOfItem(atPath: "fileWithContents")
+                XCTAssertGreaterThan(try XCTUnwrap(attrs[.size] as? UInt), 0)
+                XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeRegular)
+            }
+            
+            do {
+                let attrs = try $0.attributesOfItem(atPath: "directory")
+                XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeDirectory)
+            }
+            
+            #if !os(Windows)
+            do {
+                try $0.createSymbolicLink(atPath: "symlink", withDestinationPath: "file")
+                let attrs = try $0.attributesOfItem(atPath: "symlink")
+                XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeSymbolicLink)
+            }
+            #endif
+        }
+    }
 }


### PR DESCRIPTION
Per the [`CreateFileW` documentation](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew):

> FILE_FLAG_BACKUP_SEMANTICS: You must set this flag to obtain a handle to a directory. A directory handle can be passed to some functions instead of a file handle.

This causes an error when attempting to read attributes of a directory (the API throws the `.fileReadNoPermission` error). This resolves an issue that prevents SwiftPM from functioning properly on Windows