### PR TITLE
Port `LockedState` and `_ThreadLocal` to WASI without any locking

### DIFF
--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -33,6 +33,9 @@ package struct LockedState<State> {
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
         typealias Primitive = SRWLOCK
+#elseif os(WASI)
+        // WASI is single-threaded, so we don't need a lock.
+        typealias Primitive = Void
 #endif
 
         typealias PlatformLock = UnsafeMutablePointer<Primitive>
@@ -45,6 +48,8 @@ package struct LockedState<State> {
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
 
@@ -62,6 +67,8 @@ package struct LockedState<State> {
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
 
@@ -72,6 +79,8 @@ package struct LockedState<State> {
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
     }

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -30,6 +30,8 @@ struct _ThreadLocal {
     fileprivate typealias PlatformKey = tss_t
 #elseif canImport(WinSDK)
     fileprivate typealias PlatformKey = DWORD
+#elseif os(WASI)
+    fileprivate typealias PlatformKey = UnsafeMutablePointer<UnsafeMutableRawPointer?>
 #endif
     
     struct Key<Value> {
@@ -46,6 +48,8 @@ struct _ThreadLocal {
             self.key = key
 #elseif canImport(WinSDK)
             key = FlsAlloc(nil)
+#elseif os(WASI)
+            key = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(capacity: 1)
 #endif
         }
     }
@@ -58,6 +62,8 @@ struct _ThreadLocal {
             tss_get(key)
 #elseif canImport(WinSDK)
             FlsGetValue(key)
+#elseif os(WASI)
+            key.pointee
 #endif
         }
         
@@ -68,6 +74,8 @@ struct _ThreadLocal {
             tss_set(key, newValue)
 #elseif canImport(WinSDK)
             FlsSetValue(key, newValue)
+#elseif os(WASI)
+            key.pointee = newValue
 #endif
         }
     }


### PR DESCRIPTION
`wasm32-unknown-wasi` target does not have pthread API and is considered to be single-threaded, so skip actual locking on it.