### PR TITLE
Use platform shims for clock_gettime to support wasi-libc

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(FoundationEssentials
     SortComparator.swift
     UUID_Wrappers.swift
     UUID.swift
+    WASILibc+Extensions.swift
     WinSDK+Extensions.swift)
 
 add_subdirectory(AttributedString)

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -129,7 +129,7 @@ final class _ProcessInfo: Sendable {
 #else
         var ts: timespec = timespec()
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
-        let time: UInt64 = UInt64(ts.tv_sec * 1000000000 + ts.tv_nsec)
+        let time: UInt64 = UInt64(ts.tv_sec) * 1000000000 + UInt64(ts.tv_nsec)
 #endif
         let timeString = String(time, radix: 16, uppercase: true)
         let padding = String(repeating: "0", count: 16 - timeString.count)

--- a/Sources/FoundationEssentials/WASILibc+Extensions.swift
+++ b/Sources/FoundationEssentials/WASILibc+Extensions.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if os(WASI)
+
+import WASILibc
+internal import _FoundationCShims
+
+// MARK: - Clock
+
+internal var CLOCK_REALTIME: clockid_t {
+    return _platform_shims_clock_realtime()
+}
+
+internal var CLOCK_MONOTONIC: clockid_t {
+    return _platform_shims_clock_monotonic()
+}
+
+internal var CLOCK_MONOTONIC_RAW: clockid_t {
+    // WASI does not have a raw monotonic clock, so we use the monotonic clock instead.
+    return CLOCK_MONOTONIC
+}
+
+#endif // os(WASI)

--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -68,4 +68,17 @@ typedef enum {
 INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName();
 #endif
 
+#if TARGET_OS_WASI
+// Define clock id getter shims so that we can use them in Swift
+// even if clock id macros can't be imported through ClangImporter.
+
+#include <time.h>
+static inline _Nonnull clockid_t _platform_shims_clock_monotonic(void) {
+    return CLOCK_MONOTONIC;
+}
+static inline _Nonnull clockid_t _platform_shims_clock_realtime(void) {
+    return CLOCK_REALTIME;
+}
+#endif
+
 #endif /* CSHIMS_PLATFORM_SHIMS */


### PR DESCRIPTION
This change adds platform shims for `clock_gettime` so that we can use it in Swift code even when the clock id macros can't be imported through ClangImporter like wasi-libc's definitions.

Also wasi-libc's `timespec.tv_sec` and `timespec.tv_nsec` are not imported as `Int` in Swift, so we need to cast them to `UInt64` before doing arithmetic operations on them.