### PR TITLE
[Android] Use the Bionic module in more places

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -12,8 +12,8 @@
 
 #if canImport(Darwin)
 internal import os
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -12,8 +12,8 @@
 
 #if canImport(os)
 internal import os
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationEssentials/CodableUtilities.swift
+++ b/Sources/FoundationEssentials/CodableUtilities.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -18,7 +18,7 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc
@@ -377,7 +377,7 @@ internal func readBytesFromFile(path inPath: PathOrURL, reportProgress: Bool, ma
         localProgress?.completedUnitCount = 1
     } else if shouldMap {
 #if !NO_FILESYSTEM
-#if os(Android)
+#if canImport(Android)
         let bytes = mmap(nil, Int(fileSize), PROT_READ, MAP_PRIVATE, fd, 0)
         if bytes == UnsafeMutableRawPointer(bitPattern: -1) {
             throw CocoaError.errorWithFilePath(inPath, errno: errno, reading: true)

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -19,7 +19,7 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 import unistd
 #elseif canImport(Glibc)

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -17,7 +17,7 @@
 @usableFromInline let memset = ucrt.memset
 @usableFromInline let memcpy = ucrt.memcpy
 @usableFromInline let memcmp = ucrt.memcmp
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 @usableFromInline let calloc = Bionic.calloc
 @usableFromInline let malloc = Bionic.malloc

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -12,8 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -15,7 +15,7 @@ internal import _ForSwiftFoundation
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -10,7 +10,7 @@
  //===----------------------------------------------------------------------===//
 
 // Import for POSIXErrorCode
-#if os(Android)
+#if canImport(Android)
 @preconcurrency import Android
 #elseif canImport(Glibc)
 @preconcurrency import Glibc 

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -18,7 +18,7 @@ internal import os
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 import unistd
 #elseif canImport(Glibc)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -17,7 +17,7 @@ internal import DarwinPrivate.sys.content_protection
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 import posix_filesystem
 #elseif canImport(Glibc)

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 import unistd
 #elseif canImport(Glibc)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -23,7 +23,7 @@ internal import QuarantinePrivate
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -109,7 +109,7 @@ struct _Win32DirectoryContentsSequence: Sequence {
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 import posix_filesystem.dirent
 #elseif canImport(Glibc)
@@ -328,7 +328,7 @@ extension Sequence<_FTSSequence.Element> {
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)
     typealias DirectoryEntryPtr = UnsafeMutablePointer<DIR>
-    #elseif os(Android) || canImport(Glibc) || canImport(Musl) || os(WASI)
+    #elseif canImport(Android) || canImport(Glibc) || canImport(Musl) || os(WASI)
     typealias DirectoryEntryPtr = OpaquePointer
     #endif
     

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -12,8 +12,8 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -15,7 +15,7 @@ internal import os
 #if FOUNDATION_FRAMEWORK && canImport(C.os.lock)
 internal import C.os.lock
 #endif
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
@@ -31,7 +31,7 @@ package struct LockedState<State> {
     private struct _Lock {
 #if canImport(os)
         typealias Primitive = os_unfair_lock
-#elseif os(Android) || canImport(Glibc) || canImport(Musl)
+#elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
         typealias Primitive = SRWLOCK
@@ -46,7 +46,7 @@ package struct LockedState<State> {
         fileprivate static func initialize(_ platformLock: PlatformLock) {
 #if canImport(os)
             platformLock.initialize(to: os_unfair_lock())
-#elseif os(Android) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc)
             pthread_mutex_init(platformLock, nil)
 #elseif canImport(WinSDK)
             InitializeSRWLock(platformLock)
@@ -56,7 +56,7 @@ package struct LockedState<State> {
         }
 
         fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-#if os(Android) || canImport(Glibc)
+#if canImport(Bionic) || canImport(Glibc)
             pthread_mutex_destroy(platformLock)
 #endif
             platformLock.deinitialize(count: 1)
@@ -65,7 +65,7 @@ package struct LockedState<State> {
         static fileprivate func lock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_lock(platformLock)
-#elseif os(Android) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc)
             pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
             AcquireSRWLockExclusive(platformLock)
@@ -77,7 +77,7 @@ package struct LockedState<State> {
         static fileprivate func unlock(_ platformLock: PlatformLock) {
 #if canImport(os)
             os_unfair_lock_unlock(platformLock)
-#elseif os(Android) || canImport(Glibc)
+#elseif canImport(Bionic) || canImport(Glibc)
             pthread_mutex_unlock(platformLock)
 #elseif canImport(WinSDK)
             ReleaseSRWLockExclusive(platformLock)

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -28,7 +28,7 @@ fileprivate let _pageSize: Int = {
 #elseif os(WASI)
 // WebAssembly defines a fixed page size
 fileprivate let _pageSize: Int = 65_536
-#elseif os(Android)
+#elseif canImport(Android)
 import Bionic
 import unistd
 fileprivate let _pageSize: Int = Int(getpagesize())
@@ -175,7 +175,7 @@ extension Platform {
         // FIXME: bionic implements this as `return 0;` and does not expose the
         // function via headers. We should be able to shim this and use the call
         // if it is available.
-#if !os(Android) && !os(WASI)
+#if !canImport(Android) && !os(WASI)
         guard issetugid() == 0 else { return nil }
 #endif
         if let value = getenv(name) {

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -14,7 +14,7 @@ internal import _FoundationCShims
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import Bionic
 import unistd
 #elseif canImport(Glibc)
@@ -165,7 +165,7 @@ final class _ProcessInfo: Sendable {
     }
 
     var userName: String {
-#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#if canImport(Darwin) || canImport(Android) || canImport(Glibc) || canImport(Musl)
         // Darwin and Linux
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
@@ -200,10 +200,10 @@ final class _ProcessInfo: Sendable {
     }
 
     var fullUserName: String {
-#if os(Android) && (arch(i386) || arch(arm))
+#if canImport(Android) && (arch(i386) || arch(arm))
         // On LP32 Android, pw_gecos doesn't exist and is presumed to be NULL.
         return ""
-#elseif canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#elseif canImport(Darwin) || canImport(Android) || canImport(Glibc) || canImport(Musl)
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
            let fullname = upwd.pointee.pw_gecos {
@@ -368,7 +368,7 @@ extension _ProcessInfo {
     }
 
     var operatingSystemVersion: (major: Int, minor: Int, patch: Int) {
-#if canImport(Darwin) || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+#if canImport(Darwin) || os(Linux) || os(FreeBSD) || os(OpenBSD) || canImport(Android)
         var uts: utsname = utsname()
         guard uname(&uts) == 0 else {
             return (major: -1, minor: 0, patch: 0)

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 internal import os
-#elseif os(Android)
+#elseif canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -12,7 +12,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Android)
 import unistd
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -11,7 +11,7 @@
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
+#elseif canImport(Bionic)
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
@@ -26,7 +26,7 @@ internal import threads
 #endif
 
 struct _ThreadLocal {
-#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#if canImport(Darwin) || canImport(Bionic) || canImport(Glibc) || canImport(Musl)
     fileprivate typealias PlatformKey = pthread_key_t
 #elseif USE_TSS
     fileprivate typealias PlatformKey = tss_t
@@ -40,7 +40,7 @@ struct _ThreadLocal {
         fileprivate let key: PlatformKey
         
         init() {
-#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#if canImport(Darwin) || canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             var key = PlatformKey()
             pthread_key_create(&key, nil)
             self.key = key
@@ -58,7 +58,7 @@ struct _ThreadLocal {
     
     private static subscript(_ key: PlatformKey) -> UnsafeMutableRawPointer? {
         get {
-#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#if canImport(Darwin) || canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_getspecific(key)
 #elseif USE_TSS
             tss_get(key)
@@ -70,7 +70,7 @@ struct _ThreadLocal {
         }
         
         set {
-#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
+#if canImport(Darwin) || canImport(Bionic) || canImport(Glibc) || canImport(Musl)
             pthread_setspecific(key, newValue)
 #elseif USE_TSS
             tss_set(key, newValue)

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -14,7 +14,7 @@
 import FoundationEssentials
 #endif
 
-#if os(Android)
+#if canImport(Android)
 import Android
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -15,8 +15,8 @@ import FoundationEssentials
 
 internal import _FoundationICU
 
-#if os(Android)
-import Android
+#if canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -18,8 +18,8 @@ internal import _FoundationICU
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -16,8 +16,8 @@ import FoundationEssentials
 
 #if canImport(Darwin)
 import Darwin
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)


### PR DESCRIPTION
Also, use `canImport()` wherever importing APIs, reserving `os(Android)` for platform differences.

I've started porting this repo to Android: this is a first pull that keeps everything building while more narrowly scoping imports.

@compnerd and @hyp, try it out and let me know what you think.