### PR TITLE
Prevent null character in Windows home directory

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -374,7 +374,7 @@ extension String {
                     guard GetEnvironmentVariableW(pwszVariable, $0.baseAddress, dwLength) == dwLength - 1 else {
                         return nil
                     }
-                    return String(decoding: $0, as: UTF16.self)
+                    return String(decodingCString: $0.baseAddress!, as: UTF16.self)
                 }
             }
         }
@@ -436,7 +436,7 @@ extension String {
             guard GetUserProfileDirectoryW(hToken, $0.baseAddress, &dwcchSize) else {
                 fatalError("unable to query user profile directory")
             }
-            return String(decoding: $0, as: UTF16.self)
+            return String(decodingCString: $0.baseAddress!, as: UTF16.self)
         }
 #else
         #if targetEnvironment(simulator)

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1324,7 +1324,7 @@ public struct URL: Equatable, Sendable, Hashable {
         if result.count > 1 && result.utf8.last == UInt8(ascii: "/") {
             _ = result.popLast()
         }
-        let charsToLeaveEncoded = Set([UInt8(ascii: "/")])
+        let charsToLeaveEncoded: Set<UInt8> = [._slash, 0]
         return Parser.percentDecode(result, excluding: charsToLeaveEncoded) ?? ""
     }
 


### PR DESCRIPTION
Resolves #807

`String(decoding:as:)` was including the null-terminator from the Windows API, and when this is passed to `URL`, it's encoded in the form `file:///C:/Users/alex%00/`. When enumerating the directory, we get the file system representation of the `URL`, which decodes `%00` to back to `\0`. This was causing us to append a file name `alex` to the directory, getting `file:///C:/Users/alex%00/alex`, which "exists" because it was only checking for the existence of `file:///C:/Users/alex`. This cycle repeats, causing an infinite loop in the enumerator.

This PR 1) replaces `String(decoding:as:)` with `String(decodingCString:as:)` in the home directory function and 2) prevents `URL.fileSystemPath` from decoding `%00` to `\0`.