### PR TITLE
URLComponents: support http(s)+unix schemes

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -222,6 +222,8 @@ internal struct RFC3986Parser: URLParserProtocol {
         "addressbook",
         "contact",
         "phasset",
+        "http+unix",
+        "https+unix",
     ])
 
     private static func looksLikeIPLiteral(_ host: some StringProtocol) -> Bool {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1103,4 +1103,38 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(urlComponents.string, nsURLComponents.string)
     }
 #endif
+
+    func testURLComponentsUnixDomainSocketOverHTTPScheme() {
+        var comp = URLComponents()
+        comp.scheme = "http+unix"
+        comp.host = "/path/to/socket"
+        comp.path = "/info"
+        XCTAssertEqual(comp.string, "http+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.scheme = "https+unix"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.encodedHost = "%2Fpath%2Fto%2Fsocket"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+
+        // "/path/to/socket" is not a valid host for schemes
+        // that IDNA-encode hosts instead of percent-encoding
+        comp.scheme = "http"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "https"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "https+unix"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        // Check that we can parse a percent-encoded http+unix URL string
+        comp = URLComponents(string: "http+unix://%2Fpath%2Fto%2Fsocket/info")!
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+    }
 }


### PR DESCRIPTION
The common (but not standardized) way to represent an "HTTP over Unix socket" URL is to use the scheme `http+unix` and set the URL's host to the percent-encoded path of the socket, e.g.

`http+unix://%2Fvar%2Frun%2Fdocker.sock/info`

Before the swift-corelibs-foundation re-core, `URLComponents` would always percent-encode the `.host`, so this worked as expected. After the re-core, `URLComponents` now supports and favors IDNA-encoding of the host, breaking this use case.

This PR special-cases the `http+unix` and `https+unix` schemes to percent-encode the host like before.