### PR TITLE
[CMake] Resolve module map conflict with duplicate in SDK

### DIFF
--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -19,6 +19,9 @@ add_library(_FoundationCShims STATIC
 
 target_include_directories(_FoundationCShims PUBLIC include)
 
+target_compile_options(_FoundationCShims INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+
 set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _FoundationCShims)
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
When building this package locally via CMake using a toolchain that contains the _FoundationCShims module, you currently encounter errors like:

```
/usr/lib/swift/_FoundationCShims/module.modulemap:1:8: error: redefinition of module '_FoundationCShims'
1 | module _FoundationCShims {
  |        `- error: redefinition of module '_FoundationCShims'
2 |     header "_FoundationCShims.h"
3 | 

/Repos/Public/swift-foundation/Sources/_FoundationCShims/include/module.modulemap:1:8: note: previously defined here
1 | module _FoundationCShims {
  |        `- note: previously defined here
2 |     header "_FoundationCShims.h"
3 | 
```

To solve this, we add an explicit `-fmodule-map-file` flag to swift clients which causes clang to prefer the local module over the module from the SDK. SwiftPM already applies this flag which is how the SwiftPM build works today.