### PR TITLE
[6.0] Add explicit modulemap path to take priority over modulemap from SDK

### DIFF
--- a/Sources/_FoundationCShims/CMakeLists.txt
+++ b/Sources/_FoundationCShims/CMakeLists.txt
@@ -19,6 +19,9 @@ add_library(_FoundationCShims STATIC
 
 target_include_directories(_FoundationCShims PUBLIC include)
 
+target_compile_options(_FoundationCShims INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+
 set_property(GLOBAL APPEND PROPERTY SWIFT_FOUNDATION_EXPORTS _FoundationCShims)
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
Explanation: Allows building the project via CMake outside of the toolchain
Scope: Should only resolve an issue in local, non-toolchain CMake builds
Original PR: https://github.com/apple/swift-foundation/pull/789
Risk: Minimal - minor change to CMake that has been tested
Testing: Testing done via swift-ci toolchain builds and local, standalone CMake builds
Reviewer: @iCharlesHu