### PR TITLE
[6.0] FileManager.fileExists(atPath:) should follow symlinks

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+Files.swift
@@ -376,12 +376,19 @@ extension _FileManagerImpl {
     private func _fileExists(_ path: String) -> (exists: Bool, isDirectory: Bool) {
 #if os(Windows)
         guard !path.isEmpty else { return (false, false) }
-        return (try? path.withNTPathRepresentation {
-            var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = .init()
-            guard GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) else {
+        return (try? path.withNTPathRepresentation { pwszPath in
+            let handle = CreateFileW(pwszPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nil, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nil)
+            if handle == INVALID_HANDLE_VALUE {
                 return (false, false)
             }
-            return (true, faAttributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY)
+            defer { CloseHandle(handle) }
+
+            var info: BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION()
+            guard GetFileInformationByHandle(handle, &info) else {
+                return (false, false)
+            }
+
+            return (true, info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY)
         }) ?? (false, false)
 #else
         path.withFileSystemRepresentation { rep -> (Bool, Bool) in

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -571,6 +571,9 @@ final class FileManagerTests : XCTestCase {
                 "bar"
             }
             "other"
+            SymbolicLink("link_to_file", destination: "other")
+            SymbolicLink("link_to_dir", destination: "dir")
+            SymbolicLink("link_to_nonexistent", destination: "does_not_exist")
         }.test {
             #if FOUNDATION_FRAMEWORK
             var isDir: ObjCBool = false
@@ -591,7 +594,12 @@ final class FileManagerTests : XCTestCase {
             XCTAssertTrue(isDirBool())
             XCTAssertTrue($0.fileExists(atPath: "other", isDirectory: &isDir))
             XCTAssertFalse(isDirBool())
+            XCTAssertTrue($0.fileExists(atPath: "link_to_file", isDirectory: &isDir))
+            XCTAssertFalse(isDirBool())
+            XCTAssertTrue($0.fileExists(atPath: "link_to_dir", isDirectory: &isDir))
+            XCTAssertTrue(isDirBool())
             XCTAssertFalse($0.fileExists(atPath: "does_not_exist"))
+            XCTAssertFalse($0.fileExists(atPath: "link_to_nonexistent"))
         }
     }
 


### PR DESCRIPTION
Explanation: Fixes a behavioral regression in Swift 6 for `FileManager.fileExists(atPath:)` when given symlinks
Scope: Only impacts this API on Windows
Original PR: https://github.com/apple/swift-foundation/pull/859
Risk: Minimal - well tested change with minimal scope
Testing: Testing done via local testing and testing in swift-ci
Reviewer: @compnerd @itingliu