### PR TITLE
[main] Get Swift-Foundation building against MUSL for Swift Static SDK

### DIFF
--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -16,6 +16,8 @@ internal import os
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Gregorian.swift
@@ -16,6 +16,8 @@ internal import os
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/Data/Data+Reading.swift
+++ b/Sources/FoundationEssentials/Data/Data+Reading.swift
@@ -22,6 +22,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK
@@ -32,7 +34,7 @@ import WASILibc
 func _fgetxattr(_ fd: Int32, _ name: UnsafePointer<CChar>!, _ value: UnsafeMutableRawPointer!, _ size: Int, _ position: UInt32, _ options: Int32) -> Int {
 #if canImport(Darwin)
     return fgetxattr(fd, name, value, size, position, options)
-#elseif canImport(Glibc)
+#elseif canImport(Glibc) || canImport(Musl)
     return fgetxattr(fd, name, value, size)
 #else
     return -1

--- a/Sources/FoundationEssentials/Data/Data+Writing.swift
+++ b/Sources/FoundationEssentials/Data/Data+Writing.swift
@@ -24,6 +24,8 @@ import Android
 import unistd
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK
@@ -632,7 +634,7 @@ private func writeExtendedAttributes(fd: Int32, attributes: [String : Data]) {
             // Returns non-zero on error, but we ignore them
 #if canImport(Darwin)
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0, 0)
-#elseif canImport(Glibc)
+#elseif canImport(Glibc) || canImport(Musl)
             _ = fsetxattr(fd, key, valueBuf.baseAddress!, valueBuf.count, 0)
 #endif
         }

--- a/Sources/FoundationEssentials/Date.swift
+++ b/Sources/FoundationEssentials/Date.swift
@@ -16,6 +16,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WinSDK)
 import WinSDK
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Math.swift
@@ -16,6 +16,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
+++ b/Sources/FoundationEssentials/Error/CocoaError+FilePath.swift
@@ -19,6 +19,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
+++ b/Sources/FoundationEssentials/Error/ErrorCodes+POSIX.swift
@@ -14,6 +14,8 @@
 @preconcurrency import Android
 #elseif canImport(Glibc)
 @preconcurrency import Glibc 
+#elseif canImport(Musl)
+@preconcurrency import Musl
 #elseif canImport(Darwin)
 @preconcurrency import Darwin
 #elseif os(Windows)

