### PR TITLE
Support initializing string with nonLossyASCII encoding

### DIFF
--- a/Sources/FoundationEssentials/String/String+IO.swift
+++ b/Sources/FoundationEssentials/String/String+IO.swift
@@ -66,7 +66,7 @@ extension String {
         where S.Iterator.Element == UInt8
     {
         switch encoding {
-        case .ascii:
+        case .ascii, .nonLossyASCII:
             func makeString(buffer: UnsafeBufferPointer<UInt8>) -> String? {
                 return String(_validating: buffer, as: Unicode.ASCII.self)
             }

--- a/Tests/FoundationEssentialsTests/StringTests.swift
+++ b/Tests/FoundationEssentialsTests/StringTests.swift
@@ -983,6 +983,13 @@ final class StringTests : XCTestCase {
         XCTAssertEqual("e\u{301}\u{301}f".data(using: .ascii, allowLossyConversion: true), Data([UInt8(ascii: "e"), 0xFF, 0xFF, UInt8(ascii: "f")]))
         XCTAssertEqual("e\u{301}\u{301}f".data(using: .nonLossyASCII, allowLossyConversion: true), Data([UInt8(ascii: "e"), UInt8(ascii: "?"), UInt8(ascii: "?"), UInt8(ascii: "f")]))
     }
+    
+    func test_initWithBytes_ascii() {
+        XCTAssertEqual(String(bytes: "abc".utf8, encoding: String._Encoding.ascii), "abc")
+        XCTAssertEqual(String(bytes: "abc".utf8, encoding: String._Encoding.nonLossyASCII), "abc")
+        XCTAssertEqual(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.ascii), nil)
+        XCTAssertEqual(String(bytes: "e\u{301}\u{301}f".utf8, encoding: String._Encoding.nonLossyASCII), nil)
+    }
 
     func test_transmutingCompressingSlashes() {
         let testCases: [(String, String)] = [


### PR DESCRIPTION
In Foundation.framework, initializing a `String` with `.nonLossyASCII` behaves the same way as `.ascii`, so this replicates the behavior for non-`FOUNDATION_FRAMEWORK` builds.

Resolves https://github.com/apple/swift-foundation/issues/929