### PR TITLE
Use fallback home directory on Windows

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -371,11 +371,11 @@ extension String {
 #if os(Windows)
         if let user {
             func fallbackUserDirectory() -> String {
-                guard let systemDrive = ProcessInfo.processInfo.environment["SystemDrive"] else {
-                    fatalError("Unable to evaluate %SystemDrive%")
+                guard let fallback = ProcessInfo.processInfo.environment["ALLUSERSPROFILE"] else {
+                    fatalError("Unable to find home directory for user \(user) and ALLUSERSPROFILE environment variable is not set")
                 }
                 
-                return "\(systemDrive)\\Users\\Public"
+                return fallback
             }
             
             return user.withCString(encodedAs: UTF16.self) { pwszUserName in

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -897,4 +897,15 @@ final class FileManagerTests : XCTestCase {
             }
         }
     }
+    
+    func testHomeDirectoryForNonExistantUser() throws {
+        #if os(Windows)
+        let fallbackPath = URL(fileURLWithPath: "\(try XCTUnwrap(ProcessInfo.processInfo.environment["SystemDrive"]))\\Users\\Public")
+        #else
+        let fallbackPath = URL(fileURLWithPath: "/var/empty")
+        #endif
+        
+        XCTAssertEqual(FileManager.default.homeDirectory(forUser: ""), fallbackPath)
+        XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
+    }
 }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -899,6 +899,9 @@ final class FileManagerTests : XCTestCase {
     }
     
     func testHomeDirectoryForNonExistantUser() throws {
+        #if canImport(Darwin) && !os(macOS)
+        throw XCTSkip("This test is not applicable on this platform")
+        #else
         #if os(Windows)
         let fallbackPath = URL(filePath: try XCTUnwrap(ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]), directoryHint: .isDirectory)
         #else
@@ -907,5 +910,6 @@ final class FileManagerTests : XCTestCase {
         
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: ""), fallbackPath)
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: UUID().uuidString), fallbackPath)
+        #endif
     }
 }

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -900,9 +900,9 @@ final class FileManagerTests : XCTestCase {
     
     func testHomeDirectoryForNonExistantUser() throws {
         #if os(Windows)
-        let fallbackPath = URL(fileURLWithPath: try XCTUnwrap(ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]))
+        let fallbackPath = URL(filePath: try XCTUnwrap(ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]), directoryHint: .isDirectory)
         #else
-        let fallbackPath = URL(fileURLWithPath: "/var/empty")
+        let fallbackPath = URL(filePath: "/var/empty", directoryHint: .isDirectory)
         #endif
         
         XCTAssertEqual(FileManager.default.homeDirectory(forUser: ""), fallbackPath)

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -900,7 +900,7 @@ final class FileManagerTests : XCTestCase {
     
     func testHomeDirectoryForNonExistantUser() throws {
         #if os(Windows)
-        let fallbackPath = URL(fileURLWithPath: "\(try XCTUnwrap(ProcessInfo.processInfo.environment["SystemDrive"]))\\Users\\Public")
+        let fallbackPath = URL(fileURLWithPath: try XCTUnwrap(ProcessInfo.processInfo.environment["ALLUSERSPROFILE"]))
         #else
         let fallbackPath = URL(fileURLWithPath: "/var/empty")
         #endif


### PR DESCRIPTION
On macOS/Linux, when asking for the home directory of a user that doesn't exist, we fallback to `/var/empty` - we also have a handful of unit tests in swift-corelibs-foundation that verify this behavior. However, on Windows we currently crash with a `fatalError` when provided a non-existent user name. swift-corelibs-foundation previously defaulted to `/var/empty` on Windows too, but that directory doesn't make sense on Windows. Instead, we standardize on a fallback of `%SystemDrive%\Users\Public` for users that don't exist which is still a valid directory and is close enough to the macOS/Linux semantics despite not having a direct equivalent to `/var/empty`