### PR TITLE
Remove unneccessary _FileManagerImpl.delegate

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -41,21 +41,12 @@ extension LARGE_INTEGER /* : @retroactive Equatable */ {
 
 internal struct _FileManagerImpl {
     weak var _manager: FileManager?
-    weak var delegate: FileManagerDelegate?
     
     var fileManager: FileManager {
         guard let _manager else {
             fatalError("_FileManagerImpl called without a valid reference to a FileManager")
         }
         return _manager
-    }
-    
-    var safeDelegate: FileManagerDelegate? {
-#if FOUNDATION_FRAMEWORK
-        fileManager._safeDelegate() as? FileManagerDelegate
-#else
-        self.delegate
-#endif
     }
     
     init() {}


### PR DESCRIPTION
A file manager's delegate is stored as a property of the `FileManager` itself, rather than as a property of the underlying `_FileManagerImpl` type. However, when creating this type I accidentally left a stray `delegate` property here that was unused. To Avoid confusion, remove the extra, unused property and the function that referenced it so that it's clear that only `FileManager.delegate` is used.