### PR TITLE
Fix to correct order of the alphabet

### DIFF
--- a/Benchmarks/Benchmarks/String/BenchmarkString.swift
+++ b/Benchmarks/Benchmarks/String/BenchmarkString.swift
@@ -26,7 +26,7 @@ let benchmarks = {
     Benchmark.defaultConfiguration.metrics = [.cpuTotal, .wallClock, .throughput]
     
     // MARK: Encoding strings
-    let asciiSmallStr = "abcdefghijklmnopqrtuvwxyz"
+    let asciiSmallStr = "abcdefghijklmnopqrstuvwxyz"
     let nonAsciiSmallStr = "🛬x𝄞𝄢y👽"
     
     var asciiLargeStr = ""


### PR DESCRIPTION
### Summary

I fixed to correct order of the alphabet in `BenchmarkString.swift` because it's missing the letter 's'.


