### PR TITLE
[6.0] Fix ProcessInfo.processName for Windows (#839)

### DIFF
--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -49,8 +49,6 @@ package struct Platform {
         _pageSize
     }
 
-    // FIXME: Windows SEPARATOR
-    static let PATH_SEPARATOR: Character = "/"
     static let MAX_HOSTNAME_LENGTH = 1024
 
     static func roundDownToMultipleOfPageSize(_ size: Int) -> Int {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -581,13 +581,7 @@ extension _ProcessInfo {
         guard let processPath = CommandLine.arguments.first else {
             return ""
         }
-
-        if let lastSlash = processPath.lastIndex(of: Platform.PATH_SEPARATOR) {
-            return String(processPath[
-                processPath.index(after: lastSlash) ..< processPath.endIndex])
-        }
-
-        return processPath
+        return processPath.lastPathComponent
     }
 
 #if os(macOS)


### PR DESCRIPTION
Explanation: fix ProcessInfo.processName for Windows by using existing `String.lastPathComponent`
Scope: Limited to `ProcessInfo._getProcessName`
Original PR: https://github.com/apple/swift-foundation/pull/839
Risk: Minimal - no new code introduced since we are replying on existing code.
Reviewer: @jmschonfeld 