--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -16,6 +16,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift
@@ -23,6 +23,8 @@ import Android
 import unistd
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -23,6 +23,9 @@ import posix_filesystem
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims
+#elseif canImport(Musl)
+import Musl
+internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -17,6 +17,8 @@ import Android
 import unistd
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Utilities.swift
@@ -28,6 +28,9 @@ import Android
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims
+#elseif canImport(Musl)
+import Musl
+internal import _FoundationCShims
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -115,6 +115,8 @@ import posix_filesystem.dirent
 #elseif canImport(Glibc)
 import Glibc
 internal import _FoundationCShims
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 internal import _FoundationCShims
@@ -326,7 +328,7 @@ extension Sequence<_FTSSequence.Element> {
 struct _POSIXDirectoryContentsSequence: Sequence {
     #if canImport(Darwin)
     typealias DirectoryEntryPtr = UnsafeMutablePointer<DIR>
-    #elseif os(Android) || canImport(Glibc) || os(WASI)
+    #elseif os(Android) || canImport(Glibc) || canImport(Musl) || os(WASI)
     typealias DirectoryEntryPtr = OpaquePointer
     #endif
     

--- a/Sources/FoundationEssentials/FileManager/FileOperations.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations.swift
@@ -16,6 +16,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
+++ b/Sources/FoundationEssentials/Formatting/BinaryInteger+NumericStringRepresentation.swift
@@ -16,6 +16,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -19,6 +19,8 @@ internal import C.os.lock
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WinSDK)
 import WinSDK
 #endif
@@ -29,7 +31,7 @@ package struct LockedState<State> {
     private struct _Lock {
 #if canImport(os)
         typealias Primitive = os_unfair_lock
-#elseif os(Android) || canImport(Glibc)
+#elseif os(Android) || canImport(Glibc) || canImport(Musl)
         typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
         typealias Primitive = SRWLOCK

--- a/Sources/FoundationEssentials/Platform.swift
+++ b/Sources/FoundationEssentials/Platform.swift
@@ -35,6 +35,9 @@ fileprivate let _pageSize: Int = Int(getpagesize())
 #elseif canImport(Glibc)
 import Glibc
 fileprivate let _pageSize: Int = Int(getpagesize())
+#elseif canImport(Musl)
+import Musl
+fileprivate let _pageSize: Int = Int(getpagesize())
 #elseif canImport(C)
 fileprivate let _pageSize: Int = Int(getpagesize())
 #endif // canImport(Darwin)

--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -19,6 +19,8 @@ import Bionic
 import unistd
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import WinSDK
 #elseif os(WASI)
@@ -163,7 +165,7 @@ final class _ProcessInfo: Sendable {
     }
 
     var userName: String {
-#if canImport(Darwin) || os(Android) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
         // Darwin and Linux
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
@@ -201,7 +203,7 @@ final class _ProcessInfo: Sendable {
 #if os(Android) && (arch(i386) || arch(arm))
         // On LP32 Android, pw_gecos doesn't exist and is presumed to be NULL.
         return ""
-#elseif canImport(Darwin) || os(Android) || canImport(Glibc)
+#elseif canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
         let (euid, _) = Platform.getUGIDs()
         if let upwd = getpwuid(euid),
            let fullname = upwd.pointee.pw_gecos {

--- a/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
+++ b/Sources/FoundationEssentials/PropertyList/OpenStepPlist.swift
@@ -16,6 +16,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #endif

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -16,6 +16,8 @@ internal import os
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import WinSDK
 #elseif os(WASI)

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -16,6 +16,8 @@ import Darwin
 import unistd
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif

--- a/Sources/FoundationEssentials/_ThreadLocal.swift
+++ b/Sources/FoundationEssentials/_ThreadLocal.swift
@@ -15,6 +15,8 @@ import Darwin
 import Bionic
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WinSDK)
 import WinSDK
 #elseif canImport(threads_h)
@@ -24,7 +26,7 @@ internal import threads
 #endif
 
 struct _ThreadLocal {
-#if canImport(Darwin) || os(Android) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
     fileprivate typealias PlatformKey = pthread_key_t
 #elseif USE_TSS
     fileprivate typealias PlatformKey = tss_t
@@ -38,7 +40,7 @@ struct _ThreadLocal {
         fileprivate let key: PlatformKey
         
         init() {
-#if canImport(Darwin) || os(Android) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
             var key = PlatformKey()
             pthread_key_create(&key, nil)
             self.key = key
@@ -56,7 +58,7 @@ struct _ThreadLocal {
     
     private static subscript(_ key: PlatformKey) -> UnsafeMutableRawPointer? {
         get {
-#if canImport(Darwin) || os(Android) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
             pthread_getspecific(key)
 #elseif USE_TSS
             tss_get(key)
@@ -68,7 +70,7 @@ struct _ThreadLocal {
         }
         
         set {
-#if canImport(Darwin) || os(Android) || canImport(Glibc)
+#if canImport(Darwin) || os(Android) || canImport(Glibc) || canImport(Musl)
             pthread_setspecific(key, newValue)
 #elseif USE_TSS
             tss_set(key, newValue)

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift
@@ -18,6 +18,8 @@ import FoundationEssentials
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #elseif canImport(Darwin)

--- a/Sources/FoundationInternationalization/Date+ICU.swift
+++ b/Sources/FoundationInternationalization/Date+ICU.swift
@@ -19,6 +19,8 @@ internal import _FoundationICU
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Darwin)
 import Darwin
 #endif

--- a/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Date/ICUDateFormatter.swift
@@ -22,6 +22,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 typealias UChar = UInt16

--- a/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
+++ b/Sources/FoundationInternationalization/Formatting/Duration+Formatting.swift
@@ -20,6 +20,8 @@ import Darwin
 import Android
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 #elseif os(WASI)


### PR DESCRIPTION
Adding MUSL support to Swift-Foundation to get the Swift static SDK building again after the swift-corelibs-foundation recore.

Cherry-picked from 6.0: https://github.com/apple/swift-foundation/pull/838