### PR TITLE
URL.host should not return percent-encoded host

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1188,7 +1188,7 @@ public struct URL: Equatable, Sendable, Hashable {
             return _url.host
         }
         #endif
-        return host()
+        return host(percentEncoded: false)
     }
 
     /// Returns the host component of the URL if present, otherwise returns `nil`.

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -622,6 +622,11 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(url.path(), "/my/non/existent/path")
     }
 
+    func testURLHostRetainsIDNAEncoding() throws {
+        let url = URL(string: "ftp://user:password@*.xn--poema-9qae5a.com.br:4343/cat.txt")!
+        XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
Before this change, `URL.host` would just call `.host()`, which defaults to `.host(percentEncoded: true)`. This meant that if the host was IDNA-encoded, `.host` would decode the IDNA-encoding and then percent-encode, returning the percent-encoded string.

This PR fixes `.host` to match the behavior before the Swift URL implementation:
- If the host was percent-encoded, return the percent-decoded host
- If the host was IDNA-encoded (or not encoded at all), return that host string

This is exactly the behavior of `.host(percentEncoded: false)`, which is now used instead of `.host()`.

Resolves #863 (thanks @Lukasa!)