### PR TITLE
Fix Windows home directory for specific user

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -382,7 +382,8 @@ extension String {
                 var cbSID: DWORD = 0
                 var cchReferencedDomainName: DWORD = 0
                 var eUse: SID_NAME_USE = SidTypeUnknown
-                guard LookupAccountNameW(nil, pwszUserName, nil, &cbSID, nil, &cchReferencedDomainName, &eUse) else {
+                LookupAccountNameW(nil, pwszUserName, nil, &cbSID, nil, &cchReferencedDomainName, &eUse)
+                guard cbSID > 0 else {
                     return fallbackUserDirectory()
                 }
 
@@ -397,10 +398,11 @@ extension String {
                             fatalError("unable to convert SID to string for user \(user)")
                         }
 
-                        return #"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\#\(String(decodingCString: pwszSID!, as: UTF16.self))"#.withCString(encodedAs: UTF16.self) { pwszKeyPath in
+                        return #"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\\#(String(decodingCString: pwszSID!, as: UTF16.self))"#.withCString(encodedAs: UTF16.self) { pwszKeyPath in
                             return "ProfileImagePath".withCString(encodedAs: UTF16.self) { pwszKey in
                                 var cbData: DWORD = 0
-                                guard RegGetValueW(HKEY_LOCAL_MACHINE, pwszKeyPath, pwszKey, RRF_RT_REG_SZ, nil, nil, &cbData) == ERROR_SUCCESS else {
+                                RegGetValueW(HKEY_LOCAL_MACHINE, pwszKeyPath, pwszKey, RRF_RT_REG_SZ, nil, nil, &cbData)
+                                guard cbData > 0 else {
                                     fatalError("unable to query ProfileImagePath for user \(user)")
                                 }
                                 return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(cbData)) { pwszData in

--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -377,6 +377,10 @@ extension String {
                 
                 return fallback
             }
+
+            guard !user.isEmpty else {
+                return fallbackUserDirectory()
+            }
             
             return user.withCString(encodedAs: UTF16.self) { pwszUserName in
                 var cbSID: DWORD = 0

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -864,6 +864,15 @@ final class FileManagerTests : XCTestCase {
             try $0.setAttributes(attrs, ofItemAtPath: "foo")
         }
     }
+
+    func testCurrentUserHomeDirectory() throws {
+        #if canImport(Darwin) && !os(macOS)
+        throw XCTSkip("This test is not applicable on this platform")
+        #else
+        let userName = ProcessInfo.processInfo.userName
+        XCTAssertEqual(FileManager.default.homeDirectory(forUser: userName), FileManager.default.homeDirectoryForCurrentUser)
+        #endif
+    }
     
     func testAttributesOfItemAtPath() throws {
         try FileManagerPlayground {


### PR DESCRIPTION
When looking up a home directory for a specific user, we currently have a bug that results in always using the fallback path. This PR updates the implementation to:

- Expect `LookupAccountNameW` and `RegGetValueW` to fail at the first call with an empty buffer (since there is no space in the buffer and it needs to return a valid buffer size
- Fix a minor typo in the registry key that ensures we interpolate the user name rather than putting the literal `\(String(decodingC...` text into the key string

The added unit test ensures we exercise this code path