### PR TITLE
Hide Windows magic environment values from ProcessInfo.environment

### DIFF
--- a/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
+++ b/Sources/FoundationEssentials/ProcessInfo/ProcessInfo.swift
@@ -75,6 +75,16 @@ final class _ProcessInfo: Sendable {
             for env in environments {
                 let environmentString = String(cString: env)
 
+#if os(Windows)
+                // Windows GetEnvironmentStringsW API can return
+                // magic environment variables set by the cmd shell
+                // that starts with `=`
+                // We should exclude these values
+                if environmentString.utf8.first == ._equal {
+                    continue
+                }
+#endif // os(Windows)
+
                 guard let delimiter = environmentString.firstIndex(of: "=") else {
                     continue
                 }

--- a/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
+++ b/Tests/FoundationEssentialsTests/ProcessInfoTests.swift
@@ -189,4 +189,14 @@ final class ProcessInfoTests : XCTestCase {
         processInfo.processName = originalProcessName
         XCTAssertEqual(processInfo.processName, originalProcessName)
     }
+
+    func testWindowsEnvironmentDoesNotContainMagicValues() {
+        // Windows GetEnvironmentStringsW API can return
+        // magic environment variables set by the cmd shell
+        // that starts with `=`
+        // This test makes sure we don't include these
+        // magic variables
+        let env = ProcessInfo.processInfo.environment
+        XCTAssertNil(env[""])
+    }
 }


### PR DESCRIPTION
Windows GetEnvironmentStringsW API can return magic environment variables set by the cmd shell that starts with "=". We should hide these values to avoid surprising behavior.

resolves: https://github.com/apple/swift-foundation/issues/847