### PR TITLE
[6.0] Int128 support in json

### DIFF
--- a/Sources/FoundationEssentials/JSON/JSONDecoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONDecoder.swift
@@ -1134,6 +1134,11 @@ extension JSONDecoderImpl : SingleValueDecodingContainer {
     func decode(_: Int64.Type) throws -> Int64 {
         try decodeFixedWidthInteger()
     }
+  
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func decode(_: Int128.Type) throws -> Int128 {
+      try decodeFixedWidthInteger()
+    }
 
     func decode(_: UInt.Type) throws -> UInt {
         try decodeFixedWidthInteger()
@@ -1153,6 +1158,11 @@ extension JSONDecoderImpl : SingleValueDecodingContainer {
 
     func decode(_: UInt64.Type) throws -> UInt64 {
         try decodeFixedWidthInteger()
+    }
+  
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func decode(_: UInt128.Type) throws -> UInt128 {
+      try decodeFixedWidthInteger()
     }
 
     func decode<T: Decodable>(_ type: T.Type) throws -> T {
@@ -1280,6 +1290,11 @@ extension JSONDecoderImpl {
         func decode(_: Int64.Type, forKey key: K) throws -> Int64 {
             try decodeFixedWidthInteger(key: key)
         }
+      
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+        func decode(_: Int128.Type, forKey key: K) throws -> Int128 {
+          try decodeFixedWidthInteger(key: key)
+        }
 
         func decode(_: UInt.Type, forKey key: K) throws -> UInt {
             try decodeFixedWidthInteger(key: key)
@@ -1299,6 +1314,11 @@ extension JSONDecoderImpl {
 
         func decode(_: UInt64.Type, forKey key: K) throws -> UInt64 {
             try decodeFixedWidthInteger(key: key)
+        }
+      
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+        func decode(_: UInt128.Type, forKey key: K) throws -> UInt128 {
+          try decodeFixedWidthInteger(key: key)
         }
 
         func decode<T: Decodable>(_ type: T.Type, forKey key: K) throws -> T {
@@ -1462,6 +1482,11 @@ extension JSONDecoderImpl {
         mutating func decode(_: Int64.Type) throws -> Int64 {
             try decodeFixedWidthInteger()
         }
+      
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+        mutating func decode(_: Int128.Type) throws -> Int128 {
+          try decodeFixedWidthInteger()
+        }
 
         mutating func decode(_: UInt.Type) throws -> UInt {
             try decodeFixedWidthInteger()
@@ -1481,6 +1506,11 @@ extension JSONDecoderImpl {
 
         mutating func decode(_: UInt64.Type) throws -> UInt64 {
             try decodeFixedWidthInteger()
+        }
+      
+        @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+        mutating func decode(_: UInt128.Type) throws -> UInt128 {
+          try decodeFixedWidthInteger()
         }
 
         mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {

--- a/Sources/FoundationEssentials/JSON/JSONEncoder.swift
+++ b/Sources/FoundationEssentials/JSON/JSONEncoder.swift
@@ -712,6 +712,10 @@ private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContain
     public mutating func encode(_ value: Int64, forKey key: Key) throws {
         reference.insert(self.encoder.wrap(value), for: _converted(key))
     }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public mutating func encode(_ value: Int128, forKey key: Key) throws {
+        reference.insert(self.encoder.wrap(value), for: _converted(key))
+    }
     public mutating func encode(_ value: UInt, forKey key: Key) throws {
         reference.insert(self.encoder.wrap(value), for: _converted(key))
     }
@@ -725,6 +729,10 @@ private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContain
         reference.insert(self.encoder.wrap(value), for: _converted(key))
     }
     public mutating func encode(_ value: UInt64, forKey key: Key) throws {
+        reference.insert(self.encoder.wrap(value), for: _converted(key))
+    }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public mutating func encode(_ value: UInt128, forKey key: Key) throws {
         reference.insert(self.encoder.wrap(value), for: _converted(key))
     }
     public mutating func encode(_ value: String, forKey key: Key) throws {
@@ -827,11 +835,15 @@ private struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     public mutating func encode(_ value: Int16)  throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: Int32)  throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: Int64)  throws { self.reference.insert(self.encoder.wrap(value)) }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public mutating func encode(_ value: Int128)  throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: UInt)   throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: UInt8)  throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: UInt16) throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: UInt32) throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: UInt64) throws { self.reference.insert(self.encoder.wrap(value)) }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public mutating func encode(_ value: UInt128)  throws { self.reference.insert(self.encoder.wrap(value)) }
     public mutating func encode(_ value: String) throws { self.reference.insert(self.encoder.wrap(value)) }
 
     public mutating func encode(_ value: Float)  throws {
@@ -908,6 +920,12 @@ extension __JSONEncoder : SingleValueEncodingContainer {
         assertCanEncodeNewValue()
         self.storage.push(ref: wrap(value))
     }
+    
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public func encode(_ value: Int128) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(ref: wrap(value))
+    }
 
     public func encode(_ value: UInt) throws {
         assertCanEncodeNewValue()
@@ -930,6 +948,12 @@ extension __JSONEncoder : SingleValueEncodingContainer {
     }
 
     public func encode(_ value: UInt64) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(ref: wrap(value))
+    }
+    
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public func encode(_ value: UInt128) throws {
         assertCanEncodeNewValue()
         self.storage.push(ref: wrap(value))
     }
@@ -967,11 +991,15 @@ private extension __JSONEncoder {
     @inline(__always) func wrap(_ value: Int16)  -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: Int32)  -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: Int64)  -> JSONReference { .number(from: value) }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    @inline(__always) func wrap(_ value: Int128)  -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: UInt)   -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: UInt8)  -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: UInt16) -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: UInt32) -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: UInt64) -> JSONReference { .number(from: value) }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    @inline(__always) func wrap(_ value: UInt128)  -> JSONReference { .number(from: value) }
     @inline(__always) func wrap(_ value: String) -> JSONReference { .string(value) }
 
     @inline(__always)
