### PR TITLE
Skip sticky-bit check in `isDeletableFile` on WASI

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -461,7 +461,7 @@ extension _FileManagerImpl {
             parent = fileManager.currentDirectoryPath
         }
 
-#if os(Windows)
+#if os(Windows) || os(WASI)
         return fileManager.isWritableFile(atPath: parent) && fileManager.isWritableFile(atPath: path)
 #else
         guard fileManager.isWritableFile(atPath: parent),


### PR DESCRIPTION
WASI does not surface the sticky bit and getuid, so we cannot check whether the file is actually deletable before attempting to delete it.