### PR TITLE
Exclude EREMOTE definition for WASI platform

### DIFF
--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -465,10 +465,12 @@ extension POSIXError {
         return .ESTALE
     }
 
+    #if !os(WASI)
     /// Too many levels of remote in path.
     public static var EREMOTE: POSIXErrorCode {
         return .EREMOTE
     }
+    #endif
     #endif
 
     #if canImport(Darwin)


### PR DESCRIPTION
WASI does not define the EREMOTE error code.