### PR TITLE
[CMake] Fix macro install rpath

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,8 +43,9 @@ target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntaxBuilder
 )
 
+# The macro is installed into lib/swift/host/plugins, but needs to load libraries from lib/swift/host and lib/swift/${SWIFT_SYSTEM_NAME}
 set_target_properties(FoundationMacros PROPERTIES
-    INSTALL_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN/../../../swift/${SWIFT_SYSTEM_NAME}:$ORIGIN/.."
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 target_compile_options(FoundationMacros PRIVATE -parse-as-library)


### PR DESCRIPTION
This updates the macro library's rpath to reference the correct locations for the host and stldib libraries that it depends upon. This matches the rpath values for the existing macro libraries:

```
# readelf -d /usr/lib/swift/host/plugins/libSwiftMacros.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../../../swift/linux:$ORIGIN/..]
```

I confirmed that using a locally built `libFoundationMacros.so` with this change successfully finds the required libraries rather than erroring out with `compiler plugin '/usr/lib/swift/host/plugins/libFoundationMacros.so' could not be loaded;  libswift_StringProcessing.so: cannot open shared object file: No such file or directory` like before