### PR TITLE
Automatically build FoundationMacros for local CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,18 +60,22 @@ set(SwiftFoundation_MACRO "" CACHE STRING "Path to Foundation macro plugin")
 # Make sure our dependencies exists
 include(FetchContent)
 if (_SwiftFoundationICU_SourceDIR)
+    message(STATUS "_SwiftFoundationICU_SourceDIR provided, using swift-foundation-icu checkout at ${_SwiftFoundationICU_SourceDIR}")
     FetchContent_Declare(SwiftFoundationICU
         SOURCE_DIR ${_SwiftFoundationICU_SourceDIR})
 else()
+    message(STATUS "_SwiftFoundationICU_SourceDIR not provided, checking out local copy of swift-foundation-icu")
     FetchContent_Declare(SwiftFoundationICU
         GIT_REPOSITORY https://github.com/apple/swift-foundation-icu.git
         GIT_TAG 0.0.9)
 endif()
 
 if (_SwiftCollections_SourceDIR)
+    message(STATUS "_SwiftCollections_SourceDIR provided, using swift-foundation-icu checkout at ${_SwiftCollections_SourceDIR}")
     FetchContent_Declare(SwiftCollections
         SOURCE_DIR ${_SwiftCollections_SourceDIR})
 else()
+    message(STATUS "_SwiftCollections_SourceDIR not provided, checking out local copy of swift-collections")
     FetchContent_Declare(SwiftCollections
         GIT_REPOSITORY https://github.com/apple/swift-collections.git
         GIT_TAG 1.1.2)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -50,8 +50,26 @@ add_subdirectory(TimeZone)
 add_subdirectory(URL)
 
 if(SwiftFoundation_MACRO)
-  target_compile_options(FoundationEssentials PRIVATE
-    "SHELL:-plugin-path ${SwiftFoundation_MACRO}")
+    message(STATUS "SwiftFoundation_MACRO provided, using macros in ${SwiftFoundation_MACRO}")
+    # A path to Foundation macros was provided, so we use that path
+    target_compile_options(FoundationEssentials PRIVATE
+        "SHELL:-plugin-path ${SwiftFoundation_MACRO}")
+else()
+    message(STATUS "SwiftFoundation_MACRO not provided, building Foundation macros locally for host")
+    # No path to Foundation macros was provided, so we must build it ourselves
+    set(FoundationMacros_BuildLocalExecutable YES)
+    FetchContent_Declare(FoundationMacros
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/Sources/FoundationMacros)
+    FetchContent_MakeAvailable(FoundationMacros)
+    add_dependencies(FoundationEssentials FoundationMacros)
+    get_target_property(MacroDIR FoundationMacros RUNTIME_OUTPUT_DIRECTORY)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        set(MacroExecutable "${MacroDIR}/FoundationMacros.exe#FoundationMacros")
+    else()
+        set(MacroExecutable "${MacroDIR}/FoundationMacros#FoundationMacros")
+    endif()
+    target_compile_options(FoundationEssentials PUBLIC
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-load-plugin-executable ${MacroExecutable}>")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -29,6 +29,7 @@ project(FoundationMacros
 # SwiftSyntax Dependency
 find_package(SwiftSyntax QUIET)
 if(NOT SwiftSyntax_FOUND)
+  message(STATUS "SwiftSyntax_DIR not provided, checking out local copy of swift-syntax")
     include(FetchContent)
 
     # If building at desk, check out and link against the SwiftSyntax repo's targets
@@ -37,16 +38,25 @@ if(NOT SwiftSyntax_FOUND)
         GIT_TAG 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c) # 600.0.0-prerelease-2024-06-12
     FetchContent_MakeAvailable(SwiftSyntax)
 else()
-  message(STATUS "Using swift-syntax from ${SwiftSyntax_DIR}")
+  message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")
 endif()
 
-add_library(FoundationMacros SHARED
+if(NOT FoundationMacros_BuildLocalExecutable)
+    add_library(FoundationMacros SHARED)
+    target_compile_definitions(FoundationMacros PRIVATE FOUNDATION_MACROS_LIBRARY)
+else()
+    add_executable(FoundationMacros)
+    target_link_libraries(FoundationMacros PUBLIC
+        SwiftSyntax::SwiftCompilerPlugin)
+endif()
+
+# Parse the module as a library, even if it's an executable, because it uses an `@main` type to define its entry point.
+target_compile_options(FoundationMacros PRIVATE -parse-as-library)
+
+target_sources(FoundationMacros PRIVATE
     FoundationMacros.swift
     PredicateMacro.swift)
 
-target_compile_definitions(FoundationMacros PRIVATE FOUNDATION_MACROS_LIBRARY)
-
-target_compile_options(FoundationMacros PRIVATE -parse-as-library)
 target_compile_options(FoundationMacros PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
@@ -72,6 +82,8 @@ set_target_properties(FoundationMacros PROPERTIES
     INSTALL_RPATH "$ORIGIN/../../../swift/${SWIFT_SYSTEM_NAME}:$ORIGIN/.."
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
-install(TARGETS FoundationMacros
-    LIBRARY DESTINATION lib/swift/host/plugins
-    RUNTIME DESTINATION bin)
+if(NOT FoundationMacros_BuildLocalExecutable)
+    install(TARGETS FoundationMacros
+        LIBRARY DESTINATION lib/swift/host/plugins
+        RUNTIME DESTINATION bin)
+endif()


### PR DESCRIPTION
When building this project via CMake as a standalone project (not as part of a toolchain build) we automatically check out and build some dependencies such as swift-collections and swift-foundation-icu. Now that we've separated the macro build into a separate build, we need to do the same for FoundationMacros. This updates the CMake files so that when `SwiftFoundation_MACROS` is not specified, we add the macro target to the build graph and build a copy of the macro for the host to use while building the rest of the project. This builds the macro as an executable just like SwiftPM rather than as a library so that the macro can be built with a different copy of swift-syntax than what the compiler has.

While I was here, I also added some logging messages when checking out the dependencies to make it clear what build settings you can specify for local copies, as well as indicate why a cmake configuration was taking a while during git cloning