### PR TITLE
Add explicit void type parameter to C functions without parameters

### DIFF
--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -31,19 +31,19 @@
 #include <security.h>
 #endif
 
-INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ();
+INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ(void);
 
-INTERNAL void _platform_shims_lock_environ();
-INTERNAL void _platform_shims_unlock_environ();
+INTERNAL void _platform_shims_lock_environ(void);
+INTERNAL void _platform_shims_unlock_environ(void);
 
 #if __has_include(<mach/vm_page_size.h>)
 #include <mach/vm_page_size.h>
-INTERNAL vm_size_t _platform_shims_vm_size();
+INTERNAL vm_size_t _platform_shims_vm_size(void);
 #endif
 
 #if __has_include(<mach/mach.h>)
 #include <mach/mach.h>
-INTERNAL mach_port_t _platform_mach_task_self();
+INTERNAL mach_port_t _platform_mach_task_self(void);
 #endif
 
 #if __has_include(<libkern/OSThermalNotification.h>)
@@ -65,7 +65,7 @@ typedef enum {
 } _platform_shims_OSThermalPressureLevel;
 
 
-INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName();
+INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName(void);
 #endif
 
 #endif /* CSHIMS_PLATFORM_SHIMS */

--- a/Sources/_FoundationCShims/platform_shims.c
+++ b/Sources/_FoundationCShims/platform_shims.c
@@ -23,19 +23,19 @@ extern char **environ;
 
 #if __has_include(<libc_private.h>)
 #import <libc_private.h>
-void _platform_shims_lock_environ() {
+void _platform_shims_lock_environ(void) {
     environ_lock_np();
 }
 
-void _platform_shims_unlock_environ() {
+void _platform_shims_unlock_environ(void) {
     environ_unlock_np();
 }
 #else
-void _platform_shims_lock_environ() { /* noop */ }
-void _platform_shims_unlock_environ() { /* noop */ }
+void _platform_shims_lock_environ(void) { /* noop */ }
+void _platform_shims_unlock_environ(void) { /* noop */ }
 #endif
 
-char ** _platform_shims_get_environ() {
+char ** _platform_shims_get_environ(void) {
 #if __has_include(<crt_externs.h>)
     return *_NSGetEnviron();
 #elif defined(_WIN32)
@@ -48,20 +48,20 @@ char ** _platform_shims_get_environ() {
 }
 
 #if __has_include(<libkern/OSThermalNotification.h>)
-const char * _platform_shims_kOSThermalNotificationPressureLevelName() {
+const char * _platform_shims_kOSThermalNotificationPressureLevelName(void) {
     return kOSThermalNotificationPressureLevelName;
 }
 #endif
 
 #if __has_include(<mach/vm_page_size.h>)
-vm_size_t _platform_shims_vm_size() {
+vm_size_t _platform_shims_vm_size(void) {
     // This shim exists because vm_page_size is not marked const, and therefore looks like global mutable state to Swift.
     return vm_page_size;
 }
 #endif
 
 #if __has_include(<mach/mach.h>)
-mach_port_t _platform_mach_task_self() {
+mach_port_t _platform_mach_task_self(void) {
     // This shim exists because mach_task_self_ is not marked const, and therefore looks like global mutable state to Swift.
     return mach_task_self();
 }


### PR DESCRIPTION
C functions with `()` as parameter list can take any number of parameters. But WebAssembly requires static signature information for every function call, so we need to explicitly specify `(void)` to indicate that the function takes no parameters.