### PR TITLE
Throw `.featureUnsupported` when attempting to create temp files on WASI

### DIFF
--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -127,6 +127,10 @@ private func cleanupTemporaryDirectory(at inPath: String?) {
 
 /// Caller is responsible for calling `close` on the `Int32` file descriptor.
 private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, prefix: String, options: Data.WritingOptions) throws -> (Int32, String) {
+#if os(WASI)
+    // WASI does not have temp directories
+    throw CocoaError(.featureUnsupported)
+#else
     var directoryPath = destinationPath
     if !directoryPath.isEmpty && directoryPath.last! != "/" {
         directoryPath.append("/")
@@ -181,6 +185,7 @@ private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, 
             }
         }
     } while true
+#endif // os(WASI)
 }
 
 /// Returns `(file descriptor, temporary file path, temporary directory path)`


### PR DESCRIPTION
WASI does not have temp directory concept, and does not provide mktemp family of functions, so attempting to create a temporary file should be considered a feature unsupported.