### PR TITLE
Fix NSURLComponents bridging with percent-encoding

### DIFF
--- a/Sources/FoundationEssentials/URL/URLComponents.swift
+++ b/Sources/FoundationEssentials/URL/URLComponents.swift
@@ -1141,15 +1141,19 @@ extension URLComponents: ReferenceConvertible, _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSURLComponents, result: inout URLComponents?) -> Bool {
+        if let swiftComp = x as? _NSSwiftURLComponents {
+            result = swiftComp.components
+            return true
+        }
         var comp = URLComponents()
         comp.scheme = x.scheme
-        comp.user = x.user
-        comp.password = x.password
-        comp.host = x.host
+        comp.percentEncodedUser = x.percentEncodedUser
+        comp.percentEncodedPassword = x.percentEncodedPassword
+        comp.encodedHost = x.encodedHost
         comp.port = x.port?.intValue
-        comp.path = x.path ?? ""
-        comp.query = x.query
-        comp.fragment = x.fragment
+        comp.percentEncodedPath = x.percentEncodedPath ?? ""
+        comp.percentEncodedQuery = x.percentEncodedQuery
+        comp.percentEncodedFragment = x.percentEncodedFragment
         result = comp
         return true
     }

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1031,4 +1031,20 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.percentEncodedPath, "/my%00path")
         XCTAssertEqual(comp.path, "/my\u{0}path")
     }
+
+#if FOUNDATION_FRAMEWORK
+    func testURLComponentsBridging() {
+        var nsURLComponents = NSURLComponents(
+            string: "https://example.com?url=https%3A%2F%2Fapple.com"
+        )!
+        var urlComponents = nsURLComponents as URLComponents
+        XCTAssertEqual(urlComponents.string, nsURLComponents.string)
+
+        urlComponents = URLComponents(
+            string: "https://example.com?url=https%3A%2F%2Fapple.com"
+        )!
+        nsURLComponents = urlComponents as NSURLComponents
+        XCTAssertEqual(urlComponents.string, nsURLComponents.string)
+    }
+#endif
 }


### PR DESCRIPTION
Resolves https://github.com/apple/swift-foundation/issues/828 (thanks @giginet for filing!)

Because the bridging code assigns non-percentEncoded variants of the components (e.g. `.path` instead of `.percentEncodedPath`), an `NSURLComponents` that is bridged to Swift `URLComponents` loses its percent-encoding. For example:

```
let nsURLComponents = NSURLComponents(
    string: "https://example.com?url=https%3A%2F%2Fapple.com"
)!
let urlComponents = nsURLComponents as URLComponents
print(nsURLComponents.string) // "https://example.com?url=https%3A%2F%2Fapple.com"
print(urlComponents.string) // "https://example.com?url=https://apple.com"
```

Note we only lose percent-encoding if the percent-encoding is not absolutely required, e.g. `"://"` does not require encoding in the query component, but this is something we should fix regardless.

This PR first checks if we can cast the `NSURLComponents` to a `_NSSwiftURLComponents` and take the components right out of it. If the cast fails, we fall back to assigning the `percentEncoded` properties.