### PR TITLE
Remove the `#include <setjmp.h>` from `_CStdlib.h`

### DIFF
--- a/Sources/_FoundationCShims/include/_CStdlib.h
+++ b/Sources/_FoundationCShims/include/_CStdlib.h
@@ -55,10 +55,6 @@
 #include <math.h>
 #endif
 
-#if __has_include(<setjmp.h>)
-#include <setjmp.h>
-#endif
-
 #if __has_include(<signal.h>)
 /// Guard against including `signal.h` on WASI. The `signal.h` header file
 /// itself is available in wasi-libc, but it's just a stub that doesn't actually


### PR DESCRIPTION
It seems like we don't use neither setjmp nor longjmp in the Foundation codebase, so we can safely remove this include.
The main motivation for this change is to fix the build with the latest wasi-libc version. Recent wasi-libc versions started to provide `setjmp.h` header but it raises compilation errors unless Exception Handling feature (still under standardization process) is enabled.

See https://github.com/WebAssembly/wasi-libc/blob/wasi-sdk-22/libc-top-half/musl/include/setjmp.h