### PR TITLE
Add runtime check to Decimal(sign:exponent:significand:) for bin compat

### DIFF
--- a/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
+++ b/Sources/FoundationEssentials/Decimal/Decimal+Conformances.swift
@@ -236,6 +236,21 @@ extension Decimal /* : FloatingPoint */ {
     }
 
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
+#if FOUNDATION_FRAMEWORK
+        // Compatibility path
+        if Self.compatibility1 {
+            self.init(
+                _exponent: Int32(exponent) + significand._exponent,
+                _length: significand._length,
+                _isNegative: sign == .plus ? 0 : 1,
+                _isCompact: significand._isCompact,
+                _reserved: 0,
+                _mantissa: significand._mantissa
+            )
+            return
+        }
+#endif
+
         self = significand
         do {
             self = try significand._multiplyByPowerOfTen(

--- a/Tests/FoundationEssentialsTests/DecimalTests.swift
+++ b/Tests/FoundationEssentialsTests/DecimalTests.swift
@@ -1159,9 +1159,21 @@ final class DecimalTests : XCTestCase {
         var x = -42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)
         var y = Decimal(sign: .plus, exponent: 0, significand: x)
+#if FOUNDATION_FRAMEWORK
+        if Decimal.compatibility1 {
+            XCTAssertEqual(y, 42)
+            y = Decimal(sign: .minus, exponent: 0, significand: x)
+            XCTAssertEqual(y, -42)
+        } else {
+            XCTAssertEqual(y, -42)
+            y = Decimal(sign: .minus, exponent: 0, significand: x)
+            XCTAssertEqual(y, 42)
+        }
+#else
         XCTAssertEqual(y, -42)
         y = Decimal(sign: .minus, exponent: 0, significand: x)
         XCTAssertEqual(y, 42)
+#endif
 
         x = 42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)


### PR DESCRIPTION
Add runtime check to revert back to old behavior for `Decimal(sign:exponent:significand:)` if the app was build on older OSs.

resolves: rdar://135822747
resolves: https://github.com/apple/swift-foundation/issues/833