### PR TITLE
subpathsOfDirectory(atPath:) should throw on empty paths

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
+++ b/Sources/FoundationEssentials/FileManager/FileOperations+Enumeration.swift
@@ -33,6 +33,11 @@ struct _Win32DirectoryContentsSequence: Sequence {
         init(path: String, appendSlashForDirectory: Bool, prefix: [String]) {
             self.slash = appendSlashForDirectory
 
+            guard !path.isEmpty else {
+                self.error = CocoaError.errorWithFilePath(.fileReadInvalidFileName, path)
+                return
+            }
+
             do {
                 hFind = try "\(path)\\*".withNTPathRepresentation {
                     // We use `FindFirstFileExW` to avoid the lookup of the short name of the file. We never consult the field and this can speed up the file enumeration.

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -278,6 +278,14 @@ final class FileManagerTests : XCTestCase {
             XCTAssertThrowsError(try $0.subpathsOfDirectory(atPath: "does_not_exist")) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
             }
+
+            XCTAssertThrowsError(try $0.subpathsOfDirectory(atPath: "")) {
+                #if os(Windows)
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadInvalidFileName)
+                #else
+                XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadNoSuchFile)
+                #endif
+            }
             
             let fullContents = ["dir1", "dir1/dir2", "dir1/dir2/Bar", "dir1/dir2/Foo", "dir1/dir3", "dir1/dir3/Baz", "symlinks", "symlinks/Bar", "symlinks/Foo", "symlinks/Parent"]
             let cwd = $0.currentDirectoryPath


### PR DESCRIPTION
This should hopefully be the last of the Windows FileManager fixups for now 🙂

A swift-corelibs-foundation test revealed that `subpathsOfDirectory(atPath: "")` throws on Darwin/Linux but returns an empty array on Windows. We should make it behave the same by throwing an error (however Windows currently throws `.fileReadInvalidFileName` for empty paths unlike Darwin/Linux which reports that the file doesn't exist, so we maintain that consistency with other APIs here)