### PR TITLE
Fix deleteLastPathComponent() for paths with trailing /

### DIFF
--- a/Sources/FoundationEssentials/String/String+Path.swift
+++ b/Sources/FoundationEssentials/String/String+Path.swift
@@ -63,7 +63,12 @@ extension String {
             // This is a trailing slash. Ignore it.
             let beforeLastSlash = self[startIndex..<lastSlash].lastIndex { $0 == "/" }
             if let beforeLastSlash {
-                return String(self[startIndex..<beforeLastSlash])
+                if beforeLastSlash == startIndex {
+                    // Only the first slash remains, return a bare slash.
+                    return "/"
+                } else {
+                    return String(self[startIndex..<beforeLastSlash])
+                }
             } else {
                 // No other slash. Return empty string.
                 return ""

--- a/Tests/FoundationEssentialsTests/DataIOTests.swift
+++ b/Tests/FoundationEssentialsTests/DataIOTests.swift
@@ -255,6 +255,7 @@ class DataIOTests : XCTestCase {
         XCTAssertEqual("/".deletingLastPathComponent(), "/")
         XCTAssertEqual("q".deletingLastPathComponent(), "")
         XCTAssertEqual("/aaa".deletingLastPathComponent(), "/")
+        XCTAssertEqual("/aaa/".deletingLastPathComponent(), "/")
         XCTAssertEqual("/a/b/c/".deletingLastPathComponent(), "/a/b")
         XCTAssertEqual("hello".deletingLastPathComponent(), "")
         XCTAssertEqual("hello/".deletingLastPathComponent(), "")


### PR DESCRIPTION
Paths like /home/ would return "" instead of /