### PR TITLE
Adding some more tests for [U]Int128 in BinaryInteger+FormatStyleTests.swift  and JSONEncoderTests.swift

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1040,7 +1040,7 @@ public struct URL: Equatable, Sendable, Hashable {
         return basePath.merging(relativePath: relativePath)
     }
 
-    /// Calculate the "merged" path that is resovled against the base URL
+    /// Calculate the "merged" path that is resolved against the base URL
     private var mergedPath: String {
         return mergedPath(for: relativePath())
     }

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -43,7 +43,7 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: Int16.self, min: "-32768", max: "32767")
         check(type: Int32.self, min: "-2147483648", max: "2147483647")
         check(type: Int64.self, min: "-9223372036854775808", max: "9223372036854775807")
-        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             check(type: Int128.self, min: "-170141183460469231731687303715884105728", max: "170141183460469231731687303715884105727")
         }
 
@@ -51,7 +51,7 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: UInt16.self, min: "0", max: "65535")
         check(type: UInt32.self, min: "0", max: "4294967295")
         check(type: UInt64.self, min: "0", max: "18446744073709551615")
-        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             check(type: UInt128.self, min: "0", max: "340282366920938463463374607431768211455")
         }
     }

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -51,6 +51,9 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: UInt16.self, min: "0", max: "65535")
         check(type: UInt32.self, min: "0", max: "4294967295")
         check(type: UInt64.self, min: "0", max: "18446744073709551615")
+        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            check(type: UInt128.self, min: "0", max: "340282366920938463463374607431768211455")
+        }
     }
 
     func testNumericStringRepresentation_builtinIntegersAroundDecimalMagnitude() throws {

--- a/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+++ b/Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
@@ -43,6 +43,9 @@ final class BinaryIntegerFormatStyleTests: XCTestCase {
         check(type: Int16.self, min: "-32768", max: "32767")
         check(type: Int32.self, min: "-2147483648", max: "2147483647")
         check(type: Int64.self, min: "-9223372036854775808", max: "9223372036854775807")
+        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            check(type: Int128.self, min: "-170141183460469231731687303715884105728", max: "170141183460469231731687303715884105727")
+        }
 
         check(type: UInt8.self, min: "0", max: "255")
         check(type: UInt16.self, min: "0", max: "65535")

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -603,6 +603,9 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt64].self)
+         if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt128].self)
+        }
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Float].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Double].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int], as: [Bool].self)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -612,7 +612,7 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
-        if #available(macOS 15.0, *) {
+        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
           _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt128], as: [Bool].self)
         }
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -595,7 +595,7 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int64].self)
-        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int128].self)
         }
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt].self)
@@ -603,7 +603,7 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt64].self)
-         if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+         if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt128].self)
         }
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Float].self)
@@ -613,7 +613,7 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int64], as: [Bool].self)
-        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
           _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int128], as: [Bool].self)
         }
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt], as: [Bool].self)
@@ -621,7 +621,7 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
-        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
           _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt128], as: [Bool].self)
         }
         _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -607,6 +607,9 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int16], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int32], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int64], as: [Bool].self)
+        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+          _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int128], as: [Bool].self)
+        }
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt8], as: [Bool].self)
         _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)

--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -595,6 +595,9 @@ final class JSONEncoderTests : XCTestCase {
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int16].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int32].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int64].self)
+        if @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int128].self)
+        }
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt8].self)
         _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)


### PR DESCRIPTION
### Summary:

+ Bare minimum `[U]Int128` support for `JSONEncoderTests`
+ Add some more `testTypeCoercion` in `testTypeCoercion()`
+ Add some more check `[U]Int128` in `testNumericStringRepresentation_builtinIntegersLimits()`
+ Correct typo comment from `resovled` to `resolved` at `URL.swift`

### Modifications:
+ Sources/FoundationEssentials/URL/URL.swift
+ Tests/FoundationEssentialsTests/Formatting/BinaryInteger+FormatStyleTests.swift
+ Tests/FoundationEssentialsTests/JSONEncoderTests.swift