### PR TITLE
Correctly set .fileTypeSymlink on windows

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -890,13 +890,11 @@ final class FileManagerTests : XCTestCase {
                 XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeDirectory)
             }
             
-            #if !os(Windows)
             do {
                 try $0.createSymbolicLink(atPath: "symlink", withDestinationPath: "file")
                 let attrs = try $0.attributesOfItem(atPath: "symlink")
                 XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeSymbolicLink)
             }
-            #endif
         }
     }
 }


### PR DESCRIPTION
When calculating file attributes for an item, we did not previously correctly detect symlinks on Windows. This updates the implementation to correctly detect symlinks and set the file type when populating the attributes dictionary.