### PR TITLE
Correct available version macOS 10.10 for String+Essentials.swift

### DIFF
--- a/Sources/FoundationEssentials/String/String+Essentials.swift
+++ b/Sources/FoundationEssentials/String/String+Essentials.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // MARK: - Exported Types
-@available(macOS 10.0, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
+@available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 extension String {
 #if FOUNDATION_FRAMEWORK
     public typealias CompareOptions = NSString.CompareOptions


### PR DESCRIPTION
At String+Essentials.swift, correct available version macOS  is`10.10`  (release on 2014), not `10.0`(release on 2001).