### PR TITLE
FoundationMacros: use cross-compilation to build for host (#714)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ set(BUILD_TESTING NO)
 set(COLLECTIONS_SINGLE_MODULE YES)
 set(COLLECTIONS_FOUNDATION_TOOLCHAIN_MODULE YES)
 
+set(SwiftFoundation_MACRO "" CACHE STRING "Path to Foundation macro plugin")
+
 # Make sure our dependencies exists
 include(FetchContent)
 if (_SwiftFoundationICU_SourceDIR)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -13,11 +13,5 @@
 ##===----------------------------------------------------------------------===##
 
 add_subdirectory(_FoundationCShims)
-
-# Disable the macro build on Windows until we can correctly build it for the host architecture
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-	add_subdirectory(FoundationMacros)
-endif()
-
 add_subdirectory(FoundationEssentials)
 add_subdirectory(FoundationInternationalization)

--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -48,10 +48,9 @@ add_subdirectory(String)
 add_subdirectory(TimeZone)
 add_subdirectory(URL)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-    # Depend on FoundationMacros
-    add_dependencies(FoundationEssentials FoundationMacros)
-    target_compile_options(FoundationEssentials PRIVATE -plugin-path ${CMAKE_BINARY_DIR}/lib)
+if(SwiftFoundation_MACRO)
+  target_compile_options(FoundationEssentials PRIVATE
+    "SHELL:-plugin-path ${SwiftFoundation_MACRO}")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)

--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -12,29 +12,45 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+cmake_minimum_required(VERSION 3.22)
+
+if(POLICY CMP0156)
+    # Deduplicate linked libraries where appropriate
+    cmake_policy(SET CMP0156 NEW)
+endif()
+if(POLICY CMP0157)
+    # New Swift build model: improved incremental build performance and LSP support
+  cmake_policy(SET CMP0157 NEW)
+endif()
+
+project(FoundationMacros
+  LANGUAGES Swift)
+
 # SwiftSyntax Dependency
-include(FetchContent)
-find_package(SwiftSyntax)
+find_package(SwiftSyntax QUIET)
 if(NOT SwiftSyntax_FOUND)
+    include(FetchContent)
+
     # If building at desk, check out and link against the SwiftSyntax repo's targets
     FetchContent_Declare(SwiftSyntax
         GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
         GIT_TAG 4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c) # 600.0.0-prerelease-2024-06-12
     FetchContent_MakeAvailable(SwiftSyntax)
+else()
+  message(STATUS "Using swift-syntax from ${SwiftSyntax_DIR}")
 endif()
 
 add_library(FoundationMacros SHARED
     FoundationMacros.swift
     PredicateMacro.swift)
-    
+
 target_compile_definitions(FoundationMacros PRIVATE FOUNDATION_MACROS_LIBRARY)
 
-set_target_properties(FoundationMacros
-    PROPERTIES
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/lib
-)
+target_compile_options(FoundationMacros PRIVATE -parse-as-library)
+target_compile_options(FoundationMacros PRIVATE
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
+    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
 
 target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntax
@@ -43,18 +59,19 @@ target_link_libraries(FoundationMacros PUBLIC
     SwiftSyntax::SwiftSyntaxBuilder
 )
 
-# The macro is installed into lib/swift/host/plugins, but needs to load libraries from lib/swift/host and lib/swift/${SWIFT_SYSTEM_NAME}
 set_target_properties(FoundationMacros PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    PDB_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+
+    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/lib
+
+    # The macro is installed into lib/swift/host/plugins, but needs to load
+    # libraries from lib/swift/host and lib/swift/${SWIFT_SYSTEM_NAME}
     INSTALL_RPATH "$ORIGIN/../../../swift/${SWIFT_SYSTEM_NAME}:$ORIGIN/.."
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
-target_compile_options(FoundationMacros PRIVATE -parse-as-library)
-target_compile_options(FoundationMacros PRIVATE
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency>"
-    "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures>")
-
 install(TARGETS FoundationMacros
-    ARCHIVE DESTINATION lib/swift/host/plugins
     LIBRARY DESTINATION lib/swift/host/plugins
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    RUNTIME DESTINATION bin)


### PR DESCRIPTION
Use `ExternalProject` to switch FoundationMacros to cross-compilation. This allows us to build the macros for the right OS/architecture when cross-compiling Foundation for other environments.