### PR TITLE
[6.0.0] URLComponents: support http(s)+unix schemes

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -222,6 +222,8 @@ internal struct RFC3986Parser: URLParserProtocol {
         "addressbook",
         "contact",
         "phasset",
+        "http+unix",
+        "https+unix",
     ])
 
     private static func looksLikeIPLiteral(_ host: some StringProtocol) -> Bool {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1031,4 +1031,38 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.percentEncodedPath, "/my%00path")
         XCTAssertEqual(comp.path, "/my\u{0}path")
     }
+
+    func testURLComponentsUnixDomainSocketOverHTTPScheme() {
+        var comp = URLComponents()
+        comp.scheme = "http+unix"
+        comp.host = "/path/to/socket"
+        comp.path = "/info"
+        XCTAssertEqual(comp.string, "http+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.scheme = "https+unix"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.encodedHost = "%2Fpath%2Fto%2Fsocket"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+
+        // "/path/to/socket" is not a valid host for schemes
+        // that IDNA-encode hosts instead of percent-encoding
+        comp.scheme = "http"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "https"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "https+unix"
+        XCTAssertEqual(comp.string, "https+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        // Check that we can parse a percent-encoded http+unix URL string
+        comp = URLComponents(string: "http+unix://%2Fpath%2Fto%2Fsocket/info")!
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+    }
 }


### PR DESCRIPTION
Original 6.0 cherry-pick: #903 
Description from that cherry-pick:

**Explanation:** Percent-encode the host (instead of IDNA-encoding) for URLs with the `http+unix` or `https+unix` scheme, supporting the common representation of a "HTTP over Unix socket" URL. This fixes `http(s)+unix`-related regressions in clients such as Vapor and AsyncHTTPClient (see https://github.com/apple/swift-foundation/issues/863 and https://github.com/swift-server/async-http-client/issues/767)
**Scope:** Only impacts `http+unix` and `https+unix` URLs, adds them to the set of `schemesToPercentEncodeHost`
**Original PR:** https://github.com/apple/swift-foundation/pull/883
**Risk:** Low - narrow scope, added special casing of two schemes to a larger set that has been well tested
**Testing:** Local, swift-ci, stable in `main` for 2 weeks, verified to fix https://github.com/swift-server/async-http-client/issues/767
**Reviewer:** @parkera