@@ -1302,11 +1330,15 @@ extension Int8 : _JSONSimpleValueArrayElement { }
 extension Int16 : _JSONSimpleValueArrayElement { }
 extension Int32 : _JSONSimpleValueArrayElement { }
 extension Int64 : _JSONSimpleValueArrayElement { }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension Int128 : _JSONSimpleValueArrayElement { }
 extension UInt : _JSONSimpleValueArrayElement { }
 extension UInt8 : _JSONSimpleValueArrayElement { }
 extension UInt16 : _JSONSimpleValueArrayElement { }
 extension UInt32 : _JSONSimpleValueArrayElement { }
 extension UInt64 : _JSONSimpleValueArrayElement { }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension UInt128 : _JSONSimpleValueArrayElement { }
 extension String: _JSONSimpleValueArrayElement {
     fileprivate func jsonRepresentation(options: JSONEncoder._Options) -> String {
         self.serializedForJSON(withoutEscapingSlashes: options.outputFormatting.contains(.withoutEscapingSlashes))

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1327,41 +1327,91 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTrip(of: testValue)
     }
   
-    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     func test_roundTrippingInt128() {
-        let values = [
-            Int128.min,
-            Int128.min + 1,
-            -0x1_0000_0000_0000_0000,
-            0x0_8000_0000_0000_0000,
-            -1,
-            0,
-            0x7fff_ffff_ffff_ffff,
-            0x8000_0000_0000_0000,
-            0xffff_ffff_ffff_ffff,
-            0x1_0000_0000_0000_0000,
-            .max
-        ]
-        for i128 in values {
-            _testRoundTrip(of: i128)
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            let values = [
+                Int128.min,
+                Int128.min + 1,
+                -0x1_0000_0000_0000_0000,
+                0x0_8000_0000_0000_0000,
+                -1,
+                0,
+                0x7fff_ffff_ffff_ffff,
+                0x8000_0000_0000_0000,
+                0xffff_ffff_ffff_ffff,
+                0x1_0000_0000_0000_0000,
+                .max
+            ]
+            for i128 in values {
+                _testRoundTrip(of: i128)
+            }
         }
     }
     
-    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func test_Int128SlowPath() {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            let decoder = JSONDecoder()
+            let work: [Int128] = [18446744073709551615, -18446744073709551615]
+            for value in work {
+                // force the slow-path by appending ".0"
+                let json = "\(value).0".data(using: String._Encoding.utf8)!
+                XCTAssertEqual(value, try? decoder.decode(Int128.self, from: json))
+            }
+            // These should work, but making them do so probably requires
+            // rewriting the slow path to use a dedicated parser. For now,
+            // we ensure that they throw instead of returning some bogus
+            // result.
+            let shouldWorkButDontYet: [Int128] = [
+                .min, -18446744073709551616, 18446744073709551616, .max
+            ]
+            for value in shouldWorkButDontYet {
+                // force the slow-path by appending ".0"
+                let json = "\(value).0".data(using: String._Encoding.utf8)!
+                XCTAssertThrowsError(try decoder.decode(Int128.self, from: json))
+            }
+        }
+    }
+    
     func test_roundTrippingUInt128() {
-        let values = [
-            UInt128.zero,
-            1,
-            0x0000_0000_0000_0000_7fff_ffff_ffff_ffff,
-            0x0000_0000_0000_0000_8000_0000_0000_0000,
-            0x0000_0000_0000_0000_ffff_ffff_ffff_ffff,
-            0x0000_0000_0000_0001_0000_0000_0000_0000,
-            0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
-            0x8000_0000_0000_0000_0000_0000_0000_0000,
-            .max
-        ]
-        for u128 in values {
-            _testRoundTrip(of: u128)
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            let values = [
+                UInt128.zero,
+                1,
+                0x0000_0000_0000_0000_7fff_ffff_ffff_ffff,
+                0x0000_0000_0000_0000_8000_0000_0000_0000,
+                0x0000_0000_0000_0000_ffff_ffff_ffff_ffff,
+                0x0000_0000_0000_0001_0000_0000_0000_0000,
+                0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
+                0x8000_0000_0000_0000_0000_0000_0000_0000,
+                .max
+            ]
+            for u128 in values {
+                _testRoundTrip(of: u128)
+            }
+        }
+    }
+    
+    func test_UInt128SlowPath() {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            let decoder = JSONDecoder()
+            let work: [UInt128] = [18446744073709551615]
+            for value in work {
+                // force the slow-path by appending ".0"
+                let json = "\(value).0".data(using: String._Encoding.utf8)!
+                XCTAssertEqual(value, try? decoder.decode(UInt128.self, from: json))
+            }
+            // These should work, but making them do so probably requires
+            // rewriting the slow path to use a dedicated parser. For now,
+            // we ensure that they throw instead of returning some bogus
+            // result.
+            let shouldWorkButDontYet: [UInt128] = [
+                18446744073709551616, .max
+            ]
+            for value in shouldWorkButDontYet {
+                // force the slow-path by appending ".0"
+                let json = "\(value).0".data(using: String._Encoding.utf8)!
+                XCTAssertThrowsError(try decoder.decode(UInt128.self, from: json))
+            }
         }
     }
 

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -612,6 +612,9 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
+        if #available(macOS 15.0, *) {
+          _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt128], as: [Bool].self)
+        }
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
     }
