### PR TITLE
Port directory enumeration related code to WASI

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -193,6 +193,9 @@ extension _FileManagerImpl {
             }
         }
         return results
+#elseif os(WASI)
+        // wasi-libc does not support FTS for now
+        throw CocoaError.errorWithFilePath(.featureUnsupported, path)
 #else
         return try path.withFileSystemRepresentation { fileSystemRep in
             guard let fileSystemRep else {

--- a/Sources/FoundationEssentials/WASILibc+Extensions.swift
+++ b/Sources/FoundationEssentials/WASILibc+Extensions.swift
@@ -29,4 +29,25 @@ internal var CLOCK_MONOTONIC_RAW: clockid_t {
     return CLOCK_MONOTONIC
 }
 
+// MARK: - File Operations
+
+internal var DT_DIR: UInt8 {
+    return _platform_shims_DT_DIR()
+}
+internal var DT_UNKNOWN: UInt8 {
+    return _platform_shims_DT_UNKNOWN()
+}
+internal var O_CREAT: Int32 {
+    return _platform_shims_O_CREAT()
+}
+internal var O_EXCL: Int32 {
+    return _platform_shims_O_EXCL()
+}
+internal var O_TRUNC: Int32 {
+    return _platform_shims_O_TRUNC()
+}
+internal var O_WRONLY: Int32 {
+    return _platform_shims_O_WRONLY()
+}
+
 #endif // os(WASI)

--- a/Sources/_FoundationCShims/include/platform_shims.h
+++ b/Sources/_FoundationCShims/include/platform_shims.h
@@ -79,6 +79,29 @@ static inline _Nonnull clockid_t _platform_shims_clock_monotonic(void) {
 static inline _Nonnull clockid_t _platform_shims_clock_realtime(void) {
     return CLOCK_REALTIME;
 }
+
+// Define dirent shims so that we can use them in Swift because wasi-libc defines
+// `d_name` as "flexible array member" which is not supported by ClangImporter yet.
+
+#include <dirent.h>
+
+static inline char * _Nonnull _platform_shims_dirent_d_name(struct dirent * _Nonnull entry) {
+    return entry->d_name;
+}
+
+// Define getter shims for constants because wasi-libc defines them as function-like macros
+// which are not supported by ClangImporter yet.
+
+#include <stdint.h>
+#include <fcntl.h>
+#include <dirent.h>
+
+static inline uint8_t _platform_shims_DT_DIR(void) { return DT_DIR; }
+static inline uint8_t _platform_shims_DT_UNKNOWN(void) { return DT_UNKNOWN; }
+static inline int32_t _platform_shims_O_CREAT(void) { return O_CREAT; }
+static inline int32_t _platform_shims_O_EXCL(void) { return O_EXCL; }
+static inline int32_t _platform_shims_O_TRUNC(void) { return O_TRUNC; }
+static inline int32_t _platform_shims_O_WRONLY(void) { return O_WRONLY; }
 #endif
 
 #endif /* CSHIMS_PLATFORM_SHIMS */


### PR DESCRIPTION
For now wasi-libc does not include fts(3) implementation, so mark features depending on it as unsupported on WASI. Once wasi-libc includes fts or we decide to implement and maintain our own fts-like API, we can remove these `#if os(WASI)` guards. 

I'm working on porting FTS to wasi-libc (https://github.com/WebAssembly/wasi-libc/pull/522), and we can share most of the enumerator code with other posix platforms after that.


Also, wasi-libc defines some constants in a way that ClangImporter can't understand, so we need to grab them manually through _FoundationCShims in function call form.