### PR TITLE
[6.0] Prevent null character in Windows home directory

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -374,7 +374,7 @@ extension String {
                     guard GetEnvironmentVariableW(pwszVariable, $0.baseAddress, dwLength) == dwLength - 1 else {
                         return nil
                     }
-                    return String(decoding: $0, as: UTF16.self)
+                    return String(decodingCString: $0.baseAddress!, as: UTF16.self)
                 }
             }
         }
@@ -436,7 +436,7 @@ extension String {
             guard GetUserProfileDirectoryW(hToken, $0.baseAddress, &dwcchSize) else {
                 fatalError("unable to query user profile directory")
             }
-            return String(decoding: $0, as: UTF16.self)
+            return String(decodingCString: $0.baseAddress!, as: UTF16.self)
         }
 #else
         #if targetEnvironment(simulator)

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1324,7 +1324,7 @@ public struct URL: Equatable, Sendable, Hashable {
         if result.count > 1 && result.utf8.last == UInt8(ascii: "/") {
             _ = result.popLast()
         }
-        let charsToLeaveEncoded = Set([UInt8(ascii: "/")])
+        let charsToLeaveEncoded: Set<UInt8> = [._slash, 0]
         return Parser.percentDecode(result, excluding: charsToLeaveEncoded) ?? ""
     }
 


### PR DESCRIPTION
**Explanation:** Prevents a null-terminator from the Windows home directory API from ending up in the resulting `String` or `URL`. Prevents `%00` from being decoded to `\0` when getting a `URL`'s `fileSystemPath`, which is often converted to a C string for file system calls.
**Scope:** Windows-only change from `String(decoding:)` to `String(decodingCString:)` for `homeDirectoryPath(forUser:)`. Not decoding `%00` occurs for file paths of `URL`s on all platforms.
**Original PR:** https://github.com/apple/swift-foundation/pull/808
**Risk:** Low. Minor changes to prevent unexpected behavior when null-characters are included in file paths. The respective Windows APIs null-terminate their output, so `String(decodingCString:)` is safe.
**Testing:** swift-ci testing and local testing on Windows
**Reviewers:** @compnerd @jmschonfeld 