### PR TITLE
Fix windows creation of relative symlinks to directories

### DIFF
--- a/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
+++ b/Sources/FoundationEssentials/FileManager/FileManager+SymbolicLinks.swift
@@ -59,7 +59,8 @@ extension _FileManagerImpl {
     ) throws {
 #if os(Windows)
         var bIsDirectory = false
-        _ = fileManager.fileExists(atPath: destPath, isDirectory: &bIsDirectory)
+        let absoluteDestPath = URL(filePath: destPath, relativeTo: URL(filePath: path, directoryHint: .notDirectory)).path
+        _ = fileManager.fileExists(atPath: absoluteDestPath, isDirectory: &bIsDirectory)
 
         try path.withNTPathRepresentation { lpSymlinkFileName in
             try destPath.withFileSystemRepresentation {

--- a/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
+++ b/Tests/FoundationEssentialsTests/FileManager/FileManagerTests.swift
@@ -412,9 +412,13 @@ final class FileManagerTests : XCTestCase {
     func testCreateSymbolicLinkAtPath() throws {
         try FileManagerPlayground {
             "foo"
+            Directory("dir") {}
         }.test {
             try $0.createSymbolicLink(atPath: "bar", withDestinationPath: "foo")
             XCTAssertEqual(try $0.destinationOfSymbolicLink(atPath: "bar"), "foo")
+
+            try $0.createSymbolicLink(atPath: "dir_link", withDestinationPath: "dir")
+            XCTAssertEqual(try $0.destinationOfSymbolicLink(atPath: "dir_link"), "dir")
             
             XCTAssertThrowsError(try $0.createSymbolicLink(atPath: "bar", withDestinationPath: "foo")) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileWriteFileExists)
@@ -425,6 +429,21 @@ final class FileManagerTests : XCTestCase {
             XCTAssertThrowsError(try $0.destinationOfSymbolicLink(atPath: "foo")) {
                 XCTAssertEqual(($0 as? CocoaError)?.code, .fileReadUnknown)
             }
+        }
+
+        try FileManagerPlayground {
+            Directory("dir") {
+                Directory("other_dir") {
+                    "file"
+                }
+            }
+        }.test {
+            // Create a relative symlink to other_dir from within dir (tests windows special dir symlink handling)
+            try $0.createSymbolicLink(atPath: "dir/link", withDestinationPath: "other_dir")
+
+            // Ensure it is created successfully
+            XCTAssertEqual(try $0.destinationOfSymbolicLink(atPath: "dir/link"), "other_dir")
+            XCTAssertEqual(try $0.contentsOfDirectory(atPath: "dir/link"), ["file"])
         }
     }
     


### PR DESCRIPTION
On windows, we need to specify an extra flag if we are creating a symlink to a directory. To do this, we check if the provided destination is a directory using `FileManager.fileExists(atPath:isDirectory:)`. However, the destination path is relative to the _symlink_ and not relative to the current working directory like `fileExists(atPath:)` expects so we must first convert the relative path into an absolute path using the symlink path as a base.

Resolves https://github.com/apple/swift-foundation/issues/928