### PR TITLE
Fix Windows symlink handling in FileManager APIs

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Basics.swift
@@ -126,15 +126,17 @@ internal struct _FileManagerImpl {
                 let rhsIsReparsePoint = fbiRHS.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT == FILE_ATTRIBUTE_REPARSE_POINT
                 let lhsIsDirectory = fbiLHS.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY
                 let rhsIsDirectory = fbiRHS.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY
-                if lhsIsReparsePoint || rhsIsReparsePoint {
-                    guard lhsIsReparsePoint == rhsIsReparsePoint else {
-                        return false
-                    }
+                
+                guard lhsIsReparsePoint == rhsIsReparsePoint, lhsIsDirectory == rhsIsDirectory else {
+                    // If they aren't the same "type", then they cannot be equivalent
+                    return false
+                }
+                
+                if lhsIsReparsePoint {
+                    // Both are symbolic links, so they are equivalent if their destinations are equivalent
                     return (try? fileManager.destinationOfSymbolicLink(atPath: path) == fileManager.destinationOfSymbolicLink(atPath: other)) ?? false
-                } else if lhsIsDirectory || rhsIsDirectory {
-                    guard lhsIsDirectory == rhsIsDirectory else {
-                        return false
-                    }
+                } else if lhsIsDirectory {
+                    // Both are directories, so recursively compare the directories
                     guard let aLHSItems = try? fileManager.contentsOfDirectory(atPath: path),
                           let aRHSItems = try? fileManager.contentsOfDirectory(atPath: other),
                           aLHSItems == aRHSItems else {
@@ -161,6 +163,7 @@ internal struct _FileManagerImpl {
 
                     return true
                 } else {
+                    // Both must be standard files, so binary compare the contents of the files
                     var liLHSSize: LARGE_INTEGER = .init()
                     var liRHSSize: LARGE_INTEGER = .init()
                     guard GetFileSizeEx(hLHS, &liLHSSize), GetFileSizeEx(hRHS, &liRHSSize), LARGE_INTEGER._equals(liLHSSize, liRHSSize) else {


### PR DESCRIPTION
While getting SCL-F tests up and running on Windows, I noticed that those tests expose a handful of behavioral changes that swift-foundation made compared to swift-corelibs-foundation specifically around handling symlinks on Windows. In particular:

- `contentsEqual(atPath:andPath:)` would compare contents at the destination of symlinks rather than at the symlinks themselves
- `copyItem(atPath:toPath:)` would fail when copying symlinks
- `copyItem(atPath:toPath:)` would follow symlinks to directories and copy the directory contents rather than copying the symlinks themselves

This PR addresses these issues and adds a handful of unit tests to validate all of these behaviors.

Resolves https://github.com/apple/swift-foundation/issues/845