### PR TITLE
Remove RegexBuilder conditional in Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -177,6 +177,15 @@ let package = Package(
             ] + availabilityMacros + concurrencyChecking
         ),
         
+        .testTarget(
+            name: "FoundationInternationalizationTests",
+            dependencies: [
+                "TestSupport",
+                "FoundationInternationalization",
+            ],
+            swiftSettings: availabilityMacros + concurrencyChecking
+        ),
+        
         // FoundationMacros
         .macro(
             name: "FoundationMacros",
@@ -208,14 +217,5 @@ package.targets.append(contentsOf: [
         ],
         swiftSettings: availabilityMacros + concurrencyChecking
     )
-])
-#endif
-
-#if canImport(RegexBuilder)
-package.targets.append(contentsOf: [
-    .testTarget(name: "FoundationInternationalizationTests", dependencies: [
-        "TestSupport",
-        "FoundationInternationalization",
-    ], swiftSettings: availabilityMacros + concurrencyChecking),
 ])
 #endif


### PR DESCRIPTION
Originally, we added this conditional because `RegexBuilder` was not available on Windows. However CI has been successfully running these tests for some time now, so we no longer need the conditional. This simplifies the manifest a bit to remove the unnecessary logic.