@@ -1322,6 +1325,44 @@ final class JSONEncoderTests : XCTestCase {
         }
         let testValue = Numbers(floats: [.greatestFiniteMagnitude, .leastNormalMagnitude], doubles: [.greatestFiniteMagnitude, .leastNormalMagnitude])
         _testRoundTrip(of: testValue)
+    }
+  
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func test_roundTrippingInt128() {
+        let values = [
+            Int128.min,
+            Int128.min + 1,
+            -0x1_0000_0000_0000_0000,
+            0x0_8000_0000_0000_0000,
+            -1,
+            0,
+            0x7fff_ffff_ffff_ffff,
+            0x8000_0000_0000_0000,
+            0xffff_ffff_ffff_ffff,
+            0x1_0000_0000_0000_0000,
+            .max
+        ]
+        for i128 in values {
+            _testRoundTrip(of: i128)
+        }
+    }
+    
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func test_roundTrippingUInt128() {
+        let values = [
+            UInt128.zero,
+            1,
+            0x0000_0000_0000_0000_7fff_ffff_ffff_ffff,
+            0x0000_0000_0000_0000_8000_0000_0000_0000,
+            0x0000_0000_0000_0000_ffff_ffff_ffff_ffff,
+            0x0000_0000_0000_0001_0000_0000_0000_0000,
+            0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
+            0x8000_0000_0000_0000_0000_0000_0000_0000,
+            .max
+        ]
+        for u128 in values {
+            _testRoundTrip(of: u128)
+        }
     }
 
     func test_roundTrippingDoubleValues() {


### PR DESCRIPTION
Support for round-tripping [U]Int128 through our JSON encoder + decoder.

Clone of https://github.com/apple/swift-foundation/pull/767 for 6.0