### PR TITLE
[6.0] [CMake] Fix macro install rpath

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -43,8 +43,9 @@ target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntaxBuilder
 )
 
+# The macro is installed into lib/swift/host/plugins, but needs to load libraries from lib/swift/host and lib/swift/${SWIFT_SYSTEM_NAME}
 set_target_properties(FoundationMacros PROPERTIES
-    INSTALL_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN/../../../swift/${SWIFT_SYSTEM_NAME}:$ORIGIN/.."
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 target_compile_options(FoundationMacros PRIVATE -parse-as-library)


### PR DESCRIPTION
Explanation: Fixes the rpath value for the Foundation macro library in the toolchain
Scope: Should only modify the rpath value for the macro library which is currently only built on linux
Original PR: https://github.com/apple/swift-foundation/pull/793
Risk: Minimal - minor change to fix an already-broken rpath value for a macro library which no other toolchain components are using yet
Testing: Testing done via local build and validation of the rpath as well as swift-ci toolchain builds and testing
Reviewer: @iCharlesHu