### PR TITLE
[cmake] Add missing locale_notifications.swift

### DIFF
--- a/Sources/FoundationEssentials/Locale/CMakeLists.txt
+++ b/Sources/FoundationEssentials/Locale/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(FoundationEssentials PRIVATE
     Locale.swift
     Locale_Autoupdating.swift
     Locale_Cache.swift
+    Locale_Notifications.swift
     Locale_Preferences.swift
     Locale_Protocol.swift
     Locale_Unlocalized.swift)


### PR DESCRIPTION
https://github.com/apple/swift-foundation/pull/884 added Locale_Notifcations.swift but didn't include it in the FoundationEssentials library resulting in build failures. Adding it now.