### PR TITLE
[6.x] Set SWIFT_SYSTEM_NAME for macro project in CMake

### DIFF
--- a/Sources/FoundationMacros/CMakeLists.txt
+++ b/Sources/FoundationMacros/CMakeLists.txt
@@ -26,6 +26,14 @@ endif()
 project(FoundationMacros
   LANGUAGES Swift)
 
+if(NOT SWIFT_SYSTEM_NAME)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(SWIFT_SYSTEM_NAME macosx)
+  else()
+    set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  endif()
+endif()
+
 # SwiftSyntax Dependency
 find_package(SwiftSyntax QUIET)
 if(NOT SwiftSyntax_FOUND)


### PR DESCRIPTION
Explanation: A configuration change that updates the rpath value of `libFoundationMacros.so` to be correct
Scope: Only impacts the rpath value of `libFoundationMacros.so`
Original PR: https://github.com/apple/swift-foundation/pull/896
Risk: Low - scope is narrow, and fixes a regression that causes the macro to not be loadable so it can't really make anything worse :)
Testing: Testing done via local testing
Reviewer: @parkera 