### PR TITLE
[6.0] URL.host should not return percent-encoded host

### DIFF
--- a/Sources/FoundationEssentials/URL/URL.swift
+++ b/Sources/FoundationEssentials/URL/URL.swift
@@ -1188,7 +1188,7 @@ public struct URL: Equatable, Sendable, Hashable {
             return _url.host
         }
         #endif
-        return host()
+        return host(percentEncoded: false)
     }
 
     /// Returns the host component of the URL if present, otherwise returns `nil`.

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -571,6 +571,11 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(appended.relativePath, "relative/with:slash")
     }
 
+    func testURLHostRetainsIDNAEncoding() throws {
+        let url = URL(string: "ftp://user:password@*.xn--poema-9qae5a.com.br:4343/cat.txt")!
+        XCTAssertEqual(url.host, "*.xn--poema-9qae5a.com.br")
+    }
+
     func testURLComponentsPercentEncodedUnencodedProperties() throws {
         var comp = URLComponents()
 


### PR DESCRIPTION
**Explanation:** Fixes `URL.host` to match the behavior before the Swift URL implementation:
- If the host was percent-encoded, return the percent-decoded host
- If the host was IDNA-encoded (or not encoded at all), return that host string

**Scope:** Only impacts deprecated (but still used) `URL.host` for URLs with an encoded host, restoring previous behavior
**Original PR:** https://github.com/apple/swift-foundation/pull/875
**Risk:** Low - minimal scope, one line change to restore behavior
**Testing:** Local, swift-ci, stable in `main` for 2 weeks
**Reviewer:** @parkera @jmschonfeld 