### PR TITLE
[6.0] Remove _typeByName lookup of _FoundationNSNumberInitializer

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -120,8 +120,8 @@ public protocol _NSNumberInitializer {
 
 @_spi(SwiftCorelibsFoundation)
 dynamic public func _nsNumberInitializer() -> (any _NSNumberInitializer.Type)? {
-    // TODO: return nil here after swift-corelibs-foundation begins dynamically replacing this function
-    _typeByName("Foundation._FoundationNSNumberInitializer") as? any _NSNumberInitializer.Type
+    // Dynamically replaced by swift-corelibs-foundation
+    return nil
 }
 #endif
 


### PR DESCRIPTION
Explanation: Removes a _typeByName lookup in a FoundationEssentials up-call that can result in confusion between the toolchain and local builds
Scope: Should only impact up-calls from FileManager in FoundationEssentials to initialize NSNumbers
Original PR: https://github.com/apple/swift-foundation/pull/817
Risk: Minimal - the body of this function is already overridden by SCL-F, this just removes the `_typeByName` lookup for cases where Foundation isn't loaded (and therefore the lookup will only ever fail, or find the wrong Foundation)
Testing: Testing done via swift-ci testing
Reviewer: @itingliu 