### PR TITLE
Fix `operatingSystemVersion` on WASI

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -389,7 +389,7 @@ extension _ProcessInfo {
             patch: Int(osVersionInfo.dwBuildNumber)
         )
 #else
-        return OperatingSystemVersion(majorVersion: -1, minorVersion: 0, patchVersion: 0)
+        return (major: -1, minor: 0, patch: 0)
 #endif
     }
 


### PR DESCRIPTION
The `operatingSystemVersion` property type is a tuple but the it was returning an `OperatingSystemVersion` instance on unknown platforms.