### PR TITLE
Formatting performance improvements

### DIFF
--- a/Benchmarks/Benchmarks/Formatting/BenchmarkFormatting.swift
+++ b/Benchmarks/Benchmarks/Formatting/BenchmarkFormatting.swift
@@ -12,6 +12,7 @@
 
 import Benchmark
 import func Benchmark.blackHole
+import Dispatch
 
 #if os(macOS) && USE_PACKAGE
 import FoundationEssentials
@@ -56,6 +57,36 @@ let benchmarks = {
         for _ in benchmark.scaledIterations {
             for fmt in preformatted {
                 let result = try? fmt.0.parse(fmt.1)
+                blackHole(result)
+            }
+        }
+    }
+
+    Benchmark("parallel-number-formatting", configuration: .init(scalingFactor: .kilo)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+                let result = 10.123.formatted()
+                blackHole(result)
+            }
+        }
+    }
+
+    Benchmark("parallel-and-serialized-number-formatting", configuration: .init(scalingFactor: .kilo)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            DispatchQueue.concurrentPerform(iterations: 10) { _ in
+                // Reuse the values on this thread a bunch
+                for _ in 0..<100 {
+                    let result = 10.123.formatted()
+                    blackHole(result)
+                }
+            }
+        }
+    }
+
+    Benchmark("serialized-number-formatting", configuration: .init(scalingFactor: .kilo)) { benchmark in
+        for _ in benchmark.scaledIterations {
+            for _ in 0..<1000 {
+                let result = 10.123.formatted()
                 blackHole(result)
             }
         }

--- a/Sources/FoundationEssentials/Calendar/Calendar.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar.swift
@@ -323,7 +323,7 @@ public struct Calendar : Hashable, Equatable, Sendable {
     ///
     /// - note: The autoupdating Calendar will only compare equal to another autoupdating Calendar.
     public static var autoupdatingCurrent : Calendar {
-        Calendar(inner: CalendarCache.cache.autoupdatingCurrent)
+        Calendar(inner: CalendarCache.autoupdatingCurrent)
     }
 
     // MARK: -

--- a/Sources/FoundationEssentials/Formatting/FormatterCache.swift
+++ b/Sources/FoundationEssentials/Formatting/FormatterCache.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 package struct FormatterCache<Format : Hashable & Sendable, FormattingType: Sendable>: Sendable {
-
     let countLimit = 100
 
     private let _lock: LockedState<[Format: FormattingType]>

--- a/Sources/FoundationEssentials/Locale/Locale.swift
+++ b/Sources/FoundationEssentials/Locale/Locale.swift
@@ -65,7 +65,7 @@ public struct Locale : Hashable, Equatable, Sendable {
     ///
     /// - note: The autoupdating Locale will only compare equal to another autoupdating Locale.
     public static var autoupdatingCurrent : Locale {
-        Locale(inner: LocaleCache.cache.autoupdatingCurrent)
+        Locale(inner: LocaleCache.autoupdatingCurrent)
     }
 
     /// Returns the user's current locale.
@@ -75,12 +75,12 @@ public struct Locale : Hashable, Equatable, Sendable {
 
     /// System locale.
     internal static var system : Locale {
-        Locale(inner: LocaleCache.cache.system)
+        Locale(inner: LocaleCache.system)
     }
     
     /// Unlocalized locale (`en_001`).
     internal static var unlocalized : Locale {
-        Locale(inner: LocaleCache.cache.unlocalized)
+        Locale(inner: LocaleCache.unlocalized)
     }
 
 #if FOUNDATION_FRAMEWORK && canImport(_FoundationICU)

--- a/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Autoupdating.swift
@@ -263,7 +263,7 @@ internal final class _LocaleAutoupdating : _LocaleProtocol, @unchecked Sendable 
     }
     
     func bridgeToNSLocale() -> NSLocale {
-        LocaleCache.cache.autoupdatingCurrentNSLocale()
+        LocaleCache.autoupdatingCurrentNSLocale
     }
 #endif
 

--- a/Sources/FoundationEssentials/Locale/Locale_Notifications.swift
+++ b/Sources/FoundationEssentials/Locale/Locale_Notifications.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Synchronization) && FOUNDATION_FRAMEWORK
+internal import Synchronization
+#endif
+
+/// Keeps a global generation count for updated Locale information, including locale, time zone, and calendar preferences.
+/// If any of those preferences change, then `count` will update to a new value. Compare that to a cached value to see if your cached `Locale.current`, `TimeZone.current`, or `Calendar.current` to see if it is out of date.
+/// If any cached values need to be recalculated process-wide, call `reset`.
+struct LocaleNotifications : Sendable, ~Copyable {
+    static let cache = LocaleNotifications()
+    
+#if canImport(Synchronization) && FOUNDATION_FRAMEWORK
+    let _count = Atomic<Int>(1)
+#else
+    let _count = LockedState<Int>(initialState: 1)
+#endif
+    
+    func count() -> Int {
+#if canImport(Synchronization) && FOUNDATION_FRAMEWORK
+        _count.load(ordering: .relaxed)
+#else
+        _count.withLock { $0 }
+#endif
+    }
+    
+    /// Make a new generation current, but no associated Locale.
+    func reset() {
+        LocaleCache.cache.reset()
+        CalendarCache.cache.reset()
+        _ = TimeZoneCache.cache.reset()
+#if canImport(Synchronization) && FOUNDATION_FRAMEWORK
+        _count.add(1, ordering: .relaxed)
+#else
+        _count.withLock { $0 += 1 }
+#endif
+    }
+}
+
+#if FOUNDATION_FRAMEWORK
+@_cdecl("_localeNotificationCount")
+func _localeNotificationCount() -> Int {
+    LocaleNotifications.cache.count()
+}
+#endif
+

--- a/Sources/FoundationEssentials/LockedState.swift
+++ b/Sources/FoundationEssentials/LockedState.swift
@@ -155,3 +155,4 @@ extension LockedState where State == Void {
 }
 
 extension LockedState: @unchecked Sendable where State: Sendable {}
+

--- a/Sources/FoundationEssentials/String/String+Internals.swift
+++ b/Sources/FoundationEssentials/String/String+Internals.swift
@@ -52,7 +52,11 @@ extension String {
 
 extension String {
     package func _trimmingWhitespace() -> String {
-        String(unicodeScalars._trimmingCharacters {
+        if self.isEmpty {
+            return ""
+        }
+        
+        return String(unicodeScalars._trimmingCharacters {
             $0.properties.isWhitespace
         })
     }

--- a/Sources/FoundationEssentials/TimeZone/TimeZone.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone.swift
@@ -116,7 +116,7 @@ public struct TimeZone : Hashable, Equatable, Sendable {
     #endif
 
     /// The time zone currently used by the system.
-    public static var current : TimeZone {
+    public static var current: TimeZone {
         TimeZone(inner: TimeZoneCache.cache.current._tz)
     }
 
@@ -125,8 +125,8 @@ public struct TimeZone : Hashable, Equatable, Sendable {
     /// If this time zone is mutated, then it no longer tracks the system time zone.
     ///
     /// The autoupdating time zone only compares equal to itself.
-    public static var autoupdatingCurrent : TimeZone {
-        TimeZone(inner: TimeZoneCache.cache.autoupdatingCurrent())
+    public static var autoupdatingCurrent: TimeZone {
+        TimeZone(inner: TimeZoneCache.cache.autoupdatingCurrent)
     }
 
     /// The default time zone, settable via ObjC but not available in Swift API (because it's global mutable state).
@@ -405,7 +405,7 @@ extension TimeZone {
     internal static func resetSystemTimeZone() -> TimeZone? {
         let oldTimeZone = TimeZoneCache.cache.reset()
         // Also reset the calendar cache, since the current calendar uses the current time zone
-        CalendarCache.cache.reset()
+        LocaleNotifications.cache.reset()
         return oldTimeZone
     }
     

--- a/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
+++ b/Sources/FoundationEssentials/TimeZone/TimeZone_Cache.swift
@@ -51,14 +51,19 @@ dynamic package func _timeZoneGMTClass() -> _TimeZoneProtocol.Type {
 #endif
 
 /// Singleton which listens for notifications about preference changes for TimeZone and holds cached values for current, fixed time zones, etc.
-struct TimeZoneCache : Sendable {
+struct TimeZoneCache : Sendable, ~Copyable {
     // MARK: - State
     
     struct State {
+        
+        init() {
+#if FOUNDATION_FRAMEWORK
+            // On Darwin we listen for certain distributed notifications to reset the current TimeZone.
+            _CFNotificationCenterInitializeDependentNotificationIfNecessary(CFNotificationName.cfTimeZoneSystemTimeZoneDidChange!.rawValue)
+#endif
+        }
         // a.k.a. `systemTimeZone`
-        private var currentTimeZone: TimeZone!
-
-        private var autoupdatingCurrentTimeZone: _TimeZoneAutoupdating!
+        private var currentTimeZone: TimeZone?
         
         // If this is not set, the behavior is to fall back to the current time zone
         private var defaultTimeZone: TimeZone?
@@ -69,44 +74,24 @@ struct TimeZoneCache : Sendable {
         // This cache holds offset-specified time zones, but only a subset of the universe of possible values. See the implementation below for the policy.
         private var offsetTimeZones: [Int: any _TimeZoneProtocol] = [:]
 
-        private var noteCount = -1
         private var identifiers: [String]?
         private var abbreviations: [String : String]?
 
 #if FOUNDATION_FRAMEWORK
         // These are caches of the NSTimeZone subclasses for use from Objective-C (without allocating each time)
-        private var bridgedCurrentTimeZone: _NSSwiftTimeZone!
-        private var bridgedAutoupdatingCurrentTimeZone: _NSSwiftTimeZone!
+        private var bridgedCurrentTimeZone: _NSSwiftTimeZone?
         private var bridgedDefaultTimeZone: _NSSwiftTimeZone?
         private var bridgedFixedTimeZones: [String : _NSSwiftTimeZone] = [:]
         private var bridgedOffsetTimeZones: [Int : _NSSwiftTimeZone] = [:]
 #endif // FOUNDATION_FRAMEWORK
-
-        mutating func check() {
-#if FOUNDATION_FRAMEWORK
-            // On Darwin we listen for certain distributed notifications to reset the current TimeZone.
-            let newNoteCount = _CFLocaleGetNoteCount() + _CFTimeZoneGetNoteCount() + Int(_CFCalendarGetMidnightNoteCount())
-#else
-            let newNoteCount = 1
-#endif // FOUNDATION_FRAMEWORK
-
-            if newNoteCount != noteCount {
-                currentTimeZone = findCurrentTimeZone()
-                noteCount = newNoteCount
-#if FOUNDATION_FRAMEWORK
-                bridgedCurrentTimeZone = _NSSwiftTimeZone(timeZone: currentTimeZone)
-                _CFNotificationCenterInitializeDependentNotificationIfNecessary(CFNotificationName.cfTimeZoneSystemTimeZoneDidChange!.rawValue)
-#endif // FOUNDATION_FRAMEWORK
-            }
-        }
         
         mutating func reset() -> TimeZone? {
             let oldTimeZone = currentTimeZone
 
-            // Ensure we do not reuse the existing time zone
-            noteCount = -1
-            check()
-
+            currentTimeZone = nil
+#if FOUNDATION_FRAMEWORK
+            bridgedCurrentTimeZone = nil
+#endif
             return oldTimeZone
         }
 
@@ -194,23 +179,24 @@ struct TimeZoneCache : Sendable {
         }
 
         mutating func current() -> TimeZone {
-            check()
-            return currentTimeZone
-        }
-
-        mutating func `default`() -> TimeZone {
-            check()
-            if let manuallySetDefault = defaultTimeZone {
-                return manuallySetDefault
-            } else {
+            if let currentTimeZone {
                 return currentTimeZone
+            } else {
+                let newCurrent = findCurrentTimeZone()
+                currentTimeZone = newCurrent
+                return newCurrent
             }
         }
 
-        mutating func setDefaultTimeZone(_ tz: TimeZone?) -> TimeZone? {
-            // Ensure we are listening for notifications from here on out
-            check()
-            let old = defaultTimeZone
+        mutating func `default`() -> TimeZone {
+            if let manuallySetDefault = defaultTimeZone {
+                return manuallySetDefault
+            } else {
+                return current()
+            }
+        }
+
+        mutating func setDefaultTimeZone(_ tz: TimeZone?) {
             defaultTimeZone = tz
 #if FOUNDATION_FRAMEWORK
             if let tz {
@@ -219,7 +205,6 @@ struct TimeZoneCache : Sendable {
                 bridgedDefaultTimeZone = nil
             }
 #endif // FOUNDATION_FRAMEWORK
-            return old
         }
         
         mutating func fixed(_ identifier: String) -> (any _TimeZoneProtocol)? {
@@ -255,15 +240,6 @@ struct TimeZoneCache : Sendable {
             }
         }
         
-        mutating func autoupdatingCurrent() -> _TimeZoneAutoupdating {
-            if let cached = autoupdatingCurrentTimeZone {
-                return cached
-            } else {
-                autoupdatingCurrentTimeZone = _TimeZoneAutoupdating()
-                return autoupdatingCurrentTimeZone
-            }
-        }
-
         mutating func timeZoneAbbreviations() -> [String : String] {
             if abbreviations == nil {
                 abbreviations = defaultAbbreviations
@@ -332,28 +308,20 @@ struct TimeZoneCache : Sendable {
 // MARK: - State Bridging
 #if FOUNDATION_FRAMEWORK
         mutating func bridgedCurrent() -> _NSSwiftTimeZone {
-            check()
-            return bridgedCurrentTimeZone
-        }
-
-        mutating func bridgedAutoupdatingCurrent() -> _NSSwiftTimeZone {
-            if let autoupdating = bridgedAutoupdatingCurrentTimeZone {
-                return autoupdating
+            if let bridgedCurrentTimeZone {
+                return bridgedCurrentTimeZone
             } else {
-                // Do not call TimeZone.autoupdatingCurrent, as it will recursively lock.
-                let tz = TimeZone(inner: autoupdatingCurrent())
-                let result = _NSSwiftTimeZone(timeZone: tz)
-                bridgedAutoupdatingCurrentTimeZone = result
-                return result
+                let newBridged = _NSSwiftTimeZone(timeZone: current())
+                bridgedCurrentTimeZone = newBridged
+                return newBridged
             }
         }
 
         mutating func bridgedDefault() -> _NSSwiftTimeZone {
-            check()
             if let manuallySetDefault = bridgedDefaultTimeZone {
                 return manuallySetDefault
             } else {
-                return bridgedCurrentTimeZone
+                return bridgedCurrent()
             }
         }
 
@@ -433,19 +401,10 @@ struct TimeZoneCache : Sendable {
     }
 
     func setDefault(_ tz: TimeZone?) {
-        let oldDefaultTimeZone = lock.withLock {
-            return $0.setDefaultTimeZone(tz)
-        }
+        lock.withLock { $0.setDefaultTimeZone(tz) }
 
-        CalendarCache.cache.reset()
-#if FOUNDATION_FRAMEWORK
-        if let oldDefaultTimeZone {
-            let noteName = CFNotificationName(rawValue: "kCFTimeZoneSystemTimeZoneDidChangeNotification-2" as CFString)
-            let oldAsNS = oldDefaultTimeZone as NSTimeZone
-            let unmanaged = Unmanaged.passRetained(oldAsNS).autorelease()
-            CFNotificationCenterPostNotification(CFNotificationCenterGetLocalCenter(), noteName, unmanaged.toOpaque(), nil, true)
-        }
-#endif // FOUNDATION_FRAMEWORK
+        // Reset any 'current' locales, calendars, time zones
+        LocaleNotifications.cache.reset()
     }
 
     func fixed(_ identifier: String) -> _TimeZoneProtocol? {
@@ -456,8 +415,9 @@ struct TimeZoneCache : Sendable {
         lock.withLock { $0.offsetFixed(seconds) }
     }
     
-    func autoupdatingCurrent() -> _TimeZoneAutoupdating {
-        lock.withLock { $0.autoupdatingCurrent() }
+    private static let _autoupdatingCurrentCache = _TimeZoneAutoupdating()
+    var autoupdatingCurrent: _TimeZoneAutoupdating {
+        return Self._autoupdatingCurrentCache
     }
 
     func timeZoneAbbreviations() -> [String : String] {
@@ -474,8 +434,9 @@ struct TimeZoneCache : Sendable {
         lock.withLock { $0.bridgedCurrent() }
     }
 
+    private static let _bridgedAutoupdatingCurrent = _NSSwiftTimeZone(timeZone: TimeZone(inner: TimeZoneCache.cache.autoupdatingCurrent))
     var bridgedAutoupdatingCurrent: _NSSwiftTimeZone {
-        lock.withLock { $0.bridgedAutoupdatingCurrent() }
+        Self._bridgedAutoupdatingCurrent
     }
 
     var bridgedDefault: _NSSwiftTimeZone {

--- a/Sources/FoundationInternationalization/Calendar/Calendar_ObjC.swift
+++ b/Sources/FoundationInternationalization/Calendar/Calendar_ObjC.swift
@@ -75,11 +75,6 @@ extension NSCalendar {
         }
         return _NSSwiftCalendar(calendar: Calendar(identifier: id))
     }
-
-    @objc
-    class func _resetCurrent() {
-        CalendarCache.cache.reset()
-    }
 }
 
 // MARK: -

--- a/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/ICUNumberFormatter.swift
@@ -33,7 +33,7 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
     /// Stored for testing purposes only
     internal let skeleton: String
 
-    init?(skeleton: String, localeIdentifier: String, preferences: LocalePreferences?) {
+    init?(skeleton: String, localeIdentifier: String) {
         self.skeleton = skeleton
         let ustr = Array(skeleton.utf16)
         var status = U_ZERO_ERROR
@@ -222,29 +222,28 @@ internal class ICUNumberFormatterBase : @unchecked Sendable {
 
 final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
-        let collection: NumberFormatStyleConfiguration.Collection
+        let skeleton: String
         let localeIdentifier: String
-        let localePreferences: LocalePreferences?
     }
 
     fileprivate static let cache = FormatterCache<Signature, ICUNumberFormatter?>()
 
     private static func _create(with signature: Signature) -> ICUNumberFormatter? {
         Self.cache.formatter(for: signature) {
-            .init(skeleton: signature.collection.skeleton, localeIdentifier: signature.localeIdentifier, preferences: signature.localePreferences)
+            .init(skeleton: signature.skeleton, localeIdentifier: signature.localeIdentifier)
         }
     }
 
     static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>) -> ICUNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create(for style: Decimal.FormatStyle) -> ICUNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>) -> ICUNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     func attributedFormat(_ v: Value) -> AttributedString {
@@ -259,16 +258,15 @@ final class ICUNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
 
 final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
-        let collection: CurrencyFormatStyleConfiguration.Collection
+        let skeleton: String
         let currencyCode: String
         let localeIdentifier: String
-        let localePreferences: LocalePreferences?
     }
 
     private static func skeleton(for signature: Signature) -> String {
         var s = "currency/\(signature.currencyCode)"
 
-        let stem = signature.collection.skeleton
+        let stem = signature.skeleton
         if stem.count > 0 {
             s += " " + stem
         }
@@ -280,20 +278,20 @@ final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Send
 
     static private func _create(with signature: Signature) -> ICUCurrencyNumberFormatter? {
         return Self.cache.formatter(for: signature) {
-            .init(skeleton: Self.skeleton(for: signature), localeIdentifier: signature.localeIdentifier, preferences: signature.localePreferences)
+            .init(skeleton: Self.skeleton(for: signature), localeIdentifier: signature.localeIdentifier)
         }
     }
 
     static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
-        _create(with: .init(collection: style.collection, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create(for style: Decimal.FormatStyle.Currency) -> ICUCurrencyNumberFormatter? {
-        _create(with: .init(collection: style.collection, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>.Currency) -> ICUCurrencyNumberFormatter? {
-        _create(with: .init(collection: style.collection, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, currencyCode: style.currencyCode, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     func attributedFormat(_ v: Value) -> AttributedString {
@@ -308,14 +306,13 @@ final class ICUCurrencyNumberFormatter : ICUNumberFormatterBase, @unchecked Send
 
 final class ICUPercentNumberFormatter : ICUNumberFormatterBase, @unchecked Sendable {
     fileprivate struct Signature : Hashable {
-        let collection: NumberFormatStyleConfiguration.Collection
+        let skeleton: String
         let localeIdentifier: String
-        let localePreferences: LocalePreferences?
     }
 
     private static func skeleton(for signature: Signature) -> String {
         var s = "percent"
-        let stem = signature.collection.skeleton
+        let stem = signature.skeleton
         if stem.count > 0 {
             s += " " + stem
         }
@@ -326,20 +323,20 @@ final class ICUPercentNumberFormatter : ICUNumberFormatterBase, @unchecked Senda
 
     private static func _create(with signature: Signature) -> ICUPercentNumberFormatter? {
         return Self.cache.formatter(for: signature) {
-            .init(skeleton: Self.skeleton(for: signature), localeIdentifier: signature.localeIdentifier, preferences: signature.localePreferences)
+            .init(skeleton: Self.skeleton(for: signature), localeIdentifier: signature.localeIdentifier)
         }
     }
 
     static func create<T: BinaryInteger>(for style: IntegerFormatStyle<T>.Percent) -> ICUPercentNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create(for style: Decimal.FormatStyle.Percent) -> ICUPercentNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     static func create<T: BinaryFloatingPoint>(for style: FloatingPointFormatStyle<T>.Percent) -> ICUPercentNumberFormatter? {
-        _create(with: .init(collection: style.collection, localeIdentifier: style.locale.identifierCapturingPreferences, localePreferences: style.locale.prefs))
+        _create(with: .init(skeleton: style.collection.skeleton, localeIdentifier: style.locale.identifierCapturingPreferences))
     }
 
     func attributedFormat(_ v: Value) -> AttributedString {
@@ -356,15 +353,14 @@ final class ICUByteCountNumberFormatter : ICUNumberFormatterBase, @unchecked Sen
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let localeIdentifier: String
-        let localePreferences: LocalePreferences?
     }
 
     fileprivate static let cache = FormatterCache<Signature, ICUByteCountNumberFormatter?>()
 
     static func create(for skeleton: String, locale: Locale) -> ICUByteCountNumberFormatter? {
-        let signature = Signature(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences, localePreferences: locale.prefs)
+        let signature = Signature(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences)
         return Self.cache.formatter(for: signature) {
-            .init(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences, preferences: locale.prefs)
+            .init(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences)
         }
     }
 
@@ -415,15 +411,14 @@ final class ICUMeasurementNumberFormatter : ICUNumberFormatterBase, @unchecked S
     fileprivate struct Signature : Hashable {
         let skeleton: String
         let localeIdentifier: String
-        let localePreferences: LocalePreferences?
     }
 
     fileprivate static let cache = FormatterCache<Signature, ICUMeasurementNumberFormatter?>()
 
     static func create(for skeleton: String, locale: Locale) -> ICUMeasurementNumberFormatter? {
-        let signature = Signature(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences, localePreferences: locale.prefs)
+        let signature = Signature(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences)
         return Self.cache.formatter(for: signature) {
-            .init(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences, preferences: locale.prefs)
+            .init(skeleton: skeleton, localeIdentifier: locale.identifierCapturingPreferences)
         }
     }
 

--- a/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ICU.swift
@@ -41,7 +41,6 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
     // Single-optional values are caches where the result may not be nil. If the value is nil, the result has not yet been calculated.
     struct State: Hashable, Sendable {
         var languageComponents: Locale.Language.Components?
-        var calendarId: Calendar.Identifier?
         var collation: Locale.Collation?
         var currency: Locale.Currency??
         var numberingSystem: Locale.NumberingSystem?
@@ -56,7 +55,6 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
         var subdivision: Locale.Subdivision??
         var timeZone: TimeZone??
         var variant: Locale.Variant??
-        var identifierCapturingPreferences: String?
 
         // If the key is present, the value has been calculated (and the result may or may not be nil).
         var identifierDisplayNames: [String : String?] = [:]
@@ -131,6 +129,8 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
     // MARK: - ivar
 
     let identifier: String
+    let identifierCapturingPreferences: String
+    let calendarIdentifier: Calendar.Identifier
     
     let doesNotRequireSpecialCaseHandling: Bool
     
@@ -159,6 +159,8 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
         self.identifier = Locale._canonicalLocaleIdentifier(from: identifier)
         doesNotRequireSpecialCaseHandling = Locale.identifierDoesNotRequireSpecialCaseHandling(self.identifier)
         self.prefs = prefs
+        calendarIdentifier = Self._calendarIdentifier(forIdentifier: self.identifier)
+        identifierCapturingPreferences = Self._identifierCapturingPreferences(forIdentifier: self.identifier, calendarIdentifier: calendarIdentifier, preferences: prefs)
         lock = LockedState(initialState: State())
     }
 
@@ -166,12 +168,12 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
         self.identifier = components.icuIdentifier
         doesNotRequireSpecialCaseHandling = Locale.identifierDoesNotRequireSpecialCaseHandling(self.identifier)
         prefs = nil
+        calendarIdentifier = Self._calendarIdentifier(forIdentifier: self.identifier)
+        identifierCapturingPreferences = Self._identifierCapturingPreferences(forIdentifier: self.identifier, calendarIdentifier: calendarIdentifier, preferences: prefs)
 
         // Copy over the component values into our internal state - if they are set
         var state = State()
         state.languageComponents = components.languageComponents
-        if let v = components.calendar { state.calendarId = v }
-        if let v = components.calendar { state.calendarId = v }
         if let v = components.collation { state.collation = v }
         if let v = components.currency { state.currency = v }
         if let v = components.numberingSystem { state.numberingSystem = v }
@@ -284,6 +286,8 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
         self.identifier = Locale._canonicalLocaleIdentifier(from: fixedIdent)
         doesNotRequireSpecialCaseHandling = Locale.identifierDoesNotRequireSpecialCaseHandling(self.identifier)
         self.prefs = prefs
+        calendarIdentifier = Self._calendarIdentifier(forIdentifier: self.identifier)
+        identifierCapturingPreferences = Self._identifierCapturingPreferences(forIdentifier: self.identifier, calendarIdentifier: calendarIdentifier, preferences: prefs)
         lock = LockedState(initialState: State())
     }
     
@@ -432,42 +436,33 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
     //
     // Intentionally ignore `prefs.country`: Locale identifier should already contain
     // that information. Do not override it.
-    var identifierCapturingPreferences: String {
-        lock.withLock { state in
-            if let result = state.identifierCapturingPreferences {
-                return result
-            }
-
-            guard let prefs else {
-                state.identifierCapturingPreferences = identifier
-                return identifier
-            }
-
-            var components = Locale.Components(identifier: identifier)
-
-            if let id = prefs.collationOrder {
-                components.collation = .init(id)
-            }
-
-            if let firstWeekdayPrefs = prefs.firstWeekday {
-                let calendarID = _lockedCalendarIdentifier(&state)
-                if let weekdayNumber = firstWeekdayPrefs[calendarID], let weekday = Locale.Weekday(Int32(weekdayNumber)) {
-                    components.firstDayOfWeek = weekday
-                }
-            }
-
-            if let measurementSystem = prefs.measurementSystem {
-                components.measurementSystem = measurementSystem
-            }
-
-            if let hourCycle = prefs.hourCycle {
-                components.hourCycle = hourCycle
-            }
-
-            let completeID = components.icuIdentifier
-            state.identifierCapturingPreferences = completeID
-            return completeID
+    static func _identifierCapturingPreferences(forIdentifier identifier: String, calendarIdentifier: Calendar.Identifier, preferences prefs: LocalePreferences?) -> String {
+        guard let prefs else {
+            return identifier
         }
+        
+        var components = Locale.Components(identifier: identifier)
+        
+        if let id = prefs.collationOrder {
+            components.collation = .init(id)
+        }
+        
+        if let firstWeekdayPrefs = prefs.firstWeekday {
+            let calendarID = calendarIdentifier
+            if let weekdayNumber = firstWeekdayPrefs[calendarID], let weekday = Locale.Weekday(Int32(weekdayNumber)) {
+                components.firstDayOfWeek = weekday
+            }
+        }
+        
+        if let measurementSystem = prefs.measurementSystem {
+            components.measurementSystem = measurementSystem
+        }
+        
+        if let hourCycle = prefs.hourCycle {
+            components.hourCycle = hourCycle
+        }
+        
+        return components.icuIdentifier
     }
 
     // MARK: - Language Code
@@ -720,46 +715,31 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
     // MARK: - LocaleCalendarIdentifier
 
-    private func _lockedCalendarIdentifier(_ state: inout State) -> Calendar.Identifier {
-        if let calendarId = state.calendarId {
-            return calendarId
-        } else {
-            var calendarIDString = Locale.keywordValue(identifier: identifier, key: "calendar")
-            if calendarIDString == nil {
-                // Try again
-                var status = U_ZERO_ERROR
-                let e = ucal_getKeywordValuesForLocale("calendar", identifier, UBool.true, &status)
-                defer { uenum_close(e) }
-                guard let e, status.isSuccess else {
-                    state.calendarId = .gregorian
-                    return .gregorian
-                }
-                // Just get the first value
-                var resultLength = Int32(0)
-                let result = uenum_next(e, &resultLength, &status)
-                guard status.isSuccess, let result else {
-                    state.calendarId = .gregorian
-                    return .gregorian
-                }
-                calendarIDString = String(cString: result)
-            }
-
-            guard let calendarIDString else {
-                // Fallback value
-                state.calendarId = .gregorian
+    private static func _calendarIdentifier(forIdentifier identifier: String) -> Calendar.Identifier {
+        var calendarIDString = Locale.keywordValue(identifier: identifier, key: "calendar")
+        if calendarIDString == nil {
+            // Try again
+            var status = U_ZERO_ERROR
+            let e = ucal_getKeywordValuesForLocale("calendar", identifier, UBool.true, &status)
+            defer { uenum_close(e) }
+            guard let e, status.isSuccess else {
                 return .gregorian
             }
-
-            let id = Calendar.Identifier(identifierString: calendarIDString) ?? .gregorian
-            state.calendarId = id
-            return id
+            // Just get the first value
+            var resultLength = Int32(0)
+            let result = uenum_next(e, &resultLength, &status)
+            guard status.isSuccess, let result else {
+                return .gregorian
+            }
+            calendarIDString = String(cString: result)
         }
-    }
-
-    var calendarIdentifier: Calendar.Identifier {
-        lock.withLock { state in
-            _lockedCalendarIdentifier(&state)
+        
+        guard let calendarIDString else {
+            // Fallback value
+            return .gregorian
         }
+
+        return Calendar.Identifier(identifierString: calendarIDString) ?? .gregorian
     }
 
     func calendarIdentifierDisplayName(for value: Calendar.Identifier) -> String? {
@@ -780,20 +760,17 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
     // MARK: - LocaleCalendar
 
     var calendar: Calendar {
-        lock.withLock { state in
-            let id = _lockedCalendarIdentifier(&state)
-            var calendar = Calendar(identifier: id)
-
-            if let prefs {
-                let firstWeekday = prefs.firstWeekday?[id]
-                let minDaysInFirstWeek = prefs.minDaysInFirstWeek?[id]
-                if let firstWeekday { calendar.firstWeekday = firstWeekday }
-                if let minDaysInFirstWeek { calendar.minimumDaysInFirstWeek = minDaysInFirstWeek }
-            }
-
-            // In order to avoid a retain cycle (Calendar has a Locale, Locale has a Calendar), we do not keep a reference to the Calendar in Locale but create one each time. Most of the time the value of `Calendar(identifier:)` will return a cached value in any case.
-            return calendar
+        var calendar = Calendar(identifier: calendarIdentifier)
+        
+        if let prefs {
+            let firstWeekday = prefs.firstWeekday?[calendarIdentifier]
+            let minDaysInFirstWeek = prefs.minDaysInFirstWeek?[calendarIdentifier]
+            if let firstWeekday { calendar.firstWeekday = firstWeekday }
+            if let minDaysInFirstWeek { calendar.minimumDaysInFirstWeek = minDaysInFirstWeek }
         }
+        
+        // In order to avoid a retain cycle (Calendar has a Locale, Locale has a Calendar), we do not keep a reference to the Calendar in Locale but create one each time. Most of the time the value of `Calendar(identifier:)` will return a cached value in any case.
+        return calendar
     }
 
     var timeZone: TimeZone? {
@@ -1185,7 +1162,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
                     return hourCycle
                 }
 
-                let calendarId = _lockedCalendarIdentifier(&state)
+                let calendarId = calendarIdentifier
                 let rootHourCycle = Locale.HourCycle.zeroToTwentyThree
                 if let regionOverride = _lockedRegion(&state)?.identifier {
                     // Use the "rg" override in the identifier if there's one
@@ -1239,8 +1216,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
 
                 // Check prefs
                 if let firstWeekdayPref = prefs?.firstWeekday {
-                    // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
-                    let calendarId = _lockedCalendarIdentifier(&state)
+                    let calendarId = calendarIdentifier
                     if let first = forceFirstWeekday(calendarId) {
                         state.firstDayOfWeek = first
                         return first
@@ -1398,7 +1374,7 @@ internal final class _LocaleICU: _LocaleProtocol, Sendable {
             // Check prefs
             if prefs != nil {
                 // `_lockedCalendarIdentifier` isn't cheap. Only call it when we already know there is `prefs` to read from
-                let calendarId = _lockedCalendarIdentifier(&state)
+                let calendarId = calendarIdentifier
                 if let minDays = forceMinDaysInFirstWeek(calendarId) {
                     state.minimalDaysInFirstWeek = minDays
                     return minDays

--- a/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
+++ b/Sources/FoundationInternationalization/Locale/Locale_ObjC.swift
@@ -27,7 +27,7 @@ internal import Foundation_Private.NSLocale
 extension NSLocale {
     @objc
     static var _autoupdatingCurrent: NSLocale {
-        LocaleCache.cache.autoupdatingCurrentNSLocale()
+        LocaleCache.autoupdatingCurrentNSLocale
     }
 
     @objc
@@ -37,7 +37,7 @@ extension NSLocale {
 
     @objc
     static var _system: NSLocale {
-        LocaleCache.cache.systemNSLocale()
+        LocaleCache.systemNSLocale
     }
 
     @objc
@@ -65,7 +65,7 @@ extension NSLocale {
 
     @objc
     private class func _resetCurrent() {
-        LocaleCache.cache.reset()
+        LocaleNotifications.cache.reset()
     }
 
     @objc


### PR DESCRIPTION
Re-apply the diff from #719 (reverted in #744). We discovered the root cause was use of ICU's ability to set the malloc functions used, which can race. We will be disabling those in swift-foundation-icu soon. In the meantime, we know that they are not used on Linux so this patch is safe.