### PR TITLE
URLComponents: support ws(s)+unix schemes

### DIFF
--- a/Sources/FoundationEssentials/URL/URLParser.swift
+++ b/Sources/FoundationEssentials/URL/URLParser.swift
@@ -224,6 +224,8 @@ internal struct RFC3986Parser: URLParserProtocol {
         "phasset",
         "http+unix",
         "https+unix",
+        "ws+unix",
+        "wss+unix",
     ])
 
     private static func looksLikeIPLiteral(_ host: some StringProtocol) -> Bool {

--- a/Tests/FoundationEssentialsTests/URLTests.swift
+++ b/Tests/FoundationEssentialsTests/URLTests.swift
@@ -1137,4 +1137,38 @@ final class URLTests : XCTestCase {
         XCTAssertEqual(comp.host, "/path/to/socket")
         XCTAssertEqual(comp.path, "/info")
     }
+
+    func testURLComponentsUnixDomainSocketOverWebSocketScheme() {
+        var comp = URLComponents()
+        comp.scheme = "ws+unix"
+        comp.host = "/path/to/socket"
+        comp.path = "/info"
+        XCTAssertEqual(comp.string, "ws+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.scheme = "wss+unix"
+        XCTAssertEqual(comp.string, "wss+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        comp.encodedHost = "%2Fpath%2Fto%2Fsocket"
+        XCTAssertEqual(comp.string, "wss+unix://%2Fpath%2Fto%2Fsocket/info")
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+
+        // "/path/to/socket" is not a valid host for schemes
+        // that IDNA-encode hosts instead of percent-encoding
+        comp.scheme = "ws"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "wss"
+        XCTAssertNil(comp.string)
+
+        comp.scheme = "wss+unix"
+        XCTAssertEqual(comp.string, "wss+unix://%2Fpath%2Fto%2Fsocket/info")
+
+        // Check that we can parse a percent-encoded ws+unix URL string
+        comp = URLComponents(string: "ws+unix://%2Fpath%2Fto%2Fsocket/info")!
+        XCTAssertEqual(comp.encodedHost, "%2Fpath%2Fto%2Fsocket")
+        XCTAssertEqual(comp.host, "/path/to/socket")
+        XCTAssertEqual(comp.path, "/info")
+    }
 }


### PR DESCRIPTION
Similar to https://github.com/apple/swift-foundation/pull/883, the common way to represent a "WebSocket over Unix socket" URL is to use the scheme `ws+unix` and set the URL's host to the percent-encoded path of the socket.

This PR adds `ws+unix` and `wss+unix` to the set of schemes where we percent-encode the host instead of IDNA-encode.