### PR TITLE
Add `.count` and `.date` properties to `Calendar.RecurrenceRule.End`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,9 @@ list(APPEND _SwiftFoundation_versions
     "0.1"
     "0.2"
     "0.3"
-    "0.4")
+    "0.4"
+    "6.0.2"
+    )
 
 # Each availability name to define
 list(APPEND _SwiftFoundation_availability_names

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let availabilityTags: [_Availability] = [
     _Availability("FoundationPredicate", availability: .macOS14_0), // Predicate relies on pack parameter runtime support
     _Availability("FoundationPredicateRegex", availability: .macOS15_0) // Predicate regexes rely on new stdlib APIs
 ]
-let versionNumbers = ["0.1", "0.2", "0.3", "0.4"]
+let versionNumbers = ["0.1", "0.2", "0.3", "0.4", "6.0.2"]
 
 // Availability Macro Utilities
 

--- a/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
+++ b/Sources/FoundationEssentials/Calendar/Calendar_Recurrence.swift
@@ -335,7 +335,7 @@ extension Calendar {
                 
                 dates = dates.filter { $0 >= self.start }
                 
-                if let limit = recurrence.end.until {
+                if let limit = recurrence.end.date {
                     let hadDates = !dates.isEmpty
                     dates = dates.filter { $0 <= limit }
                     if hadDates && dates.isEmpty {
@@ -363,7 +363,7 @@ extension Calendar {
             
             mutating func next() -> Element? {
                 guard !finished else { return nil }
-                if let limit = recurrence.end.count, resultsFound >= limit {
+                if let limit = recurrence.end.occurrences, resultsFound >= limit {
                     finished = true
                     return nil
                 }
@@ -371,7 +371,7 @@ extension Calendar {
                 while !finished {
                     if let date = currentGroup.popLast() {
                         resultsFound += 1
-                        if let limit = recurrence.end.until, date > limit {
+                        if let limit = recurrence.end.date, date > limit {
                             finished = true
                             return nil
                         }

--- a/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
+++ b/Sources/FoundationEssentials/Calendar/RecurrenceRule.swift
@@ -135,16 +135,23 @@ extension Calendar {
             public static var never: Self {
                 .init(_guts: .never)
             }
-            
-            internal var until: Date? {
+
+            /// At most many times the event may occur
+            /// This value is set when the struct was initialized with `.afterOccurrences()`
+            @available(FoundationPreview 6.0.2, *)
+            public var occurrences: Int? {
                 switch _guts {
-                    case let .afterDate(date): date
+                    case let .afterOccurrences(count): count
                     default: nil
                 }
             }
-            internal var count: Int? {
+
+            /// The latest date when the event may occur
+            /// This value is set when the struct was initialized with `.afterDate()`
+            @available(FoundationPreview 6.0.2, *)
+            public var date: Date? {
                 switch _guts {
-                    case let .afterOccurrences(count): count
+                    case let .afterDate(date): date
                     default: nil
                 }
             }
@@ -438,5 +445,16 @@ extension Calendar.RecurrenceRule: Codable {
         try container.encode(minutes, forKey: .minutes)
         try container.encode(seconds, forKey: .seconds)
         try container.encode(setPositions, forKey: .setPositions)
+    }
+}
+
+@available(FoundationPreview 6.0.2, *)
+extension Calendar.RecurrenceRule.End: CustomStringConvertible {
+    public var description: String {
+        switch self._guts {
+            case .never: "Never"
+            case .afterDate(let date): "After \(date)"
+            case .afterOccurrences(let n): "After \(n) occurrence(s)"
+        }
     }
 }


### PR DESCRIPTION
`Calendar.RecurrenceRule.End` is de-facto an enum, but has been implemented as a struct so we can more easily extend it in the future without breaking ABI. Sadly the current API only provides a way to construct the struct, and does not let us introspect the associated values. This change adds a couple read-only properties to the struct to address this.