### PR TITLE
[6.0] Add FoundationNetworking hook for reading contents of remote URL

### DIFF
--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -2077,6 +2077,14 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         public static let fileProtectionMask = WritingOptions(rawValue: 0xf0000000)
     }
 #endif
+    
+    #if !FOUNDATION_FRAMEWORK
+    @_spi(SwiftCorelibsFoundation)
+    public dynamic init(_contentsOfRemote url: URL, options: ReadingOptions = []) throws {
+        assert(!url.isFileURL)
+        throw CocoaError(.fileReadUnsupportedScheme)
+    }
+    #endif
 
     /// Initialize a `Data` with the contents of a `URL`.
     ///
@@ -2096,7 +2104,7 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
             let d = try NSData(contentsOf: url, options: NSData.ReadingOptions(rawValue: options.rawValue))
             self.init(referencing: d)
             #else
-            throw CocoaError(.fileReadUnsupportedScheme)
+            try self.init(_contentsOfRemote: url, options: options)
             #endif
         }
 #endif


### PR DESCRIPTION
Explanation: Adds a hook point for FoundationNetworking to allow `Data(contentsOf:)` to perform a remote URL request to fetch data
Scope: Should only impact calling `Data(contentsOf:)` with a non-file URL, turning an error into non-regressed behavior (but is inert without the matching SCL-F change)
Original PR: https://github.com/apple/swift-foundation/pull/820
Risk: Minimal - fixes a regression where the current behavior is just to `throw`, and fairly limited scope
Testing: Testing done via swift-ci testing and local testing
Reviewer: @iCharlesHu 