### PR TITLE
[6.0] Correctly set .fileTypeSymlink on windows

### DIFF
--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -890,13 +890,11 @@ final class FileManagerTests : XCTestCase {
                 XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeDirectory)
             }
             
-            #if !os(Windows)
             do {
                 try $0.createSymbolicLink(atPath: "symlink", withDestinationPath: "file")
                 let attrs = try $0.attributesOfItem(atPath: "symlink")
                 XCTAssertEqual(attrs[.type] as? FileAttributeType, FileAttributeType.typeSymbolicLink)
             }
-            #endif
         }
     }
 }


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift-foundation/pull/773

Explanation: Fixes a regression caused by the foundation re-core in the result of `FileManager.attributesOfItem(atPath:)` for the `.type` key
Scope: Only impacts Windows results of this function
Original PR: https://github.com/apple/swift-foundation/pull/773
Risk: Minimal - this only impacts Windows, and we have a unit test in place that tests this change
Testing: Testing done via local unit testing and swift-ci testing
Reviewer: @compnerd 