### PR TITLE
Fix big float as int crash in JSONDecoder.

### DIFF
--- a/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
+++ b/Tests/FoundationEssentialsTests/JSONEncoderTests.swift
@@ -1865,6 +1865,8 @@ final class JSONEncoderTests : XCTestCase {
             "+1e",
             "-1e ",
             "-1E ",
+            "1147e0286",
+            "1147e02864",
         ]
         for json in unsuccessfulIntegers {
             do {


### PR DESCRIPTION
Fixes (#812) in the least disruptive way I could think of.

I read the comments in the GitHub issue and got the impression that you want to keep the precondition in `JSONScanner.validateNumber(from: fullSource:)`. In that case, I suggest a simple `Bool` to keep track of whether any of the conversions failed halfway. You can then throw a `JSONError.numberIsNotRepresentableInSwift` error if this flag is set, at the end.

Again, a dedicated parser would avoid all of this. But, until then...
