### PR TITLE
Change @_nonSendable to unavailable extensions

### DIFF
--- a/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributeScope.swift
@@ -22,10 +22,16 @@ public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigu
     static var encodingConfiguration: AttributeScopeCodableConfiguration { get }
 }
 
-@_nonSendable
 @frozen
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public enum AttributeScopes { }
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes : Sendable {}
 
 #if FOUNDATION_FRAMEWORK
 

--- a/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/FoundationEssentials/AttributedString/AttributedStringAttribute.swift
@@ -133,7 +133,6 @@ extension AttributedStringKey {
 
 // MARK: Attribute Scopes
 
-@_nonSendable
 @dynamicMemberLookup @frozen
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public enum AttributeDynamicLookup {
@@ -141,6 +140,13 @@ public enum AttributeDynamicLookup {
         get { fatalError("Called outside of a dynamicMemberLookup subscript overload") }
     }
 }
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeDynamicLookup : Sendable {}
 
 @dynamicMemberLookup
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
+++ b/Sources/FoundationEssentials/AttributedString/FoundationAttributes.swift
@@ -20,7 +20,6 @@ internal import Foundation_Private.NSAttributedString
 extension AttributeScopes {
     public var foundation: FoundationAttributes.Type { FoundationAttributes.self }
     
-    @_nonSendable
     public struct FoundationAttributes : AttributeScope {
         public let link: LinkAttribute
         public let languageIdentifier: LanguageIdentifierAttribute
@@ -65,6 +64,14 @@ extension AttributeScopes {
     }
 }
 
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes : Sendable {}
+
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeDynamicLookup {
     public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes, T>) -> T {
@@ -92,7 +99,6 @@ extension AttributeDynamicLookup {
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes.FoundationAttributes {
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum LinkAttribute : CodableAttributedStringKey {
         public typealias Value = URL
@@ -106,7 +112,7 @@ extension AttributeScopes.FoundationAttributes {
     
 #if FOUNDATION_FRAMEWORK
     
-    @frozen @_nonSendable
+    @frozen
     @available(FoundationPreview 0.1, *)
     public enum ReferentConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
@@ -114,7 +120,7 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "referentConcept"
     }
 
-    @frozen @_nonSendable
+    @frozen
     @available(FoundationPreview 0.1, *)
     public enum AgreementConceptAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
@@ -122,7 +128,7 @@ extension AttributeScopes.FoundationAttributes {
         public static let markdownName = "agreeWithConcept"
     }
     
-    @frozen @_nonSendable
+    @frozen
     @available(FoundationPreview 0.1, *)
     public enum AgreementArgumentAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Int
@@ -131,7 +137,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum MorphologyAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = Morphology
@@ -140,7 +145,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InflectionRuleAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public typealias Value = InflectionRule
@@ -149,7 +153,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     @_spi(AutomaticGrammaticalAgreement)
     public enum AssumedFallbackInflectionAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
@@ -159,7 +162,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(FoundationPreview 0.4, *)
     public enum LocalizedNumberFormatAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
         public struct Value: Equatable, Hashable, Codable, Sendable {
@@ -194,7 +196,6 @@ extension AttributeScopes.FoundationAttributes {
 #endif // FOUNDATION_FRAMEWORK
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum LanguageIdentifierAttribute : CodableAttributedStringKey {
         public typealias Value = String
@@ -202,7 +203,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum PersonNameComponentAttribute : CodableAttributedStringKey {
         public typealias Value = Component
@@ -213,14 +213,12 @@ extension AttributeScopes.FoundationAttributes {
         }
     }
     
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public struct NumberFormatAttributes: AttributeScope {
         public let numberSymbol: SymbolAttribute
         public let numberPart: NumberPartAttribute
         
         @frozen
-        @_nonSendable
         public enum NumberPartAttribute : CodableAttributedStringKey {
             public enum NumberPart : Int, Codable, Sendable {
                 case integer
@@ -232,7 +230,6 @@ extension AttributeScopes.FoundationAttributes {
         }
         
         @frozen
-        @_nonSendable
         public enum SymbolAttribute : CodableAttributedStringKey {
             public enum Symbol : Int, Codable, Sendable {
                 case groupingSeparator
@@ -248,7 +245,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum DateFieldAttribute : CodableAttributedStringKey {
         public enum Field : Hashable, Codable, Sendable {
@@ -381,7 +377,6 @@ extension AttributeScopes.FoundationAttributes {
 #if FOUNDATION_FRAMEWORK
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InflectionAlternativeAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
         public typealias Value = AttributedString
@@ -409,7 +404,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
 	@frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum InlinePresentationIntentAttribute : CodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
         public typealias Value = InlinePresentationIntent
@@ -426,7 +420,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum PresentationIntentAttribute : CodableAttributedStringKey {
         public typealias Value = PresentationIntent
@@ -434,7 +427,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public enum MarkdownSourcePositionAttribute: CodableAttributedStringKey {
         public static let name = NSAttributedString.Key.markdownSourcePosition.rawValue
@@ -444,7 +436,6 @@ extension AttributeScopes.FoundationAttributes {
 #endif // FOUNDATION_FRAMEWORK
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum AlternateDescriptionAttribute : CodableAttributedStringKey {
         public typealias Value = String
@@ -452,7 +443,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum ImageURLAttribute : CodableAttributedStringKey {
         public typealias Value = URL
@@ -460,14 +450,12 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum ReplacementIndexAttribute : CodableAttributedStringKey {
         public typealias Value = Int
         public static let name = "NSReplacementIndex"
     }
     
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public struct MeasurementAttribute : CodableAttributedStringKey {
         public typealias Value = Component
@@ -479,7 +467,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
     @frozen
-    @_nonSendable
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public enum ByteCountAttribute : CodableAttributedStringKey {
         public typealias Value = Component
@@ -505,7 +492,6 @@ extension AttributeScopes.FoundationAttributes {
     }
 
     @frozen
-    @_nonSendable
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     public enum DurationFieldAttribute : CodableAttributedStringKey {
         public typealias Value = Field
@@ -523,7 +509,6 @@ extension AttributeScopes.FoundationAttributes {
     }
     
 #if FOUNDATION_FRAMEWORK
-    @_nonSendable
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     public struct LocalizedStringArgumentAttributes {
     
@@ -535,7 +520,6 @@ extension AttributeScopes.FoundationAttributes {
         public let localizedURLArgument: LocalizedURLArgumentAttribute
         
         @frozen
-        @_nonSendable
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedNumericArgumentAttribute : CodableAttributedStringKey {
             public static let name = "Foundation.LocalizedNumericArgumentAttribute"
@@ -548,7 +532,6 @@ extension AttributeScopes.FoundationAttributes {
         }
         
         @frozen
-        @_nonSendable
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedDateArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = Date
@@ -556,7 +539,6 @@ extension AttributeScopes.FoundationAttributes {
         }
         
         @frozen
-        @_nonSendable
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedDateIntervalArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = Range<Date>
@@ -564,7 +546,6 @@ extension AttributeScopes.FoundationAttributes {
         }
         
         @frozen
-        @_nonSendable
         @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
         public enum LocalizedURLArgumentAttribute : CodableAttributedStringKey {
             public typealias Value = URL
@@ -574,7 +555,212 @@ extension AttributeScopes.FoundationAttributes {
 #endif // FOUNDATION_FRAMEWORK
 }
 
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LinkAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LanguageIdentifierAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.PersonNameComponentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.NumberFormatAttributes : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.NumberFormatAttributes.NumberPartAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.NumberFormatAttributes.SymbolAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.DateFieldAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.AlternateDescriptionAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.ImageURLAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.ReplacementIndexAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.MeasurementAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.ByteCountAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.DurationFieldAttribute : Sendable {}
+
 #if FOUNDATION_FRAMEWORK
+
+@available(macOS, unavailable, introduced: 14.0)
+@available(iOS, unavailable, introduced: 17.0)
+@available(tvOS, unavailable, introduced: 17.0)
+@available(watchOS, unavailable, introduced: 10.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.ReferentConceptAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 14.0)
+@available(iOS, unavailable, introduced: 17.0)
+@available(tvOS, unavailable, introduced: 17.0)
+@available(watchOS, unavailable, introduced: 10.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.AgreementConceptAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 14.0)
+@available(iOS, unavailable, introduced: 17.0)
+@available(tvOS, unavailable, introduced: 17.0)
+@available(watchOS, unavailable, introduced: 10.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.AgreementArgumentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.MorphologyAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.InflectionRuleAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.AssumedFallbackInflectionAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 15.0)
+@available(iOS, unavailable, introduced: 18.0)
+@available(tvOS, unavailable, introduced: 18.0)
+@available(watchOS, unavailable, introduced: 11.0)
+@available(visionOS, unavailable, introduced: 2.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedNumberFormatAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.InflectionAlternativeAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.InlinePresentationIntentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.PresentationIntentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.MarkdownSourcePositionAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes.LocalizedNumericArgumentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes.LocalizedURLArgumentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes.LocalizedDateArgumentAttribute : Sendable {}
+
+@available(macOS, unavailable, introduced: 13.0)
+@available(iOS, unavailable, introduced: 16.0)
+@available(tvOS, unavailable, introduced: 16.0)
+@available(watchOS, unavailable, introduced: 9.0)
+@available(*, unavailable)
+extension AttributeScopes.FoundationAttributes.LocalizedStringArgumentAttributes.LocalizedDateIntervalArgumentAttribute : Sendable {}
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AttributeScopes.FoundationAttributes.LinkAttribute : ObjectiveCConvertibleAttributedStringKey {

--- a/Sources/FoundationEssentials/Data/Data.swift
+++ b/Sources/FoundationEssentials/Data/Data.swift
@@ -1844,7 +1844,6 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
     // A standard or custom deallocator for `Data`.
     ///
     /// When creating a `Data` with the no-copy initializer, you may specify a `Data.Deallocator` to customize the behavior of how the backing store is deallocated.
-    @_nonSendable
     public enum Deallocator {
         /// Use a virtual memory deallocator.
 #if canImport(Darwin)
@@ -2687,6 +2686,13 @@ public struct Data : Equatable, Hashable, RandomAccessCollection, MutableCollect
         return true
     }
 }
+
+@available(macOS, unavailable, introduced: 10.10)
+@available(iOS, unavailable, introduced: 8.0)
+@available(tvOS, unavailable, introduced: 9.0)
+@available(watchOS, unavailable, introduced: 2.0)
+@available(*, unavailable)
+extension Data.Deallocator : Sendable {}
 
 #if !FOUNDATION_FRAMEWORK
 // MARK: Exported Types

--- a/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
+++ b/Sources/FoundationEssentials/FileManager/SwiftFileManager.swift
@@ -176,7 +176,6 @@ extension FileManager {
     }
 }
 
-@_nonSendable
 open class FileManager : @unchecked Sendable {
     // Sendable note: _impl may only be mutated in `init`
     private var _impl: _FileManagerImpl

--- a/Sources/FoundationEssentials/Predicate/Predicate.swift
+++ b/Sources/FoundationEssentials/Predicate/Predicate.swift
@@ -50,7 +50,14 @@ extension Predicate {
 
 // Namespace for operator expressions
 @available(FoundationPredicate 0.1, *)
-@frozen @_nonSendable public enum PredicateExpressions {}
+@frozen public enum PredicateExpressions {}
+
+@available(macOS, unavailable, introduced: 14.0)
+@available(iOS, unavailable, introduced: 17.0)
+@available(tvOS, unavailable, introduced: 17.0)
+@available(watchOS, unavailable, introduced: 10.0)
+@available(*, unavailable)
+extension PredicateExpressions : Sendable {}
 
 @available(FoundationPredicate 0.1, *)
 extension Sequence {

--- a/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
+++ b/Sources/FoundationEssentials/Predicate/PredicateBindings.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_nonSendable
 @available(FoundationPredicate 0.1, *)
 public struct PredicateBindings {
     // Store as a values as an array instead of a dictionary (since it is almost always very few elements, this reduces heap allocation and hashing overhead)
@@ -53,3 +52,10 @@ public struct PredicateBindings {
         return mutable
     }
 }
+
+@available(macOS, unavailable, introduced: 14.0)
+@available(iOS, unavailable, introduced: 17.0)
+@available(tvOS, unavailable, introduced: 17.0)
+@available(watchOS, unavailable, introduced: 10.0)
+@available(*, unavailable)
+extension PredicateBindings : Sendable {}

--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -22,7 +22,6 @@ internal import CoreFoundation_Private.CFURL
 /// Note that not all property values will exist for all file system URLs. For example, if a file is located on a volume that does not support creation dates, it is valid to request the creation date property, but the returned value will be nil, and no error will be generated.
 ///
 /// Only the fields requested by the keys you pass into the `URL` function to receive this value will be populated. The others will return `nil` regardless of the underlying property on the file system. As a convenience, volume resource values can be requested from any file system URL. The value returned will reflect the property value for the volume on which the resource is located.
-@_nonSendable
 @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, *)
 public struct URLResourceValues {
 
@@ -596,6 +595,13 @@ public struct URLResourceValues {
 
 #endif // !NO_FILESYSTEM
 }
+
+@available(macOS, unavailable, introduced: 10.10)
+@available(iOS, unavailable, introduced: 8.0)
+@available(tvOS, unavailable, introduced: 9.0)
+@available(watchOS, unavailable, introduced: 2.0)
+@available(*, unavailable)
+extension URLResourceValues : Sendable {}
 #endif // FOUNDATION_FRAMEWORK
 
 #if FOUNDATION_FRAMEWORK_NSURL

--- a/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
+++ b/Sources/FoundationInternationalization/Formatting/Number/NumberFormatStyleConfiguration.swift
@@ -88,7 +88,6 @@ public struct FormatStyleCapitalizationContext : Codable, Hashable, Sendable {
     }
 }
 
-@_nonSendable
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum NumberFormatStyleConfiguration {
     internal struct Collection : Codable, Hashable, Sendable {
@@ -305,7 +304,13 @@ public enum NumberFormatStyleConfiguration {
     }
 }
 
-@_nonSendable
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension NumberFormatStyleConfiguration : Sendable {}
+
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum CurrencyFormatStyleConfiguration {
     public typealias Grouping = NumberFormatStyleConfiguration.Grouping
@@ -377,7 +382,13 @@ public enum CurrencyFormatStyleConfiguration {
     }
 }
 
-@_nonSendable
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension CurrencyFormatStyleConfiguration : Sendable {}
+
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum DescriptiveNumberFormatConfiguration {
     public typealias CapitalizationContext = FormatStyleCapitalizationContext
@@ -427,6 +438,13 @@ public enum DescriptiveNumberFormatConfiguration {
         }
     }
 }
+
+@available(macOS, unavailable, introduced: 12.0)
+@available(iOS, unavailable, introduced: 15.0)
+@available(tvOS, unavailable, introduced: 15.0)
+@available(watchOS, unavailable, introduced: 8.0)
+@available(*, unavailable)
+extension DescriptiveNumberFormatConfiguration : Sendable {}
 
 // MARK: - Codable
 

--- a/Sources/FoundationInternationalization/String/KeyPathComparator.swift
+++ b/Sources/FoundationInternationalization/String/KeyPathComparator.swift
@@ -16,7 +16,6 @@ import FoundationEssentials
 
 /// Compares elements using a `KeyPath`, and a `SortComparator` which compares
 /// elements of the `KeyPath`s `Value` type.
-@_nonSendable
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct KeyPathComparator<Compared>: SortComparator {
     /// The key path to the property to be used for comparisons.

--- a/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
+++ b/Tests/FoundationInternationalizationTests/SortDescriptorTests.swift
@@ -21,10 +21,12 @@ import TestSupport
 @testable import FoundationInternationalization
 #endif // FOUNDATION_FRAMEWORK
 
-@_nonSendable
 class Hello {
     var str: NSMutableString = "hi"
 }
+
+@available(*, unavailable)
+extension Hello : Sendable {}
 
 @available(FoundationPreview 0.1, *)
 final class SortDescriptorTests: XCTestCase {


### PR DESCRIPTION
`@_nonSendable` was designed as a detail for the compiler to use and was not intended to be written directly in source. As such, the compiler treats it slightly differently and has allowed us to commit some incorrect annotations, such as:

```swift
@_nonSendable
open class FileManager : @unchecked Sendable {
```
(a both non-sendable and unchecked-sendable class)

and

```swift
@_nonSendable
public struct KeyPathComparator<Compared>: SortComparator {
```
(a non-sendable struct that conforms to a `Sendable` protocol)

This PR replaces usages of `@_nonSendable` with the officially supported design (unavailable extensions). This has the drawbacks of needing to duplicate the type's availability and moving the non-sendable annotation away from the type itself, but it means that both of the errors above would be diagnosed as actual compilation errors rather than silently being accepted and potentially causing issues for clients.