### PR TITLE
[6.0] Fix Windows home directory for specific user

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -375,12 +375,17 @@ extension String {
                 
                 return fallback
             }
+
+            guard !user.isEmpty else {
+                return fallbackUserDirectory()
+            }
             
             return user.withCString(encodedAs: UTF16.self) { pwszUserName in
                 var cbSID: DWORD = 0
                 var cchReferencedDomainName: DWORD = 0
                 var eUse: SID_NAME_USE = SidTypeUnknown
-                guard LookupAccountNameW(nil, pwszUserName, nil, &cbSID, nil, &cchReferencedDomainName, &eUse) else {
+                LookupAccountNameW(nil, pwszUserName, nil, &cbSID, nil, &cchReferencedDomainName, &eUse)
+                guard cbSID > 0 else {
                     return fallbackUserDirectory()
                 }
 
@@ -395,10 +400,11 @@ extension String {
                             fatalError("unable to convert SID to string for user \(user)")
                         }
 
-                        return #"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\#\(String(decodingCString: pwszSID!, as: UTF16.self))"#.withCString(encodedAs: UTF16.self) { pwszKeyPath in
+                        return #"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\\#(String(decodingCString: pwszSID!, as: UTF16.self))"#.withCString(encodedAs: UTF16.self) { pwszKeyPath in
                             return "ProfileImagePath".withCString(encodedAs: UTF16.self) { pwszKey in
                                 var cbData: DWORD = 0
-                                guard RegGetValueW(HKEY_LOCAL_MACHINE, pwszKeyPath, pwszKey, RRF_RT_REG_SZ, nil, nil, &cbData) == ERROR_SUCCESS else {
+                                RegGetValueW(HKEY_LOCAL_MACHINE, pwszKeyPath, pwszKey, RRF_RT_REG_SZ, nil, nil, &cbData)
+                                guard cbData > 0 else {
                                     fatalError("unable to query ProfileImagePath for user \(user)")
                                 }
                                 return withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(cbData)) { pwszData in

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -909,6 +909,15 @@ final class FileManagerTests : XCTestCase {
             try $0.setAttributes(attrs, ofItemAtPath: "foo")
         }
     }
+
+    func testCurrentUserHomeDirectory() throws {
+        #if canImport(Darwin) && !os(macOS)
+        throw XCTSkip("This test is not applicable on this platform")
+        #else
+        let userName = ProcessInfo.processInfo.userName
+        XCTAssertEqual(FileManager.default.homeDirectory(forUser: userName), FileManager.default.homeDirectoryForCurrentUser)
+        #endif
+    }
     
     func testAttributesOfItemAtPath() throws {
         try FileManagerPlayground {


### PR DESCRIPTION
Explanation: Fixes a behavioral regression in Swift 6 for getting the home directory of a specific user
Scope: Only impacts this API on Windows
Original PR: https://github.com/apple/swift-foundation/pull/861
Risk: Minimal - well tested change with minimal scope
Testing: Testing done via local testing and testing in swift-ci
Reviewer: @compnerd @itingliu