### PR TITLE
6.0: Fix WASI support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,14 @@ foreach(version ${_SwiftFoundation_versions})
     endforeach()
 endforeach()
 
+# wasi-libc emulation feature flags
+set(_SwiftFoundation_wasi_libc_flags)
+if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+    list(APPEND _SwiftFoundation_wasi_libc_flags
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_SIGNAL>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_MMAN>")
+endif()
+
 include(GNUInstallDirs)
 include(SwiftFoundationSwiftSupport)
 

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -66,6 +66,7 @@ target_compile_options(FoundationEssentials PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
 target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_availability_macros})
+target_compile_options(FoundationEssentials PRIVATE ${_SwiftFoundation_wasi_libc_flags})
 target_compile_options(FoundationEssentials PRIVATE -package-name "SwiftFoundation")
 
 target_link_libraries(FoundationEssentials PUBLIC

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -25,6 +25,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 func _fgetxattr(_ fd: Int32, _ name: UnsafePointer<CChar>!, _ value: UnsafeMutableRawPointer!, _ size: Int, _ position: UInt32, _ options: Int32) -> Int {

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -27,6 +27,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !NO_FILESYSTEM

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -127,6 +127,10 @@ private func cleanupTemporaryDirectory(at inPath: String?) {
 
 /// Caller is responsible for calling `close` on the `Int32` file descriptor.
 private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, prefix: String, options: Data.WritingOptions) throws -> (Int32, String) {
+#if os(WASI)
+    // WASI does not have temp directories
+    throw CocoaError(.featureUnsupported)
+#else
     var directoryPath = destinationPath
     if !directoryPath.isEmpty && directoryPath.last! != "/" {
         directoryPath.append("/")
@@ -181,6 +185,7 @@ private func createTemporaryFile(at destinationPath: String, inPath: PathOrURL, 
             }
         }
     } while true
+#endif // os(WASI)
 }
 
 /// Returns `(file descriptor, temporary file path, temporary directory path)`

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -519,6 +519,7 @@ private func writeToFileAux(path inPath: PathOrURL, buffer: UnsafeRawBufferPoint
                 
                 cleanupTemporaryDirectory(at: temporaryDirectoryPath)
                 
+#if !os(WASI) // WASI does not support fchmod for now
                 if let mode {
                     // Try to change the mode if the path has not changed. Do our best, but don't report an error.
 #if FOUNDATION_FRAMEWORK
@@ -542,6 +543,7 @@ private func writeToFileAux(path inPath: PathOrURL, buffer: UnsafeRawBufferPoint
                     fchmod(fd, mode)
 #endif
                 }
+#endif // os(WASI)
             }
         }
     }

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -76,6 +76,8 @@ import Glibc
 import Musl
 #elseif canImport(ucrt)
 import ucrt
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 #if os(Windows)
@@ -580,11 +582,11 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     @usableFromInline
     @frozen
     internal struct InlineData : Sendable {
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif _pointerBitWidth(_32)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
@@ -615,9 +617,9 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         @inlinable // This is @inlinable as a trivial initializer.
         init(count: Int = 0) {
             assert(count <= MemoryLayout<Buffer>.size)
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif _pointerBitWidth(_32)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
 #else
     #error ("Unsupported architecture: initialization for Buffer is required for this architecture")
@@ -802,9 +804,9 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         }
     }
 
