### PR TITLE
Fix macro source location

### DIFF
--- a/Sources/FoundationEssentials/CMakeLists.txt
+++ b/Sources/FoundationEssentials/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
     # No path to Foundation macros was provided, so we must build it ourselves
     set(FoundationMacros_BuildLocalExecutable YES)
     FetchContent_Declare(FoundationMacros
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/Sources/FoundationMacros)
+        SOURCE_DIR ${SwiftFoundation_SOURCE_DIR}/Sources/FoundationMacros)
     FetchContent_MakeAvailable(FoundationMacros)
     add_dependencies(FoundationEssentials FoundationMacros)
     get_target_property(MacroDIR FoundationMacros RUNTIME_OUTPUT_DIRECTORY)


### PR DESCRIPTION
When a project is used through a FetchContent/add_subdirectory, the `CMAKE_SOURCE_DIR` path points to the calling project. This is resulting in some of the CI jobs attempting to FetchContent the macros from `swift-corelibs-foundation/Sources/FoundationMacros`, rather than `swift-foundation/Sources/FoundationMacros`, ultimately failing the build.

The `project` call sets a `${CMAKE_PROJECT_NAME}_SOURCE_DIR` variable to the source directory of the project itself, making it more reliable. `CMAKE_CURRENT_SOURCE_DIR` would also work here too.

Noticed in: https://ci.swift.org/view/all/job/swift-build-static-sdk/46