### PR TITLE
Autolink wasi-libc emulation libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,16 +114,25 @@ foreach(version ${_SwiftFoundation_versions})
     endforeach()
 endforeach()
 
-# wasi-libc emulation feature flags
+# wasi-libc emulation feature flags passed to the Swift compiler
 set(_SwiftFoundation_wasi_libc_flags)
+# wasi-libc emulation libraries to link against when building a shared library
+set(_SwiftFoundation_wasi_libc_libraries)
 if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     list(APPEND _SwiftFoundation_wasi_libc_flags
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_GETPID>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-getpid>"
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_SIGNAL>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-signal>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_MMAN>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-mman>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_MMAN>")
+    if(BUILD_SHARED_LIBS)
+        # Link emulation libraries to the shared library directly when building a shared library
+        list(APPEND _SwiftFoundation_wasi_libc_libraries wasi-emulated-getpid wasi-emulated-signal wasi-emulated-mman)
+    else()
+        # Emit autolink entries to let clients to link against the emulation libraries
+        list(APPEND _SwiftFoundation_wasi_libc_flags
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-getpid>"
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-signal>"
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-mman>")
+    endif()
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,12 @@ endforeach()
 set(_SwiftFoundation_wasi_libc_flags)
 if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     list(APPEND _SwiftFoundation_wasi_libc_flags
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_GETPID>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-getpid>"
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_SIGNAL>"
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_MMAN>")
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-signal>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -D_WASI_EMULATED_MMAN>"
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-mman>")
 endif()
 
 include(GNUInstallDirs)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -73,6 +73,7 @@ target_compile_options(FoundationEssentials PRIVATE -package-name "SwiftFoundati
 target_link_libraries(FoundationEssentials PUBLIC
     _FoundationCShims
     _FoundationCollections)
+target_link_libraries(FoundationEssentials PUBLIC ${_SwiftFoundation_wasi_libc_libraries})
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationEssentials PRIVATE

--- a/Sources/FoundationInternationalization/CMakeLists.txt
+++ b/Sources/FoundationInternationalization/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(FoundationInternationalization PUBLIC
     FoundationEssentials
     _FoundationCShims
     _FoundationICU)
+target_link_libraries(FoundationInternationalization PUBLIC ${_SwiftFoundation_wasi_libc_libraries})
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationInternationalization PRIVATE


### PR DESCRIPTION
`_WASI_EMULATED_XXX` macros require linking against the corresponding emulation libraries. This patch adds `-Xfrontend -public-autolink-library` flags to the Swift compiler invocation to automatically link against the emulation libraries. Also enable getpid emulation explicitly, as it is available by default but emiting a warning.