### PR TITLE
Add WASI platform conditions for libc imports and word size

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -25,6 +25,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 func _fgetxattr(_ fd: Int32, _ name: UnsafePointer<CChar>!, _ value: UnsafeMutableRawPointer!, _ size: Int, _ position: UInt32, _ options: Int32) -> Int {

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -27,6 +27,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !NO_FILESYSTEM

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -76,6 +76,8 @@ import Glibc
 import Musl
 #elseif canImport(ucrt)
 import ucrt
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 #if os(Windows)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -582,11 +582,11 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @usableFromInline
     @frozen
     internal struct InlineData : Sendable {
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
-#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#elseif _pointerBitWidth(_32)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
@@ -617,9 +617,9 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         @inlinable // This is @inlinable as a trivial initializer.
         init(count: Int = 0) {
             assert(count <= MemoryLayout<Buffer>.size)
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
-#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#elseif _pointerBitWidth(_32)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
 #else
     #error ("Unsupported architecture: initialization for Buffer is required for this architecture")
@@ -804,9 +804,9 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
     @usableFromInline internal typealias HalfInt = Int32
-#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#elseif _pointerBitWidth(_32)
     @usableFromInline internal typealias HalfInt = Int16
 #else
     #error ("Unsupported architecture: a definition of half of the pointer sized Int needs to be defined for this architecture")

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -586,7 +586,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
@@ -619,7 +619,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             assert(count <= MemoryLayout<Buffer>.size)
 #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
 #else
     #error ("Unsupported architecture: initialization for Buffer is required for this architecture")
@@ -806,7 +806,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
 
 #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
     @usableFromInline internal typealias HalfInt = Int32
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
     @usableFromInline internal typealias HalfInt = Int16
 #else
     #error ("Unsupported architecture: a definition of half of the pointer sized Int needs to be defined for this architecture")

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -18,6 +18,8 @@ import Bionic
 import Glibc
 #elseif canImport(WinSDK)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 private let powerOfTen: [Decimal.VariableLengthInteger] = [

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -22,6 +22,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 extension CocoaError.Code {

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -19,6 +19,8 @@
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -19,6 +19,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -26,6 +26,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationCShims

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -26,6 +26,9 @@ internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+internal import _FoundationCShims
+import WASILibc
 #endif
 
 extension Date {

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -21,6 +21,8 @@ import Glibc
 import CRT
 import WinSDK
 internal import _FoundationCShims
+#elseif os(WASI)
+import WASILibc
 #endif
 
 extension _FileManagerImpl {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -31,6 +31,8 @@ internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -19,6 +19,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 // MARK: - BinaryInteger + Numeric string representation

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -21,6 +21,8 @@ import unistd
 import Glibc
 #elseif os(Windows)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !NO_PROCESS

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -16,6 +16,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if canImport(CRT)

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationCShims

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -22,6 +22,8 @@ import Glibc
 import CRT
 #elseif canImport(Darwin)
 import Darwin
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationICU

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -22,6 +22,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)


### PR DESCRIPTION
This is a starting point for repairing WASI build.

`import var WASILibc.errno` patterns appeared in this change is to avoid ambiguous reference for `errno`, which is defined in both errno.h and WASILibc overlay Swift module (we need to fix it in overlay side anyway)