### PR TITLE
Add FoundationNetworking hook for reading contents of remote URL

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2079,6 +2079,14 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         public static let fileProtectionMask = WritingOptions(rawValue: 0xf0000000)
     }
 #endif
+    
+    #if !FOUNDATION_FRAMEWORK
+    @_spi(SwiftCorelibsFoundation)
+    public dynamic init(_contentsOfRemote url: URL, options: ReadingOptions = []) throws {
+        assert(!url.isFileURL)
+        throw CocoaError(.fileReadUnsupportedScheme)
+    }
+    #endif
 
     /// Initialize a `Data` with the contents of a `URL`.
     ///
@@ -2098,7 +2106,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             let d = try NSData(contentsOf: url, options: NSData.ReadingOptions(rawValue: options.rawValue))
             self.init(referencing: d)
             #else
-            throw CocoaError(.fileReadUnsupportedScheme)
+            try self.init(_contentsOfRemote: url, options: options)
             #endif
         }
 #endif


### PR DESCRIPTION
This adds a hook for `FoundationNetworking` to override in order to support an up-call for cases where `Data` needs to read from a non-file URL