### PR TITLE
Remove _typeByName lookup of _FoundationNSNumberInitializer

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -123,8 +123,8 @@ public protocol _NSNumberInitializer {
 
 @_spi(SwiftCorelibsFoundation)
 dynamic public func _nsNumberInitializer() -> (any _NSNumberInitializer.Type)? {
-    // TODO: return nil here after swift-corelibs-foundation begins dynamically replacing this function
-    _typeByName("Foundation._FoundationNSNumberInitializer") as? any _NSNumberInitializer.Type
+    // Dynamically replaced by swift-corelibs-foundation
+    return nil
 }
 #endif
 


### PR DESCRIPTION
With https://github.com/apple/swift-corelibs-foundation/pull/5045, Foundation now dynamically replaces the implementation of this function when it is present so there is no need to perform a `_typeByName` lookup. We can safely remove this now and just return `nil` because we know that if this implementation is used, (the correct) Foundation is not loaded.