-#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+#if _pointerBitWidth(_64)
     @usableFromInline internal typealias HalfInt = Int32
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif _pointerBitWidth(_32)
     @usableFromInline internal typealias HalfInt = Int16
 #else
     #error ("Unsupported architecture: a definition of half of the pointer sized Int needs to be defined for this architecture")

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -18,6 +18,8 @@ import Bionic
 import Glibc
 #elseif canImport(WinSDK)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif canImport(CRT)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 private let powerOfTen: [Decimal.VariableLengthInteger] = [

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -22,6 +22,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 extension CocoaError.Code {

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -465,10 +465,12 @@ extension POSIXError {
         return .ESTALE
     }
 
+    #if !os(WASI)
     /// Too many levels of remote in path.
     public static var EREMOTE: POSIXErrorCode {
         return .EREMOTE
     }
+    #endif
     #endif
 
     #if canImport(Darwin)

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -19,6 +19,8 @@
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -19,6 +19,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -26,6 +26,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationCShims

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -461,7 +461,7 @@ extension _FileManagerImpl {
             parent = fileManager.currentDirectoryPath
         }
 
-#if os(Windows)
+#if os(Windows) || os(WASI)
         return fileManager.isWritableFile(atPath: parent) && fileManager.isWritableFile(atPath: path)
 #else
         guard fileManager.isWritableFile(atPath: parent),

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -26,6 +26,9 @@ internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+internal import _FoundationCShims
+import WASILibc
 #endif
 
 extension Date {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -484,7 +484,7 @@ extension _FileManagerImpl {
 #endif
     }
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
     private func _extendedAttribute(_ key: UnsafePointer<CChar>, at path: UnsafePointer<CChar>, followSymlinks: Bool) throws -> Data? {
         #if canImport(Darwin)
         var size = getxattr(path, key, nil, 0, 0, followSymlinks ? 0 : XATTR_NOFOLLOW)
@@ -638,10 +638,11 @@ extension _FileManagerImpl {
             
             var attributes = statAtPath.fileAttributes
             try? Self._catInfo(for: URL(filePath: path, directoryHint: .isDirectory), statInfo: statAtPath, into: &attributes)
-            
+            #if !os(WASI) // WASI does not support extended attributes
             if let extendedAttrs = try? _extendedAttributes(at: fsRep, followSymlinks: false) {
                 attributes[._extendedAttributes] = extendedAttrs
             }
+            #endif
             
             #if !targetEnvironment(simulator) && FOUNDATION_FRAMEWORK
             if statAtPath.isRegular || statAtPath.isDirectory {
@@ -703,6 +704,9 @@ extension _FileManagerImpl {
                 ]
             }
         }
+#elseif os(WASI)
+        // WASI does not support file system attributes
+        return [:]
 #else
         try fileManager.withFileSystemRepresentation(for: path) { rep in
             guard let rep else {
@@ -930,7 +934,12 @@ extension _FileManagerImpl {
             try Self._setCatInfoAttributes(attributes, path: path)
             
             if let extendedAttrs = attributes[.init("NSFileExtendedAttributes")] as? [String : Data] {
+                #if os(WASI)
+                // WASI does not support extended attributes
+                throw CocoaError.errorWithFilePath(.featureUnsupported, path)
+                #else
                 try Self._setAttributes(extendedAttrs, at: fileSystemRepresentation, followSymLinks: false)
+                #endif
             }
             
             if let date = attributes[.modificationDate] as? Date {

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -21,6 +21,8 @@ import Glibc
 import CRT
 import WinSDK
 internal import _FoundationCShims
+#elseif os(WASI)
+import WASILibc
 #endif
 
 extension _FileManagerImpl {

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -271,7 +271,7 @@ extension _FileManagerImpl {
     }
     #endif
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
     static func _userAccountNameToNumber(_ name: String) -> uid_t? {
         name.withCString { ptr in
             getpwnam(ptr)?.pointee.pw_uid

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -173,7 +173,7 @@ extension _FileManagerImpl {
         #endif
     }
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
     static func _setAttribute(_ key: UnsafePointer<CChar>, value: Data, at path: UnsafePointer<CChar>, followSymLinks: Bool) throws {
         try value.withUnsafeBytes { buffer in
             #if canImport(Darwin)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -31,6 +31,8 @@ internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -19,6 +19,8 @@ import Glibc
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if FOUNDATION_FRAMEWORK

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -855,12 +855,14 @@ enum _FileOperations {
         }
         defer { close(dstfd) }
 
+        #if !os(WASI) // WASI doesn't have fchmod for now
         // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
         let permissions = fileInfo.st_mode & ~S_IFMT
         guard fchmod(dstfd, permissions) == 0 else {
             try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
             return
         }
+        #endif
 
         if fileInfo.st_size == 0 {
             // no copying required

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -873,12 +873,31 @@ enum _FileOperations {
         let chunkSize: Int = Int(fileInfo.st_blksize)
         var current: off_t = 0
         
+        #if os(WASI)
+        // WASI doesn't have sendfile, so we need to do it in user space with read/write
+        try withUnsafeTemporaryAllocation(of: UInt8.self, capacity: chunkSize) { buffer in
+            while current < total {
+                let readSize = Swift.min(total - Int(current), chunkSize)
+                let bytesRead = read(srcfd, buffer.baseAddress, readSize)
+                guard bytesRead >= 0 else {
+                    try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
+                    return
+                }
+                guard write(dstfd, buffer.baseAddress, bytesRead) == bytesRead else {
+                    try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
+                    return
+                }
+                current += off_t(bytesRead)
+            }
+        }
+        #else
         while current < total {
             guard sendfile(dstfd, srcfd, &current, Swift.min(total - Int(current), chunkSize)) != -1 else {
                 try delegate.throwIfNecessary(errno, String(cString: srcPtr), String(cString: dstPtr))
                 return
             }
         }
+        #endif
     }
     #endif
 

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 // MARK: - BinaryInteger + Numeric string representation

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -33,6 +33,9 @@ package struct LockedState<State> {
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
         typealias Primitive = SRWLOCK
+#elseif os(WASI)
+        // WASI is single-threaded, so we don't need a lock.
+        typealias Primitive = Void
 #endif
 
         typealias PlatformLock = UnsafeMutablePointer<Primitive>
@@ -45,6 +48,8 @@ package struct LockedState<State> {
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
 
@@ -62,6 +67,8 @@ package struct LockedState<State> {
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
 
@@ -72,6 +79,8 @@ package struct LockedState<State> {
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)
+#elseif os(WASI)
+            // no-op
 #endif
         }
     }

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -113,7 +113,7 @@ private let _cachedUGIDs: (uid_t, gid_t) = {
 }()
 #endif
 
-#if !os(Windows)
+#if !os(Windows) && !os(WASI)
 extension Platform {
     private static var ROOT_USER: UInt32 { 0 }
     static func getUGIDs(allowEffectiveRootUID: Bool = true) -> (uid: UInt32, gid: UInt32) {
@@ -174,7 +174,7 @@ extension Platform {
         // FIXME: bionic implements this as `return 0;` and does not expose the
         // function via headers. We should be able to shim this and use the call
         // if it is available.
-#if !os(Android)
+#if !os(Android) && !os(WASI)
         guard issetugid() == 0 else { return nil }
 #endif
         if let value = getenv(name) {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -21,6 +21,8 @@ import unistd
 import Glibc
 #elseif os(Windows)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if !NO_PROCESS

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -389,7 +389,7 @@ extension _ProcessInfo {
             patch: Int(osVersionInfo.dwBuildNumber)
         )
 #else
-        return OperatingSystemVersion(majorVersion: -1, minorVersion: 0, patchVersion: 0)
+        return (major: -1, minor: 0, patch: 0)
 #endif
     }
 

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -16,6 +16,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #endif
 
 #if canImport(CRT)

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -450,6 +450,7 @@ extension String {
             return envVar.standardizingPath
         }
         
+        #if !os(WASI) // WASI does not have user concept
         // Next, attempt to find the home directory via getpwnam/getpwuid
         var pass: UnsafeMutablePointer<passwd>?
         if let user {
@@ -463,6 +464,7 @@ extension String {
         if let dir = pass?.pointee.pw_dir {
             return String(cString: dir).standardizingPath
         }
+        #endif
         
         // Fallback to HOME for the current user if possible
         if user == nil, let home = getenv("HOME") {

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -18,6 +18,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationCShims

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -30,6 +30,8 @@ struct _ThreadLocal {
     fileprivate typealias PlatformKey = tss_t
 #elseif canImport(WinSDK)
     fileprivate typealias PlatformKey = DWORD
+#elseif os(WASI)
+    fileprivate typealias PlatformKey = UnsafeMutablePointer<UnsafeMutableRawPointer?>
 #endif
     
     struct Key<Value> {
@@ -46,6 +48,8 @@ struct _ThreadLocal {
             self.key = key
 #elseif canImport(WinSDK)
             key = FlsAlloc(nil)
+#elseif os(WASI)
+            key = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(capacity: 1)
 #endif
         }
     }
@@ -58,6 +62,8 @@ struct _ThreadLocal {
             tss_get(key)
 #elseif canImport(WinSDK)
             FlsGetValue(key)
+#elseif os(WASI)
+            key.pointee
 #endif
         }
         
@@ -68,6 +74,8 @@ struct _ThreadLocal {
             tss_set(key, newValue)
 #elseif canImport(WinSDK)
             FlsSetValue(key, newValue)
+#elseif os(WASI)
+            key.pointee = newValue
 #endif
         }
     }

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_options(FoundationInternationalization PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
 target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation_availability_macros})
+target_compile_options(FoundationInternationalization PRIVATE ${_SwiftFoundation_wasi_libc_flags})
 target_compile_options(FoundationInternationalization PRIVATE -package-name "SwiftFoundation")
 
 target_link_libraries(FoundationInternationalization PUBLIC

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -22,6 +22,8 @@ import Glibc
 import CRT
 #elseif canImport(Darwin)
 import Darwin
+#elseif os(WASI)
+import WASILibc
 #endif
 
 internal import _FoundationICU

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -22,6 +22,8 @@ import Android
 import Glibc
 #elseif os(Windows)
 import CRT
+#elseif os(WASI)
+import WASILibc
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -60,7 +60,21 @@
 #endif
 
 #if __has_include(<signal.h>)
-#include <signal.h>
+/// Guard against including `signal.h` on WASI. The `signal.h` header file
+/// itself is available in wasi-libc, but it's just a stub that doesn't actually
+/// do anything. And also including it requires a special macro definition
+/// (`_WASI_EMULATED_SIGNAL`) and it causes compilation errors without the macro.
+# if !TARGET_OS_WASI || defined(_WASI_EMULATED_SIGNAL)
+#  include <signal.h>
+# endif
+#endif
+
+#if __has_include(<sys/mman.h>)
+/// Similar to `signal.h`, guard against including `sys/mman.h` on WASI unless
+/// `_WASI_EMULATED_MMAN` is enabled.
+# if !TARGET_OS_WASI || defined(_WASI_EMULATED_MMAN)
+#  include <sys/mman.h>
+# endif
 #endif
 
 #if __has_include(<stdalign.h>)

--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -31,19 +31,19 @@
 #include <security.h>
 #endif
 
-INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ();
+INTERNAL char * _Nullable * _Nullable _platform_shims_get_environ(void);
 
-INTERNAL void _platform_shims_lock_environ();
-INTERNAL void _platform_shims_unlock_environ();
+INTERNAL void _platform_shims_lock_environ(void);
+INTERNAL void _platform_shims_unlock_environ(void);
 
 #if __has_include(<mach/vm_page_size.h>)
 #include <mach/vm_page_size.h>
-INTERNAL vm_size_t _platform_shims_vm_size();
+INTERNAL vm_size_t _platform_shims_vm_size(void);
 #endif
 
 #if __has_include(<mach/mach.h>)
 #include <mach/mach.h>
-INTERNAL mach_port_t _platform_mach_task_self();
+INTERNAL mach_port_t _platform_mach_task_self(void);
 #endif
 
 #if __has_include(<libkern/OSThermalNotification.h>)
@@ -65,7 +65,7 @@ typedef enum {
 } _platform_shims_OSThermalPressureLevel;
 
 
-INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName();
+INTERNAL const char * _Nonnull _platform_shims_kOSThermalNotificationPressureLevelName(void);
 #endif
 
 #endif /* CSHIMS_PLATFORM_SHIMS */

--- a/Sources/_FoundationCShims/platform_shims.c
+++ b/Sources/_FoundationCShims/platform_shims.c
@@ -27,19 +27,19 @@ extern char **environ;
 
 #if __has_include(<libc_private.h>)
 #import <libc_private.h>
-void _platform_shims_lock_environ() {
+void _platform_shims_lock_environ(void) {
     environ_lock_np();
 }
 
-void _platform_shims_unlock_environ() {
+void _platform_shims_unlock_environ(void) {
     environ_unlock_np();
 }
 #else
-void _platform_shims_lock_environ() { /* noop */ }
-void _platform_shims_unlock_environ() { /* noop */ }
+void _platform_shims_lock_environ(void) { /* noop */ }
+void _platform_shims_unlock_environ(void) { /* noop */ }
 #endif
 
-char ** _platform_shims_get_environ() {
+char ** _platform_shims_get_environ(void) {
 #if __has_include(<crt_externs.h>)
     return *_NSGetEnviron();
 #elif defined(_WIN32)
@@ -52,20 +52,20 @@ char ** _platform_shims_get_environ() {
 }
 
 #if __has_include(<libkern/OSThermalNotification.h>)
-const char * _platform_shims_kOSThermalNotificationPressureLevelName() {
+const char * _platform_shims_kOSThermalNotificationPressureLevelName(void) {
     return kOSThermalNotificationPressureLevelName;
 }
 #endif
 
 #if __has_include(<mach/vm_page_size.h>)
-vm_size_t _platform_shims_vm_size() {
+vm_size_t _platform_shims_vm_size(void) {
     // This shim exists because vm_page_size is not marked const, and therefore looks like global mutable state to Swift.
     return vm_page_size;
 }
 #endif
 
 #if __has_include(<mach/mach.h>)
-mach_port_t _platform_mach_task_self() {
+mach_port_t _platform_mach_task_self(void) {
     // This shim exists because mach_task_self_ is not marked const, and therefore looks like global mutable state to Swift.
     return mach_task_self();
 }

--- a/Sources/_FoundationCShims/platform_shims.c
+++ b/Sources/_FoundationCShims/platform_shims.c
@@ -21,6 +21,10 @@
 extern char **environ;
 #endif
 
+#if __wasi__
+#include <wasi/libc-environ.h> // for __wasilibc_get_environ
+#endif
+
 #if __has_include(<libc_private.h>)
 #import <libc_private.h>
 void _platform_shims_lock_environ() {


### PR DESCRIPTION
**Explanation**: these patches restore support for WASI that was available in `swift-corelibs-foundation` before it was recored.
**Scope**: Isolated to WASI codepaths.
**Risk**: Low due to isolated scope.
**Testing**: Tested manually for WASI, on CI with the existing test suite for other platforms.
**Issue**: rdar://133231577
**Reviewer**: @MaxDesiatov and @jmschonfeld 