### PR TITLE
URL: Don't standardize relative file paths

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -2155,14 +2155,6 @@ extension URL {
             isDirectory = filePath.utf8.last == slash
         }
 
-        if !isAbsolute {
-            #if !NO_FILESYSTEM
-            filePath = filePath.standardizingPath
-            #else
-            filePath = filePath.removingDotSegments
-            #endif
-        }
-
         #if os(Windows)
         // Convert any "\" back to "/" before storing the URL parse info
         filePath = filePath.replacing(UInt8(ascii: "\\"), with: UInt8(ascii: "/"))

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -352,6 +352,23 @@ final class URLTests : XCTestCase {
         }
     }
 
+    func testURLRelativeDotDotResolution() throws {
+        let baseURL = URL(filePath: "/docs/src/")
+        var result = URL(filePath: "../images/foo.png", relativeTo: baseURL)
+        #if FOUNDATION_FRAMEWORK_NSURL
+        XCTAssertEqual(result.path, "/docs/images/foo.png")
+        #else
+        XCTAssertEqual(result.path(), "/docs/images/foo.png")
+        #endif
+
+        result = URL(filePath: "/../images/foo.png", relativeTo: baseURL)
+        #if FOUNDATION_FRAMEWORK_NSURL
+        XCTAssertEqual(result.path, "/../images/foo.png")
+        #else
+        XCTAssertEqual(result.path(), "/../images/foo.png")
+        #endif
+    }
+
     func testAppendFamily() throws {
         let base = URL(string: "https://www.example.com")!
 


### PR DESCRIPTION
Resolves https://github.com/apple/swift-foundation/issues/790 (thanks @nicklockwood for filing!)

We should not standardize the relative path outside of the context of its base URL, such as when calculating the absolute `.path()`. This allows us to properly handle `".."` segments at the beginning of the relative path, such as in

```
let baseURL = URL(filePath: "/docs/src/")
let result = URL(filePath: "../images/foo.png", relativeTo: baseURL)
XCTAssertEqual(result.path(), "/docs/images/foo.png")
```

Note that if the inputted path is absolute, e.g. `"/../images/foo.png"`, we should not resolve against the base URL. I've added a small unit test to cover both cases.