### PR TITLE
Set `SWIFT_SYSTEM_NAME` for macro project in CMake

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -26,6 +26,14 @@ endif()
 project(FoundationMacros
   LANGUAGES Swift)
 
+if(NOT SWIFT_SYSTEM_NAME)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(SWIFT_SYSTEM_NAME macosx)
+  else()
+    set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  endif()
+endif()
+
 # SwiftSyntax Dependency
 find_package(SwiftSyntax QUIET)
 if(NOT SwiftSyntax_FOUND)


### PR DESCRIPTION
When `FoundationMacros` was moved into its own CMake project, we did not copy over the `SWIFT_SYSTEM_NAME` setting. This results in the rpath for `libFoundationMacros.so` being `$ORIGIN/../../../swift/:$ORIGIN/..` instead of the correct value (`$ORIGIN/../../../swift/linux:$ORIGIN/..` for linux, for example). This fixes the macro build which allows `#Predicate` and `#Expression` to work as expected.

(note for context that this set value is used on line 90 of this file: `INSTALL_RPATH "$ORIGIN/../../../swift/${SWIFT_SYSTEM_NAME}:$ORIGIN/.."`)