### PR TITLE
[6.0] Upgrade SwiftFoundationICU to version 74

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ var dependencies: [Package.Dependency] {
                 from: "1.1.0"),
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                exact: "0.0.9"),
+                branch: "release/6.0"),
             .package(
                 url: "https://github.com/swiftlang/swift-syntax",
                 from: "600.0.0-latest")

--- a/Tests/FoundationInternationalizationTests/LocaleTests.swift
+++ b/Tests/FoundationInternationalizationTests/LocaleTests.swift
@@ -161,15 +161,9 @@ final class LocaleTests : XCTestCase {
             return localeComponents
         }
 
-#if FIXED_ICU_20187
         verify(cldr: "root", bcp47: "und", icu: "") {
             return Locale.Components(identifier: "")
         }
-#else
-        verify(cldr: "root", bcp47: "und", icu: "en_US_POSIX") {
-            return Locale.Components(identifier: "")
-        }
-#endif
 
         verify(cldr: "und_US", bcp47: "und-US", icu: "_US") {
             return Locale.Components(languageRegion: .unitedStates)
@@ -757,11 +751,7 @@ extension LocaleTests {
 
     // TODO: Reenable once (Locale.canonicalIdentifier) is implemented
     func test_identifierTypesFromSpecialIdentifier() throws {
-#if FIXED_ICU_20187
         verify("", cldr: "root", bcp47: "und", icu: "")
-#else
-        verify("", cldr: "root", bcp47: "und", icu: "en_US_POSIX")
-#endif
         verify("root", cldr: "root", bcp47: "root", icu: "root")
         verify("und", cldr: "root", bcp47: "und", icu: "und")
 
@@ -780,20 +770,12 @@ extension LocaleTests {
 
         // If there's only one component, it is treated as the language code
         verify("123", cldr: "root", bcp47: "und", icu: "123")
-#if FIXED_ICU_20187
         verify("😀123", cldr: "root", bcp47: "und", icu: "")
-#else
-        verify("😀123", cldr: "root", bcp47: "und", icu: "en_US_POSIX")
-#endif
 
         // The "_" prefix marks the start of the region
         verify("_ZZ", cldr: "und_ZZ", bcp47: "und-ZZ", icu: "_ZZ")
         verify("_123", cldr: "und_123", bcp47: "und-123", icu: "_123")
-#if FIXED_ICU_20187
         verify("_😀123", cldr: "root", bcp47: "und", icu: "")
-#else
-        verify("_😀123", cldr: "root", bcp47: "und", icu: "en_US_POSIX")
-#endif
 
         // Starting an ID with script code is an acceptable special case
         verify("Hant", cldr: "hant", bcp47: "hant", icu: "hant")


### PR DESCRIPTION
Explanation: Upgrade SwiftFoundationICU dependency 74, which aligns with macOS Sonoma
Scope: update Package.swift to fetch the new ICU
Original PR: https://github.com/apple/swift-foundation/pull/802
Risk: minimum. Only Package.swift and test files are affected
Testing: Testing done via local SwiftPM tests and swift-ci tests to ensure the new ICU works with SwiftFoundation
Reviewer: @jmschonfeld  