### PR TITLE
URL(filePath: path, directoryHint: .notDirectory) should strip trailing slashes

### DIFF
--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -586,6 +586,42 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.fileSystemPath, "/path/slashes")
     }
 
+    func testURLNotDirectoryHintStripsTrailingSlash() throws {
+        // Supply a path with a trailing slash but say it's not a direcotry
+        var url = URL(filePath: "/path/", directoryHint: .notDirectory)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(fileURLWithPath: "/path/", isDirectory: false)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(filePath: "/path///", directoryHint: .notDirectory)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        url = URL(fileURLWithPath: "/path///", isDirectory: false)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/path")
+
+        // With .checkFileSystem, don't modify the path for a non-existent file
+        url = URL(filePath: "/my/non/existent/path/", directoryHint: .checkFileSystem)
+        XCTAssertTrue(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path/")
+
+        url = URL(fileURLWithPath: "/my/non/existent/path/")
+        XCTAssertTrue(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path/")
+
+        url = URL(filePath: "/my/non/existent/path", directoryHint: .checkFileSystem)
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path")
+
+        url = URL(fileURLWithPath: "/my/non/existent/path")
+        XCTAssertFalse(url.hasDirectoryPath)
+        XCTAssertEqual(url.path(), "/my/non/existent/path")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
If a user supplies a `path` with trailing slash(es) and hints that it's `.notDirectory`, we should take their word for it and strip all trailing slashes. While that user input is slightly contradictory, this was the behavior before the Swift URL implementation, and at least it maintains the following consistency for any `path`:

```
let url = URL(filePath: path, directoryHint: .notDirectory)
XCTAssertEqual(url.hasDirectoryPath, false)
```